### PR TITLE
Add initial EWS MCP server skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+NODE_ENV=development
+MCP_PORT=3000
+LOG_LEVEL=info
+
+EWS_URL=https://example.com/EWS/Exchange.asmx
+EWS_USERNAME=user@example.com
+EWS_PASSWORD=changeme
+EWS_VERSION=Exchange2016
+EWS_AUTH_TYPE=Basic
+EWS_REQUEST_TIMEOUT=10000
+EWS_MAX_RETRIES=3
+
+REDIS_URL=redis://localhost:6379/0
+
+AUDIT_ENABLED=true
+CACHE_ENABLED=true
+CACHE_DEFAULT_TTL_SECONDS=300

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# EWS MCP Server
+
+Basic Node.js server exposing Exchange Web Services (EWS) operations through the Model Context Protocol (MCP).
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Building
+
+```bash
+npm run build
+```
+
+## Docker
+
+```bash
+docker compose -f docker/docker-compose.yml up --build
+```
+
+Exposes health endpoint at `/health` and metrics at `/metrics`.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+# Stage 1: build
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev
+COPY . ./
+RUN npm run build
+
+# Stage 2: runtime
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev && adduser -D mcpuser
+USER mcpuser
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s CMD curl -f http://localhost:3000/health || exit 1
+CMD ["node", "dist/main.js"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+services:
+  ews-mcp:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    env_file:
+      - ../.env
+    ports:
+      - "3000:${MCP_PORT:-3000}"
+    depends_on:
+      - redis
+    environment:
+      REDIS_URL: redis://ews-mcp-redis:6379/0
+    networks:
+      - mcp-network
+
+  redis:
+    image: redis:7-alpine
+    volumes:
+      - redis-data:/data
+    networks:
+      - mcp-network
+
+volumes:
+  redis-data:
+
+networks:
+  mcp-network:
+    driver: bridge

--- a/package.json
+++ b/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "ews-mcp-server",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "start": "node dist/main.js",
+    "dev": "tsx watch src/main.ts",
+    "build": "tsc",
+    "lint": "eslint . --ext .ts",
+    "format": "prettier --write .",
+    "docker:build": "docker build -t ews-mcp-server -f docker/Dockerfile .",
+    "docker:run": "docker compose -f docker/docker-compose.yml up --build",
+    "docker:logs": "docker compose -f docker/docker-compose.yml logs -f"
+  },
+  "dependencies": {
+    "@anthropic/mcp": "^0.2.0",
+    "@hapi/boom": "^10.0.0",
+    "axios": "^1.6.0",
+    "compression": "^1.7.4",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "fast-xml-parser": "^4.2.4",
+    "helmet": "^7.0.0",
+    "joi": "^17.9.2",
+    "redis": "^4.6.7",
+    "winston": "^3.10.0",
+    "ws": "^8.13.0",
+    "xmlbuilder2": "^4.3.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/ws": "^8.5.5",
+    "@types/node": "^20.5.9",
+    "@types/cors": "^2.8.12",
+    "@types/redis": "^4.0.11",
+    "@types/winston": "^2.4.4",
+    "@typescript-eslint/eslint-plugin": "^6.7.0",
+    "@typescript-eslint/parser": "^6.7.0",
+    "eslint": "^8.45.0",
+    "prettier": "^3.0.0",
+    "tsx": "^3.12.7",
+    "typescript": "^5.1.6"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/src/config/config.types.ts
+++ b/src/config/config.types.ts
@@ -1,0 +1,53 @@
+export interface ServerConfig {
+  port: number;
+}
+
+export interface LogConfig {
+  level: string;
+}
+
+export interface EWSAuthConfig {
+  type: string;
+  username?: string;
+  password?: string;
+}
+
+export interface EWSConfig {
+  url: string;
+  version: string;
+  auth: EWSAuthConfig;
+  requestTimeout: number;
+  maxRetries: number;
+}
+
+export interface RedisConfig {
+  url: string;
+}
+
+export interface AuditConfig {
+  enabled: boolean;
+}
+
+export interface CacheConfig {
+  enabled: boolean;
+  defaultTtlSeconds: number;
+}
+
+export interface AppConfig {
+  nodeEnv: string;
+  server: ServerConfig;
+  log: LogConfig;
+  ews: EWSConfig;
+  redis: RedisConfig;
+  audit: AuditConfig;
+  cache: CacheConfig;
+}
+
+export interface AppServices {
+  config: AppConfig;
+  // placeholders for services
+  ewsClient: any;
+  soapBuilder: any;
+  cacheService: any;
+  auditService: any;
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,48 @@
+import dotenv from 'dotenv';
+import fs from 'fs';
+import path from 'path';
+import { configSchema, ConfigSchema } from './schema';
+import { AppConfig } from './config.types';
+
+export function loadConfig(): AppConfig {
+  const nodeEnv = process.env.NODE_ENV || 'development';
+  const envFiles = ['.env', `.env.${nodeEnv}`];
+  envFiles.forEach((file) => {
+    const p = path.resolve(process.cwd(), file);
+    if (fs.existsSync(p)) {
+      dotenv.config({ path: p });
+    }
+  });
+
+  const raw: ConfigSchema = {
+    nodeEnv,
+    server: { port: Number(process.env.MCP_PORT) || 3000 },
+    log: { level: process.env.LOG_LEVEL || 'info' },
+    ews: {
+      url: process.env.EWS_URL || '',
+      version: process.env.EWS_VERSION || 'Exchange2016',
+      auth: {
+        type: process.env.EWS_AUTH_TYPE || 'Basic',
+        username: process.env.EWS_USERNAME,
+        password: process.env.EWS_PASSWORD,
+      },
+      requestTimeout: Number(process.env.EWS_REQUEST_TIMEOUT) || 10000,
+      maxRetries: Number(process.env.EWS_MAX_RETRIES) || 3,
+    },
+    redis: {
+      url: process.env.REDIS_URL || 'redis://localhost:6379/0',
+    },
+    audit: { enabled: process.env.AUDIT_ENABLED !== 'false' },
+    cache: {
+      enabled: process.env.CACHE_ENABLED !== 'false',
+      defaultTtlSeconds: Number(process.env.CACHE_DEFAULT_TTL_SECONDS) || 300,
+    },
+  } as unknown as ConfigSchema;
+
+  const { value, error } = configSchema.validate(raw, { abortEarly: false });
+  if (error) {
+    throw new Error(`Config validation failed: ${error.message}`);
+  }
+
+  return value as AppConfig;
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,0 +1,42 @@
+import Joi from 'joi';
+
+export const configSchema = Joi.object({
+  nodeEnv: Joi.string().default('development'),
+  server: Joi.object({
+    port: Joi.number().default(3000),
+  }).required(),
+  log: Joi.object({
+    level: Joi.string().default('info'),
+  }).required(),
+  ews: Joi.object({
+    url: Joi.string().uri().required(),
+    version: Joi.string().default('Exchange2016'),
+    auth: Joi.object({
+      type: Joi.string().valid('Basic').default('Basic'),
+      username: Joi.when('type', {
+        is: 'Basic',
+        then: Joi.string().required(),
+        otherwise: Joi.string().optional(),
+      }),
+      password: Joi.when('type', {
+        is: 'Basic',
+        then: Joi.string().required(),
+        otherwise: Joi.string().optional(),
+      }),
+    }).required(),
+    requestTimeout: Joi.number().default(10000),
+    maxRetries: Joi.number().default(3),
+  }).required(),
+  redis: Joi.object({
+    url: Joi.string().uri().required(),
+  }).required(),
+  audit: Joi.object({
+    enabled: Joi.boolean().default(true),
+  }).required(),
+  cache: Joi.object({
+    enabled: Joi.boolean().default(true),
+    defaultTtlSeconds: Joi.number().default(300),
+  }).required(),
+});
+
+export type ConfigSchema = Joi.inferType<typeof configSchema>;

--- a/src/ews/authStrategies/BasicAuthStrategy.ts
+++ b/src/ews/authStrategies/BasicAuthStrategy.ts
@@ -1,0 +1,18 @@
+import { Buffer } from 'buffer';
+import { EWSAuthConfig } from '../../config/config.types';
+import { AuthToken, IAuthStrategy } from './IAuthStrategy';
+
+export class BasicAuthStrategy implements IAuthStrategy {
+  constructor(private config: EWSAuthConfig) {}
+
+  async getAuthToken(): Promise<AuthToken> {
+    const token = Buffer.from(
+      `${this.config.username}:${this.config.password}`
+    ).toString('base64');
+    return { header: `Basic ${token}` };
+  }
+
+  async handleAuthError(): Promise<void> {
+    // Basic auth has no recovery
+  }
+}

--- a/src/ews/authStrategies/IAuthStrategy.ts
+++ b/src/ews/authStrategies/IAuthStrategy.ts
@@ -1,0 +1,8 @@
+export interface AuthToken {
+  header: string;
+}
+
+export interface IAuthStrategy {
+  getAuthToken(): Promise<AuthToken>;
+  handleAuthError?(error: any): Promise<void>;
+}

--- a/src/ews/ews.client.ts
+++ b/src/ews/ews.client.ts
@@ -1,0 +1,59 @@
+import axios, { AxiosInstance } from 'axios';
+import { EWSConfig } from '../config/config.types';
+import { IAuthStrategy } from './authStrategies/IAuthStrategy';
+import {
+  EWSAuthenticationError,
+  EWSServerBusyError,
+  EWSRequestError,
+} from '../shared/errors';
+import { parseEWSResponseCode } from './soap.parser';
+import { getLogger } from '../shared/logger';
+
+export class EWSClient {
+  private axios: AxiosInstance;
+  private logger = getLogger();
+
+  constructor(private config: EWSConfig, private authStrategy: IAuthStrategy) {
+    this.axios = axios.create({
+      baseURL: config.url,
+      timeout: config.requestTimeout,
+      headers: { 'Content-Type': 'text/xml' },
+    });
+
+    this.axios.interceptors.request.use(async (cfg) => {
+      const token = await this.authStrategy.getAuthToken();
+      cfg.headers = cfg.headers || {};
+      cfg.headers['Authorization'] = token.header;
+      return cfg;
+    });
+  }
+
+  async request(soapBody: string, soapAction: string): Promise<string> {
+    for (let attempt = 0; attempt <= this.config.maxRetries; attempt++) {
+      try {
+        const response = await this.axios.post('', soapBody, {
+          headers: { SOAPAction: soapAction },
+        });
+        const responseCode = parseEWSResponseCode(response.data);
+        if (responseCode === 'ErrorServerBusy') {
+          throw new EWSServerBusyError('Server busy');
+        }
+        return response.data;
+      } catch (err: any) {
+        const status = err.response?.status;
+        if (status === 401 || status === 403) {
+          await this.authStrategy.handleAuthError?.(err);
+          throw new EWSAuthenticationError('Authentication failed');
+        }
+        if (status === 503 || status === 429 || err instanceof EWSServerBusyError) {
+          const delay = Math.pow(2, attempt) * 1000;
+          await new Promise((r) => setTimeout(r, delay));
+          continue;
+        }
+        this.logger.error('EWS request failed', { err });
+        throw new EWSRequestError('EWS request failed', status, err);
+      }
+    }
+    throw new EWSRequestError('Max retries exceeded');
+  }
+}

--- a/src/ews/ews.mapper.ts
+++ b/src/ews/ews.mapper.ts
@@ -1,0 +1,34 @@
+import { GetItemResponseMessage, FindItemResponseMessage, EWSEmailItem } from './soap.parser';
+import { Email } from '../tools/tools.types';
+
+function mapEmail(item: EWSEmailItem): Email {
+  return {
+    id: item.ItemId.Id,
+    changeKey: item.ItemId.ChangeKey,
+    subject: item.Subject,
+    receivedDate: item.DateTimeReceived,
+    from: item.From?.Mailbox.EmailAddress || '',
+    fromName: item.From?.Mailbox.Name || '',
+    body: item.Body?.['#text'] || '',
+    bodyType: item.Body?.['@_BodyType'] || 'Text',
+    bodyPreview: item.BodyPreview || '',
+    hasAttachments: item.HasAttachments === 'true',
+    importance: item.Importance,
+    isRead: item.IsRead === 'true',
+  };
+}
+
+export function mapFindItemResponseToEmails(response: FindItemResponseMessage) {
+  const messages = response.RootFolder.Items.Message;
+  const items = Array.isArray(messages) ? messages : messages ? [messages] : [];
+  return {
+    emails: items.map(mapEmail),
+    totalItems: response.RootFolder.TotalItemsInView,
+    hasMore: response.RootFolder.IncludesLastItemInRange === 'false',
+  };
+}
+
+export function mapGetItemResponseToEmail(response: GetItemResponseMessage): Email | null {
+  const msg = response.Items?.Message;
+  return msg ? mapEmail(msg) : null;
+}

--- a/src/ews/soap.builder.ts
+++ b/src/ews/soap.builder.ts
@@ -1,0 +1,79 @@
+import { create } from 'xmlbuilder2';
+import { EWSConfig } from '../config/config.types';
+
+export class SOAPBuilder {
+  constructor(private config: EWSConfig) {}
+
+  private createEnvelope() {
+    return create({ version: '1.0', encoding: 'UTF-8' })
+      .ele('soap:Envelope', {
+        xmlns: 'http://schemas.xmlsoap.org/soap/envelope/',
+        'xmlns:t': 'http://schemas.microsoft.com/exchange/services/2006/types',
+        'xmlns:m': 'http://schemas.microsoft.com/exchange/services/2006/messages',
+      })
+      .ele('soap:Header')
+      .ele('t:RequestServerVersion', { Version: this.config.version })
+      .up()
+      .up()
+      .ele('soap:Body');
+  }
+
+  buildFindItemRequest(params: {
+    folderId: string;
+    queryString?: string;
+    pageSize: number;
+    offset: number;
+  }): string {
+    const doc = this.createEnvelope();
+    const body = doc
+      .ele('m:FindItem', {
+        Traversal: 'Shallow',
+      })
+      .ele('m:ItemShape')
+      .ele('t:BaseShape')
+      .txt('Default')
+      .up()
+      .up();
+
+    body
+      .ele('m:IndexedPageItemView', {
+        MaxEntriesReturned: params.pageSize,
+        Offset: params.offset,
+        BasePoint: 'Beginning',
+      })
+      .up();
+
+    if (params.queryString) {
+      body.ele('m:QueryString').txt(params.queryString).up();
+    }
+
+    body
+      .ele('m:ParentFolderIds')
+      .ele('t:DistinguishedFolderId', { Id: params.folderId })
+      .up()
+      .up();
+
+    return doc.end({ headless: true });
+  }
+
+  buildGetItemRequest(params: { itemIds: string[] }): string {
+    const doc = this.createEnvelope();
+    const body = doc
+      .ele('m:GetItem')
+      .ele('m:ItemShape')
+      .ele('t:BaseShape')
+      .txt('AllProperties')
+      .up()
+      .ele('t:BodyType')
+      .txt('HTML')
+      .up()
+      .up();
+
+    const ids = body.ele('m:ItemIds');
+    params.itemIds.forEach((id) => {
+      ids.ele('t:ItemId', { Id: id });
+    });
+
+    return doc.end({ headless: true });
+  }
+}

--- a/src/ews/soap.parser.ts
+++ b/src/ews/soap.parser.ts
@@ -1,0 +1,41 @@
+import { XMLParser } from 'fast-xml-parser';
+
+const parser = new XMLParser({ ignoreAttributes: false, removeNSPrefix: true });
+
+export function parseEWSResponseCode(xml: string): string | null {
+  const obj = parser.parse(xml);
+  const msg =
+    obj?.Envelope?.Body?.FindItemResponse?.ResponseMessages?.FindItemResponseMessage ||
+    obj?.Envelope?.Body?.GetItemResponse?.ResponseMessages?.GetItemResponseMessage;
+  return msg?.ResponseCode || null;
+}
+
+export function parseSOAPResponse<T>(xml: string, operation: string): T {
+  const obj = parser.parse(xml);
+  const response = obj?.Envelope?.Body?.[`${operation}Response`];
+  return response as T;
+}
+
+export interface EWSEmailItem {
+  ItemId: { Id: string; ChangeKey: string };
+  Subject: string;
+  DateTimeReceived: string;
+  From?: { Mailbox: { EmailAddress: string; Name: string } };
+  Body?: { '#text': string; '@_BodyType': string };
+  BodyPreview?: string;
+  HasAttachments: string;
+  Importance: string;
+  IsRead: string;
+}
+
+export interface FindItemResponseMessage {
+  RootFolder: {
+    Items: { Message?: EWSEmailItem | EWSEmailItem[] };
+    TotalItemsInView: number;
+    IncludesLastItemInRange: string;
+  };
+}
+
+export interface GetItemResponseMessage {
+  Items: { Message: EWSEmailItem };
+}

--- a/src/intelligence/audit.service.ts
+++ b/src/intelligence/audit.service.ts
@@ -1,0 +1,27 @@
+import { AuditConfig } from '../config/config.types';
+import { getLogger } from '../shared/logger';
+
+export class AuditService {
+  private logger = getLogger();
+  constructor(private config: AuditConfig) {}
+
+  logToolExecution(toolName: string, params: any, result: any, userId?: string) {
+    if (!this.config.enabled) return;
+    const entry = {
+      timestamp: new Date().toISOString(),
+      event_type: 'TOOL_EXECUTION',
+      tool_name: toolName,
+      user_id: userId,
+      params: this.sanitize(params),
+      resultSummary: result,
+    };
+    this.logger.info('audit', entry);
+  }
+
+  private sanitize(obj: any) {
+    const clone = { ...obj };
+    if ('password' in clone) clone.password = 'REDACTED';
+    if ('body' in clone) clone.body = 'REDACTED';
+    return clone;
+  }
+}

--- a/src/intelligence/cache.service.ts
+++ b/src/intelligence/cache.service.ts
@@ -1,0 +1,53 @@
+import { createClient, RedisClientType } from 'redis';
+import { CacheConfig, RedisConfig } from '../config/config.types';
+import { getLogger } from '../shared/logger';
+
+export class CacheService {
+  private client?: RedisClientType;
+  private connected = false;
+  private logger = getLogger();
+
+  constructor(private cacheConfig: CacheConfig, private redisConfig: RedisConfig) {}
+
+  async connect() {
+    if (!this.cacheConfig.enabled) {
+      this.logger.info('Caching disabled');
+      return;
+    }
+    this.client = createClient({ url: this.redisConfig.url });
+    this.client.on('error', (err) => {
+      this.logger.error('Redis error', err);
+    });
+    try {
+      await this.client.connect();
+      this.connected = true;
+    } catch (err) {
+      this.logger.error('Redis connection failed', err);
+      this.cacheConfig.enabled = false;
+    }
+  }
+
+  async get<T>(key: string): Promise<T | null> {
+    if (!this.cacheConfig.enabled || !this.connected || !this.client) return null;
+    const val = await this.client.get(key);
+    return val ? (JSON.parse(val) as T) : null;
+  }
+
+  async set<T>(key: string, value: T, ttl?: number) {
+    if (!this.cacheConfig.enabled || !this.connected || !this.client) return;
+    await this.client.set(key, JSON.stringify(value), {
+      EX: ttl || this.cacheConfig.defaultTtlSeconds,
+    });
+  }
+
+  async disconnect() {
+    if (this.client && this.connected) {
+      await this.client.disconnect();
+      this.connected = false;
+    }
+  }
+
+  isHealthy() {
+    return !this.cacheConfig.enabled || this.connected;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,45 @@
+import { loadConfig } from './config';
+import { initializeGlobalLogger } from './shared/logger';
+import { BasicAuthStrategy } from './ews/authStrategies/BasicAuthStrategy';
+import { EWSClient } from './ews/ews.client';
+import { SOAPBuilder } from './ews/soap.builder';
+import { CacheService } from './intelligence/cache.service';
+import { AuditService } from './intelligence/audit.service';
+import { createApplicationServer } from './server';
+
+async function bootstrap() {
+  const config = loadConfig();
+  initializeGlobalLogger(config.log);
+
+  const authStrategy = new BasicAuthStrategy(config.ews.auth);
+  const ewsClient = new EWSClient(config.ews, authStrategy);
+  const soapBuilder = new SOAPBuilder(config.ews);
+  const cacheService = new CacheService(config.cache, config.redis);
+  await cacheService.connect();
+  const auditService = new AuditService(config.audit);
+
+  const services = {
+    config,
+    ewsClient,
+    soapBuilder,
+    cacheService,
+    auditService,
+  };
+
+  const server = createApplicationServer(services);
+  await server.start();
+
+  const shutdown = async () => {
+    await server.stop();
+    await cacheService.disconnect();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+bootstrap().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/mcp/mcp.handler.ts
+++ b/src/mcp/mcp.handler.ts
@@ -1,0 +1,23 @@
+import { MCPServer } from '@anthropic/mcp';
+import { Server as HttpServer } from 'http';
+import { WebSocketServer } from 'ws';
+import { AppServices } from '../config/config.types';
+import { SearchEmailsTool, ReadEmailTool } from '../tools/email.tool';
+
+let mcpServer: MCPServer | null = null;
+
+export function setupMCP(httpServer: HttpServer, services: AppServices) {
+  mcpServer = new MCPServer();
+  mcpServer.registerTool(new SearchEmailsTool(services));
+  mcpServer.registerTool(new ReadEmailTool(services));
+
+  const wss = new WebSocketServer({ server: httpServer, path: '/mcp' });
+  wss.on('connection', (ws) => {
+    mcpServer?.handleConnection(ws as any);
+  });
+  return mcpServer;
+}
+
+export function getMCPServer() {
+  return mcpServer;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,68 @@
+import http from 'http';
+import express from 'express';
+import helmet from 'helmet';
+import cors from 'cors';
+import compression from 'compression';
+import * as Boom from '@hapi/boom';
+import { setupMCP, getMCPServer } from './mcp/mcp.handler';
+import { AppServices } from './config/config.types';
+import { getLogger } from './shared/logger';
+
+export function createApplicationServer(services: AppServices) {
+  const app = express();
+  const logger = getLogger();
+
+  app.use(helmet());
+  app.use(cors());
+  app.use(compression());
+  app.use(express.json());
+
+  app.use((req, res, next) => {
+    res.on('finish', () => {
+      logger.info(`${req.method} ${req.url} ${res.statusCode}`);
+    });
+    next();
+  });
+
+  app.get('/health', (_req, res) => {
+    if (services.cacheService.isHealthy()) {
+      res.status(200).json({ status: 'ok' });
+    } else {
+      res.status(503).json({ status: 'unhealthy' });
+    }
+  });
+
+  app.get('/metrics', (_req, res) => {
+    res.json({
+      uptime: process.uptime(),
+      memory: process.memoryUsage(),
+    });
+  });
+
+  app.use((req, _res, next) => {
+    next(Boom.notFound(`Route ${req.path} not found`));
+  });
+
+  app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    const boom = Boom.isBoom(err) ? err : Boom.badImplementation(err.message);
+    res.status(boom.output.statusCode).json(boom.output.payload);
+  });
+
+  const server = http.createServer(app);
+  setupMCP(server, services);
+
+  return {
+    start: () =>
+      new Promise<void>((resolve) => {
+        server.listen(services.config.server.port, () => {
+          logger.info(`Server listening on ${services.config.server.port}`);
+          resolve();
+        });
+      }),
+    stop: () =>
+      new Promise<void>((resolve) => {
+        getMCPServer()?.shutdown();
+        server.close(() => resolve());
+      }),
+  };
+}

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -1,0 +1,24 @@
+export class AppError extends Error {
+  public isOperational: boolean;
+  public statusCode: number;
+  public details?: any;
+
+  constructor(message: string, statusCode = 500, details?: any) {
+    super(message);
+    this.statusCode = statusCode;
+    this.isOperational = true;
+    this.details = details;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class EWSRequestError extends AppError {}
+export class EWSAuthenticationError extends AppError {}
+export class EWSServerBusyError extends AppError {}
+export class EWSNotFoundError extends AppError {}
+
+export class InvalidToolInputError extends AppError {
+  constructor(details: any) {
+    super('Invalid tool input', 400, details);
+  }
+}

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -1,0 +1,26 @@
+import winston from 'winston';
+import { LogConfig } from '../config/config.types';
+
+let logger: winston.Logger | null = null;
+
+export function initializeGlobalLogger(config: LogConfig) {
+  logger = winston.createLogger({
+    level: config.level,
+    format: winston.format.combine(
+      winston.format.timestamp(),
+      process.env.NODE_ENV === 'development'
+        ? winston.format.colorize()
+        : winston.format.uncolorize(),
+      winston.format.errors({ stack: true }),
+      winston.format.json()
+    ),
+    transports: [new winston.transports.Console()],
+  });
+}
+
+export function getLogger(): winston.Logger {
+  if (!logger) {
+    throw new Error('Logger not initialized');
+  }
+  return logger;
+}

--- a/src/tools/AbstractTool.ts
+++ b/src/tools/AbstractTool.ts
@@ -1,0 +1,31 @@
+import { ZodSchema } from 'zod';
+import { ToolV2, ToolHandler } from '@anthropic/mcp';
+import { AppServices } from '../config/config.types';
+import { InvalidToolInputError } from '../shared/errors';
+import { getLogger } from '../shared/logger';
+
+export abstract class AbstractTool<TInput, TOutput> implements ToolV2<TInput, TOutput> {
+  abstract name: string;
+  abstract description: string;
+  abstract version: string;
+  abstract inputSchema: ZodSchema<TInput>;
+
+  protected services: AppServices;
+  protected logger = getLogger();
+
+  constructor(services: AppServices) {
+    this.services = services;
+  }
+
+  handler: ToolHandler<TInput, TOutput> = async (input) => {
+    const parsed = this.inputSchema.safeParse(input);
+    if (!parsed.success) {
+      throw new InvalidToolInputError(parsed.error);
+    }
+    const result = await this.execute(parsed.data);
+    this.services.auditService?.logToolExecution(this.name, parsed.data, result);
+    return result;
+  };
+
+  protected abstract execute(params: TInput): Promise<TOutput>;
+}

--- a/src/tools/email.tool.ts
+++ b/src/tools/email.tool.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+import { AbstractTool } from './AbstractTool';
+import {
+  SearchEmailsParams,
+  SearchEmailsResult,
+  ReadEmailParams,
+  ReadEmailResult,
+} from './tools.types';
+import { AppServices } from '../config/config.types';
+import { parseSOAPResponse, FindItemResponseMessage, GetItemResponseMessage } from '../ews/soap.parser';
+import { mapFindItemResponseToEmails, mapGetItemResponseToEmail } from '../ews/ews.mapper';
+
+export class SearchEmailsTool extends AbstractTool<SearchEmailsParams, SearchEmailsResult> {
+  name = 'search_emails';
+  description = 'Search emails in a mailbox folder.';
+  version = '1.0.0';
+  inputSchema = z.object({
+    folder: z.string().optional().default('inbox'),
+    query: z.string().optional(),
+    pageSize: z.number().min(1).max(100).optional().default(10),
+    pageOffset: z.number().min(0).optional().default(0),
+  });
+
+  constructor(services: AppServices) {
+    super(services);
+  }
+
+  protected async execute(params: SearchEmailsParams): Promise<SearchEmailsResult> {
+    const soap = this.services.soapBuilder.buildFindItemRequest({
+      folderId: params.folder || 'inbox',
+      queryString: params.query,
+      pageSize: params.pageSize || 10,
+      offset: params.pageOffset || 0,
+    });
+    const xml = await this.services.ewsClient.request(soap, 'FindItem');
+    const parsed = parseSOAPResponse<{ ResponseMessages: { FindItemResponseMessage: FindItemResponseMessage } }>(xml, 'FindItem');
+    const msg = parsed.ResponseMessages.FindItemResponseMessage;
+    return mapFindItemResponseToEmails(msg);
+  }
+}
+
+export class ReadEmailTool extends AbstractTool<ReadEmailParams, ReadEmailResult> {
+  name = 'read_email';
+  description = 'Read a single email by id.';
+  version = '1.0.0';
+  inputSchema = z.object({
+    emailId: z.string(),
+  });
+
+  constructor(services: AppServices) {
+    super(services);
+  }
+
+  protected async execute(params: ReadEmailParams): Promise<ReadEmailResult> {
+    const soap = this.services.soapBuilder.buildGetItemRequest({ itemIds: [params.emailId] });
+    const xml = await this.services.ewsClient.request(soap, 'GetItem');
+    const parsed = parseSOAPResponse<{ ResponseMessages: { GetItemResponseMessage: GetItemResponseMessage } }>(xml, 'GetItem');
+    const msg = parsed.ResponseMessages.GetItemResponseMessage;
+    return { email: mapGetItemResponseToEmail(msg) };
+  }
+}

--- a/src/tools/tools.types.ts
+++ b/src/tools/tools.types.ts
@@ -1,0 +1,35 @@
+export interface Email {
+  id: string;
+  changeKey: string;
+  subject: string;
+  receivedDate: string;
+  from: string;
+  fromName: string;
+  body: string;
+  bodyType: string;
+  bodyPreview: string;
+  hasAttachments: boolean;
+  importance: string;
+  isRead: boolean;
+}
+
+export interface SearchEmailsParams {
+  folder?: string;
+  query?: string;
+  pageSize?: number;
+  pageOffset?: number;
+}
+
+export interface SearchEmailsResult {
+  emails: Email[];
+  totalItems: number;
+  hasMore: boolean;
+}
+
+export interface ReadEmailParams {
+  emailId: string;
+}
+
+export interface ReadEmailResult {
+  email: Email | null;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "paths": {
+      "@/*": [
+        "src/*"
+      ]
+    },
+    "sourceMap": true,
+    "declaration": true,
+    "baseUrl": "."
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold TypeScript project for the EWS MCP server
- add Dockerfile and compose setup
- provide configuration loader, logging and error helpers
- implement basic EWS client and SOAP helpers
- stub cache and audit services
- create email search and read tools
- wire up MCP server and Express app

## Testing
- `npm run build` *(fails: Cannot find module types)*
