### PR TITLE
fix: Add missing Any import in email_message.py

### DIFF
--- a/src/core/email_message.py
+++ b/src/core/email_message.py
@@ -1,7 +1,7 @@
 """Email Message model for EWS MCP v3.0."""
 
 from pydantic import BaseModel, Field
-from typing import Optional, List
+from typing import Optional, List, Any
 from datetime import datetime
 from enum import Enum
 


### PR DESCRIPTION
Fixed NameError: name 'Any' is not defined in email_message.py
- Added Any to typing imports
- Required for from_ews_message classmethod type hint
- All core modules now compile successfully

This fixes the container startup error where application crashed on import.