### PR TITLE
fix: Properly await coroutines returned by lambda functions in cache

### DIFF
--- a/src/adapters/cache_adapter.py
+++ b/src/adapters/cache_adapter.py
@@ -111,10 +111,14 @@ class CacheAdapter:
 
         # Fetch
         try:
+            # Call the fetch function
             if asyncio.iscoroutinefunction(fetch_func):
                 value = await fetch_func()
             else:
                 value = fetch_func()
+                # If the result is a coroutine (e.g., from a lambda), await it
+                if asyncio.iscoroutine(value):
+                    value = await value
 
             # Cache
             self.set(key, value, duration)


### PR DESCRIPTION
The cache adapter's get_or_fetch method now correctly handles lambdas that return coroutines. Previously, asyncio.iscoroutinefunction() would return False for lambdas, causing the returned coroutine to not be awaited.

This fixes the "TypeError: 'coroutine' object is not iterable" error in PersonService.find_person() when calling gal_adapter.search() via lambda.