### PR TITLE
fix: Add missing Response returns to SSE route handlers

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -408,10 +408,12 @@ class EWSMCPServer:
                     streams[1],
                     self.server.create_initialization_options(),
                 )
+            return Response()
 
         async def handle_messages(request):
             """Handle POST messages endpoint."""
             await sse.handle_post_message(request.scope, request.receive, request._send)
+            return Response()
 
         # Create Starlette app
         app = Starlette(


### PR DESCRIPTION
Starlette route handlers must return a Response object. The handle_sse and handle_messages functions were returning None (implicitly), causing 'TypeError: NoneType object is not callable' when Starlette tried to call the response.