### PR TITLE
fix: Resolve 2 critical bugs - soft delete and phone number type

### DIFF
--- a/src/tools/contact_tools.py
+++ b/src/tools/contact_tools.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict
 from exchangelib import Contact
-from exchangelib.indexed_properties import EmailAddress
+from exchangelib.indexed_properties import EmailAddress, PhoneNumber
 
 from .base import BaseTool
 from ..models import CreateContactRequest
@@ -86,7 +86,7 @@ class CreateContactTool(BaseTool):
 
             # Set optional fields
             if request.phone_number:
-                contact.phone_numbers = [{'label': 'BusinessPhone', 'phone_number': request.phone_number}]
+                contact.phone_numbers = [PhoneNumber(label='BusinessPhone', phone_number=request.phone_number)]
 
             if request.company:
                 contact.company_name = request.company
@@ -328,7 +328,7 @@ class UpdateContactTool(BaseTool):
                 ]
 
             if "phone_number" in kwargs:
-                contact.phone_numbers = [{'label': 'BusinessPhone', 'phone_number': kwargs["phone_number"]}]
+                contact.phone_numbers = [PhoneNumber(label='BusinessPhone', phone_number=kwargs["phone_number"])]
 
             if "company" in kwargs:
                 contact.company_name = kwargs["company"]

--- a/src/tools/email_tools.py
+++ b/src/tools/email_tools.py
@@ -749,7 +749,9 @@ class DeleteEmailTool(BaseTool):
                 item.delete()
                 action = "permanently deleted"
             else:
-                item.soft_delete()
+                # Move to trash folder (Deleted Items) so user can recover
+                # Note: soft_delete() makes items recoverable but not visible in Deleted Items
+                item.move(self.ews_client.account.trash)
                 action = "moved to trash"
 
             self.logger.info(f"Email {message_id} {action}")


### PR DESCRIPTION
Bug #7: Soft delete not working (P1 - CRITICAL)
- Changed from soft_delete() to move(account.trash)
- soft_delete() made items recoverable but not visible in Deleted Items
- Now properly moves emails to trash folder for user recovery

Bug #8: Phone number type conversion (P2)
- Added PhoneNumber import from exchangelib.indexed_properties
- Converted dictionary usage to PhoneNumber objects in create_contact
- Fixed same issue in update_contact function