### PR TITLE
fix: Reduce timezone warnings in get_calendar by fetching only needed…

### DIFF
--- a/src/tools/calendar_tools.py
+++ b/src/tools/calendar_tools.py
@@ -173,10 +173,13 @@ class GetCalendarTool(BaseTool):
 
             max_results = kwargs.get("max_results", 50)
 
-            # Query calendar
+            # Query calendar - use only() to fetch specific fields and avoid timezone parsing warnings
             items = self.ews_client.account.calendar.view(
                 start=start_date,
                 end=end_date
+            ).only(
+                'id', 'subject', 'start', 'end', 'location',
+                'organizer', 'is_all_day', 'required_attendees'
             ).order_by('start')
 
             # Format events


### PR DESCRIPTION
… fields

Use .only() to fetch specific fields when querying calendar events, avoiding exchangelib's attempt to parse unknown timezone IDs like 'Customized Time Zone' and '(UTC+03:00) Kuwait, Riyadh'.

This significantly reduces warnings for bulk calendar queries while still fetching all required data (id, subject, start, end, location, organizer, is_all_day, required_attendees).

Note: Warnings may still appear for update/delete operations that require full items, but the bulk of warnings from get_calendar are now eliminated.