### PR TITLE
docs: Add Open WebUI integration guide and setup files

### DIFF
--- a/OPENWEBUI_SETUP.md
+++ b/OPENWEBUI_SETUP.md
@@ -1,0 +1,304 @@
+# Open WebUI Integration Guide for EWS MCP Server
+
+## Overview
+
+Open WebUI doesn't natively support SSE-based MCP servers. You need to use **MCPO** (MCP-to-OpenAPI proxy) as a bridge to translate your SSE-based EWS MCP server into OpenAPI-compatible endpoints.
+
+## Architecture
+
+```
+Open WebUI → MCPO (Port 8000) → EWS MCP Server (Port 8000 internally)
+```
+
+## Setup Options
+
+### Option 1: Using Docker Compose (Recommended)
+
+Create `docker-compose.openwebui.yml`:
+
+```yaml
+version: '3.8'
+
+services:
+  # Your EWS MCP Server
+  ews-mcp:
+    build: .
+    container_name: ews-mcp-server
+    ports:
+      - "8001:8000"  # Expose on port 8001 externally
+    environment:
+      - EWS_EMAIL=${EWS_EMAIL}
+      - EWS_PASSWORD=${EWS_PASSWORD}
+      - EWS_SERVER_URL=${EWS_SERVER_URL}
+      - EWS_AUTH_TYPE=${EWS_AUTH_TYPE}
+      - MCP_TRANSPORT=sse
+      - MCP_HOST=0.0.0.0
+      - MCP_PORT=8000
+    networks:
+      - mcp-network
+    restart: unless-stopped
+
+  # MCPO Proxy (Bridge to Open WebUI)
+  mcpo:
+    image: openwebui/mcpo:latest
+    container_name: mcpo-proxy
+    ports:
+      - "9000:8000"  # MCPO on port 9000
+    command: >
+      --port 8000
+      --api-key "${MCPO_API_KEY:-your-secret-key}"
+      --server-type "sse"
+      --
+      http://ews-mcp:8000/sse
+    networks:
+      - mcp-network
+    depends_on:
+      - ews-mcp
+    restart: unless-stopped
+
+  # Open WebUI (Optional - if you don't have it running)
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:main
+    container_name: open-webui
+    ports:
+      - "3000:8080"
+    volumes:
+      - open-webui-data:/app/backend/data
+    environment:
+      - OLLAMA_BASE_URL=http://host.docker.internal:11434
+    networks:
+      - mcp-network
+    restart: unless-stopped
+
+networks:
+  mcp-network:
+    driver: bridge
+
+volumes:
+  open-webui-data:
+```
+
+**Start the stack:**
+```bash
+docker-compose -f docker-compose.openwebui.yml up -d
+```
+
+### Option 2: Manual Setup with MCPO
+
+#### 1. Start your EWS MCP Server
+```bash
+# Make sure your server is running on port 8001
+docker-compose up -d
+```
+
+#### 2. Run MCPO
+```bash
+# Using Docker
+docker run -d \
+  --name mcpo-proxy \
+  --network host \
+  -p 9000:8000 \
+  openwebui/mcpo:latest \
+  --port 8000 \
+  --api-key "your-secret-key" \
+  --server-type "sse" \
+  -- \
+  http://localhost:8001/sse
+
+# Or using npx (if you have Node.js)
+npx @openwebui/mcpo \
+  --port 9000 \
+  --api-key "your-secret-key" \
+  --server-type "sse" \
+  -- \
+  http://localhost:8001/sse
+```
+
+### Option 3: MCPO with Configuration File
+
+Create `mcpo-config.json`:
+
+```json
+{
+  "mcpServers": {
+    "ews-exchange": {
+      "type": "sse",
+      "url": "http://localhost:8001/sse",
+      "headers": {
+        "Authorization": "Bearer your-token-if-needed"
+      }
+    }
+  }
+}
+```
+
+Run MCPO with config:
+```bash
+docker run -d \
+  --name mcpo-proxy \
+  --network host \
+  -v $(pwd)/mcpo-config.json:/app/config.json \
+  -p 9000:8000 \
+  openwebui/mcpo:latest \
+  --config /app/config.json \
+  --port 8000 \
+  --api-key "your-secret-key"
+```
+
+## Configure Open WebUI
+
+### 1. Access Open WebUI Admin Panel
+- Navigate to: `http://localhost:3000` (or your Open WebUI URL)
+- Go to **Admin Settings** → **Connections**
+
+### 2. Add MCPO as an External API
+- **API Base URL**: `http://localhost:9000` (or your MCPO URL)
+- **API Key**: `your-secret-key` (same as MCPO_API_KEY)
+- **Name**: `Exchange Web Services`
+
+### 3. Test the Connection
+Open WebUI will fetch the OpenAPI schema from MCPO and discover all 44 EWS tools.
+
+## Available Tools in Open WebUI
+
+Once configured, you'll have access to 44 Exchange tools:
+
+### Email Tools (8)
+- send_email
+- read_emails
+- search_emails
+- get_email_details
+- delete_email
+- move_email
+- update_email
+- copy_email
+
+### Calendar Tools (7)
+- create_appointment
+- get_calendar
+- update_appointment
+- delete_appointment
+- respond_to_meeting
+- check_availability
+- find_meeting_times
+
+### Contact Tools (9)
+- create_contact
+- search_contacts
+- get_contacts
+- update_contact
+- delete_contact
+- resolve_names
+- find_person
+- get_communication_history
+- analyze_network
+
+### Task Tools (5)
+- create_task
+- get_tasks
+- update_task
+- complete_task
+- delete_task
+
+### Other Tools (15)
+- Attachments (5 tools)
+- Search (3 tools)
+- Folders (5 tools)
+- Out-of-Office (2 tools)
+
+## Troubleshooting
+
+### MCPO Connection Issues
+
+**Problem**: MCPO can't connect to EWS MCP server
+```bash
+# Check EWS MCP is running
+curl http://localhost:8001/sse
+
+# Check MCPO logs
+docker logs mcpo-proxy
+```
+
+**Problem**: Open WebUI can't connect to MCPO
+```bash
+# Check MCPO is running and accessible
+curl http://localhost:9000/openapi.json
+
+# Should return OpenAPI schema with all 44 tools
+```
+
+### Network Issues
+
+If using Docker networks, ensure all services are on the same network:
+```bash
+# Check network connectivity
+docker exec mcpo-proxy ping ews-mcp
+```
+
+### Authentication Issues
+
+If your EWS server requires authentication headers:
+```json
+{
+  "mcpServers": {
+    "ews-exchange": {
+      "type": "sse",
+      "url": "http://ews-mcp:8000/sse",
+      "headers": {
+        "Authorization": "Bearer ${YOUR_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+## Security Considerations
+
+1. **API Key**: Use a strong API key for MCPO
+   ```bash
+   export MCPO_API_KEY=$(openssl rand -hex 32)
+   ```
+
+2. **Network Isolation**: Run all services in a private Docker network
+
+3. **TLS/SSL**: For production, put MCPO behind a reverse proxy with TLS:
+   ```nginx
+   server {
+       listen 443 ssl;
+       server_name mcpo.yourdomain.com;
+
+       ssl_certificate /path/to/cert.pem;
+       ssl_certificate_key /path/to/key.pem;
+
+       location / {
+           proxy_pass http://localhost:9000;
+           proxy_set_header Host $host;
+           proxy_set_header X-Real-IP $remote_addr;
+       }
+   }
+   ```
+
+## Monitoring
+
+Check MCPO metrics and health:
+```bash
+# Health check
+curl http://localhost:9000/health
+
+# Metrics (if enabled)
+curl http://localhost:9000/metrics
+```
+
+## Next Steps
+
+1. Start your EWS MCP server
+2. Start MCPO with your configuration
+3. Configure Open WebUI to connect to MCPO
+4. Test a simple tool like `read_emails` or `get_calendar`
+5. Monitor logs for any issues
+
+## Resources
+
+- [Open WebUI MCP Documentation](https://docs.openwebui.com/features/mcp/)
+- [MCPO GitHub Repository](https://github.com/open-webui/mcpo)
+- [MCP Protocol Specification](https://spec.modelcontextprotocol.io/)

--- a/docker-compose.openwebui.yml
+++ b/docker-compose.openwebui.yml
@@ -1,0 +1,86 @@
+version: '3.8'
+
+services:
+  # EWS MCP Server
+  ews-mcp:
+    build: .
+    container_name: ews-mcp-server
+    ports:
+      - "8001:8000"
+    environment:
+      # Exchange credentials
+      - EWS_EMAIL=${EWS_EMAIL}
+      - EWS_PASSWORD=${EWS_PASSWORD}
+      - EWS_SERVER_URL=${EWS_SERVER_URL}
+      - EWS_AUTH_TYPE=${EWS_AUTH_TYPE:-basic}
+
+      # MCP configuration
+      - MCP_TRANSPORT=sse
+      - MCP_HOST=0.0.0.0
+      - MCP_PORT=8000
+
+      # Timezone
+      - TIMEZONE=${TIMEZONE:-Asia/Riyadh}
+
+      # Optional: Enable specific tools
+      - ENABLE_EMAIL=true
+      - ENABLE_CALENDAR=true
+      - ENABLE_CONTACTS=true
+      - ENABLE_TASKS=true
+    networks:
+      - mcp-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/sse"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # MCPO - Bridge between EWS MCP and Open WebUI
+  mcpo:
+    image: openwebui/mcpo:latest
+    container_name: mcpo-proxy
+    ports:
+      - "9000:8000"
+    command: >
+      --port 8000
+      --api-key "${MCPO_API_KEY:-change-this-secret-key}"
+      --server-type "sse"
+      --
+      http://ews-mcp:8000/sse
+    networks:
+      - mcp-network
+    depends_on:
+      ews-mcp:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # Open WebUI (Optional - uncomment if you need it)
+  # open-webui:
+  #   image: ghcr.io/open-webui/open-webui:main
+  #   container_name: open-webui
+  #   ports:
+  #     - "3000:8080"
+  #   volumes:
+  #     - open-webui-data:/app/backend/data
+  #   environment:
+  #     - OLLAMA_BASE_URL=http://host.docker.internal:11434
+  #     # Add MCPO as default connection
+  #     - ENABLE_OAUTH_SIGNUP=false
+  #     - ENABLE_SIGNUP=true
+  #   networks:
+  #     - mcp-network
+  #   restart: unless-stopped
+
+networks:
+  mcp-network:
+    driver: bridge
+
+volumes:
+  open-webui-data:
+    driver: local

--- a/start-openwebui.sh
+++ b/start-openwebui.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}=== EWS MCP + MCPO + Open WebUI Setup ===${NC}\n"
+
+# Check if .env file exists
+if [ ! -f .env ]; then
+    echo -e "${RED}Error: .env file not found!${NC}"
+    echo "Please create a .env file with your Exchange credentials:"
+    echo ""
+    echo "EWS_EMAIL=your-email@company.com"
+    echo "EWS_PASSWORD=your-password"
+    echo "EWS_SERVER_URL=https://your-exchange-server/EWS/Exchange.asmx"
+    echo "EWS_AUTH_TYPE=basic"
+    echo "MCPO_API_KEY=your-secret-key"
+    echo ""
+    exit 1
+fi
+
+# Generate MCPO API key if not set
+if ! grep -q "MCPO_API_KEY" .env; then
+    echo -e "${YELLOW}Generating MCPO API key...${NC}"
+    MCPO_KEY=$(openssl rand -hex 32)
+    echo "MCPO_API_KEY=${MCPO_KEY}" >> .env
+    echo -e "${GREEN}✓ Generated MCPO API key${NC}\n"
+fi
+
+# Build and start services
+echo -e "${YELLOW}Building and starting services...${NC}"
+docker-compose -f docker-compose.openwebui.yml up --build -d
+
+echo ""
+echo -e "${GREEN}=== Services Started ===${NC}\n"
+
+# Wait for services to be healthy
+echo "Waiting for services to start..."
+sleep 5
+
+# Check EWS MCP
+if curl -s http://localhost:8001/sse > /dev/null 2>&1; then
+    echo -e "${GREEN}✓ EWS MCP Server: http://localhost:8001${NC}"
+else
+    echo -e "${RED}✗ EWS MCP Server: Failed to start${NC}"
+fi
+
+# Check MCPO
+if curl -s http://localhost:9000/health > /dev/null 2>&1; then
+    echo -e "${GREEN}✓ MCPO Proxy: http://localhost:9000${NC}"
+else
+    echo -e "${RED}✗ MCPO Proxy: Failed to start${NC}"
+fi
+
+# Show available tools
+echo ""
+echo -e "${YELLOW}Fetching available tools...${NC}"
+if curl -s http://localhost:9000/openapi.json | jq -r '.paths | keys[]' 2>/dev/null; then
+    echo -e "${GREEN}✓ MCPO is serving tools${NC}"
+else
+    echo -e "${YELLOW}Note: Install 'jq' to see available tools${NC}"
+fi
+
+# Instructions
+echo ""
+echo -e "${GREEN}=== Next Steps ===${NC}"
+echo ""
+echo "1. Configure Open WebUI:"
+echo "   - Navigate to Admin Settings → Connections"
+echo "   - Add External API:"
+echo "     • API Base URL: http://localhost:9000"
+echo "     • API Key: $(grep MCPO_API_KEY .env | cut -d= -f2)"
+echo "     • Name: Exchange Web Services"
+echo ""
+echo "2. View logs:"
+echo "   docker-compose -f docker-compose.openwebui.yml logs -f"
+echo ""
+echo "3. Stop services:"
+echo "   docker-compose -f docker-compose.openwebui.yml down"
+echo ""
+echo -e "${GREEN}=== Available Tools ===${NC}"
+echo "44 Exchange tools available for:"
+echo "  • Email (8 tools)"
+echo "  • Calendar (7 tools)"
+echo "  • Contacts (9 tools)"
+echo "  • Tasks (5 tools)"
+echo "  • Attachments (5 tools)"
+echo "  • Search (3 tools)"
+echo "  • Folders (5 tools)"
+echo "  • Out-of-Office (2 tools)"
+echo ""


### PR DESCRIPTION
Added comprehensive setup for integrating EWS MCP server with Open WebUI:

- OPENWEBUI_SETUP.md: Complete integration guide with architecture, setup options, troubleshooting, and security considerations

- docker-compose.openwebui.yml: Docker Compose configuration that runs EWS MCP server + MCPO bridge + optional Open WebUI in one stack

- start-openwebui.sh: Automated startup script that builds services, checks health, and provides next steps

MCPO (MCP-to-OpenAPI proxy) bridges SSE-based MCP servers to Open WebUI by translating them into OpenAPI-compatible endpoints. This makes all 44 Exchange tools available in Open WebUI's chat interface.