### PR TITLE
feat: Add built-in OpenAPI/REST API support - eliminate MCPO dependency

### DIFF
--- a/OPENWEBUI_SETUP.md
+++ b/OPENWEBUI_SETUP.md
@@ -1,0 +1,395 @@
+# Open WebUI Integration Guide for EWS MCP Server
+
+## Overview
+
+The EWS MCP Server now has **built-in OpenAPI/REST support**, eliminating the need for MCPO as a separate bridge. The server exposes both MCP SSE endpoints (for MCP clients like Claude Desktop) and REST API endpoints (for Open WebUI and other HTTP clients) on the same port.
+
+## Architecture
+
+```
+Open WebUI → EWS MCP Server (Port 8000)
+             ├─ GET  /sse                    (MCP SSE connection)
+             ├─ POST /messages               (MCP messages)
+             ├─ GET  /openapi.json           (OpenAPI 3.0 schema)
+             ├─ POST /api/tools/{tool_name}  (REST tool execution)
+             └─ GET  /health                 (Health check)
+```
+
+**Benefits:**
+- ✅ Single server for both MCP and REST protocols
+- ✅ No additional proxy needed
+- ✅ Simplified deployment
+- ✅ Direct tool invocation via REST API
+- ✅ Auto-generated OpenAPI schema
+
+## Quick Start
+
+### Using the Automated Script (Easiest)
+
+```bash
+# Run the setup script
+./start-openwebui.sh
+```
+
+This will:
+1. Validate your `.env` file
+2. Build and start the EWS MCP server
+3. Display available endpoints
+4. Show next steps for Open WebUI configuration
+
+### Manual Setup with Docker Compose
+
+Use the provided `docker-compose.openwebui.yml`:
+
+```bash
+# Start the server
+docker-compose -f docker-compose.openwebui.yml up -d
+
+# Check health
+curl http://localhost:8000/health
+
+# View OpenAPI schema
+curl http://localhost:8000/openapi.json
+
+# View logs
+docker-compose -f docker-compose.openwebui.yml logs -f
+```
+
+### Using Existing Docker Setup
+
+If you already have the server running:
+
+```bash
+# The server now exposes REST endpoints by default
+# No configuration change needed!
+
+# Test OpenAPI endpoint
+curl http://localhost:8000/openapi.json | jq
+```
+
+## Configure Open WebUI
+
+### 1. Access Open WebUI Admin Panel
+- Navigate to your Open WebUI instance
+- Go to **Admin Settings** → **Connections** → **External APIs**
+
+### 2. Add EWS MCP Server
+- **API Base URL**: `http://localhost:8000` (or your server URL)
+- **Name**: `Exchange Web Services`
+- **Description**: `Microsoft Exchange operations via MCP`
+
+### 3. Auto-Discovery
+Open WebUI will automatically:
+- Fetch the OpenAPI schema from `/openapi.json`
+- Discover all 44 Exchange tools
+- Make them available in the chat interface
+
+### 4. Test the Connection
+Try a simple query like:
+```
+"Read my last 5 emails"
+"Show me today's calendar"
+"Search my contacts for John"
+```
+
+## Available Endpoints
+
+### MCP Protocol (for Claude Desktop, etc.)
+- `GET  /sse` - Server-Sent Events connection
+- `POST /messages` - Message handling
+
+### REST API (for Open WebUI, etc.)
+- `GET  /openapi.json` - OpenAPI 3.0 schema
+- `POST /api/tools/send_email` - Send email
+- `POST /api/tools/read_emails` - Read emails
+- `POST /api/tools/search_emails` - Search emails
+- `POST /api/tools/get_calendar` - Get calendar events
+- `POST /api/tools/create_contact` - Create contact
+- ... (44 tools total)
+
+### Utility
+- `GET  /health` - Health check endpoint
+
+## Testing the REST API
+
+### List Available Tools
+```bash
+# Get OpenAPI schema
+curl http://localhost:8000/openapi.json | jq '.paths | keys'
+```
+
+### Read Emails
+```bash
+curl -X POST http://localhost:8000/api/tools/read_emails \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "folder": "inbox",
+    "max_results": 5,
+    "unread_only": false
+  }'
+```
+
+### Search Emails
+```bash
+curl -X POST http://localhost:8000/api/tools/search_emails \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "subject_contains": "meeting",
+    "max_results": 10
+  }'
+```
+
+### Get Calendar
+```bash
+curl -X POST http://localhost:8000/api/tools/get_calendar \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "days_ahead": 7,
+    "max_results": 20
+  }'
+```
+
+### Create Contact
+```bash
+curl -X POST http://localhost:8000/api/tools/create_contact \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "given_name": "John",
+    "surname": "Doe",
+    "email_address": "john.doe@example.com",
+    "phone_number": "+1234567890"
+  }'
+```
+
+## Available Tools (44 Total)
+
+### Email Tools (8)
+- `send_email` - Send email with attachments
+- `read_emails` - Read emails from folder
+- `search_emails` - Search with filters
+- `get_email_details` - Get full email details
+- `delete_email` - Delete or move to trash
+- `move_email` - Move between folders
+- `update_email` - Update flags/categories
+- `copy_email` - Copy to another folder
+
+### Calendar Tools (7)
+- `create_appointment` - Create calendar event
+- `get_calendar` - Retrieve events
+- `update_appointment` - Modify event
+- `delete_appointment` - Delete event
+- `respond_to_meeting` - Accept/decline
+- `check_availability` - Check free/busy
+- `find_meeting_times` - Find available slots
+
+### Contact Tools (9)
+- `create_contact` - Create new contact
+- `search_contacts` - Search contacts
+- `get_contacts` - List contacts
+- `update_contact` - Modify contact
+- `delete_contact` - Remove contact
+- `resolve_names` - Resolve email addresses
+- `find_person` - Smart person search
+- `get_communication_history` - Email history
+- `analyze_network` - Contact relationships
+
+### Task Tools (5)
+- `create_task` - Create task
+- `get_tasks` - List tasks
+- `update_task` - Modify task
+- `complete_task` - Mark complete
+- `delete_task` - Remove task
+
+### Attachment Tools (5)
+- `list_attachments` - List email attachments
+- `download_attachment` - Download file
+- `add_attachment` - Add to email
+- `delete_attachment` - Remove attachment
+- `read_attachment` - Read attachment content
+
+### Search Tools (3)
+- `advanced_search` - Multi-folder search
+- `search_by_conversation` - Conversation threads
+- `full_text_search` - Full-text search
+
+### Folder Tools (5)
+- `list_folders` - List all folders
+- `create_folder` - Create new folder
+- `delete_folder` - Delete folder
+- `rename_folder` - Rename folder
+- `move_folder` - Move folder
+
+### Out-of-Office Tools (2)
+- `set_oof_settings` - Set OOF message
+- `get_oof_settings` - Get OOF status
+
+## Troubleshooting
+
+### OpenAPI Schema Not Loading
+
+**Problem**: Open WebUI can't fetch schema
+```bash
+# Check if server is running
+curl http://localhost:8000/health
+
+# Check OpenAPI endpoint
+curl http://localhost:8000/openapi.json
+```
+
+**Solution**: Ensure server is running and accessible from Open WebUI container
+
+### Tools Not Appearing in Open WebUI
+
+**Problem**: Tools don't show up after adding connection
+
+**Check**:
+1. Verify OpenAPI schema is valid: `curl http://localhost:8000/openapi.json | jq`
+2. Check Open WebUI logs for errors
+3. Restart Open WebUI to force re-fetch
+
+### Network Connectivity
+
+If using Docker networks:
+```bash
+# Check connectivity from Open WebUI container
+docker exec open-webui curl http://ews-mcp:8000/health
+
+# Or use host network mode
+docker run --network host ...
+```
+
+### REST API Returns 404
+
+**Problem**: `/api/tools/tool_name` returns 404
+
+**Check**:
+- Tool name is correct (use `/openapi.json` to list available tools)
+- Using POST method (not GET)
+- Server is fully started and tools are registered
+
+## Security Considerations
+
+### Authentication
+
+Currently, the REST API doesn't require authentication. For production:
+
+```python
+# Add API key middleware
+# In src/main.py, check for Authorization header
+```
+
+### Network Security
+
+1. **Use TLS/SSL**: Put server behind reverse proxy with TLS
+2. **Firewall**: Only allow connections from Open WebUI
+3. **Rate Limiting**: Enable rate limiting in config
+
+Example Nginx config:
+```nginx
+server {
+    listen 443 ssl;
+    server_name ews-mcp.yourdomain.com;
+
+    ssl_certificate /path/to/cert.pem;
+    ssl_certificate_key /path/to/key.pem;
+
+    location / {
+        proxy_pass http://localhost:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+## Performance Tips
+
+### Connection Pooling
+The server reuses Exchange connections. Monitor with:
+```bash
+curl http://localhost:8000/health
+```
+
+### Request Timeout
+Adjust timeout for large operations:
+```env
+REQUEST_TIMEOUT=300  # 5 minutes
+```
+
+### Concurrent Requests
+The async server handles concurrent requests efficiently. No special configuration needed.
+
+## Monitoring
+
+### Health Check
+```bash
+# Simple health check
+curl http://localhost:8000/health
+
+# Should return:
+# {"status":"ok","tools":44}
+```
+
+### Server Logs
+```bash
+# View logs
+docker-compose -f docker-compose.openwebui.yml logs -f ews-mcp
+
+# Filter for errors
+docker-compose -f docker-compose.openwebui.yml logs ews-mcp | grep ERROR
+```
+
+### Metrics
+Enable structured logging in `.env`:
+```env
+LOG_LEVEL=INFO
+ENABLE_AUDIT_LOG=true
+```
+
+## Migration from MCPO
+
+If you were using MCPO before:
+
+### What Changed
+- ✅ No separate MCPO container needed
+- ✅ Port changed from 9000 → 8000
+- ✅ Direct connection to EWS MCP
+- ✅ Same functionality, simpler setup
+
+### Update Open WebUI
+1. Remove old MCPO connection
+2. Add new connection pointing to `http://localhost:8000`
+3. Tools will auto-discover
+
+### Update Docker Compose
+```bash
+# Stop old setup
+docker-compose -f docker-compose.openwebui.yml down
+
+# Pull latest code
+git pull
+
+# Start new setup
+./start-openwebui.sh
+```
+
+## Support
+
+### Resources
+- [MCP Protocol Specification](https://spec.modelcontextprotocol.io/)
+- [Open WebUI Documentation](https://docs.openwebui.com/)
+- [EWS MCP GitHub](https://github.com/azizmazrou/ews-mcp)
+
+### Common Issues
+See [Troubleshooting](#troubleshooting) section above
+
+## Next Steps
+
+1. **Test the REST API** with curl commands above
+2. **Configure Open WebUI** to connect to the server
+3. **Try sample queries** in Open WebUI chat
+4. **Enable monitoring** with health checks and logs
+5. **Set up TLS** for production deployments
+
+---
+
+**Note**: The server now provides both MCP SSE and REST API on port 8000. No separate MCPO proxy is needed!

--- a/docker-compose.openwebui.yml
+++ b/docker-compose.openwebui.yml
@@ -1,32 +1,49 @@
 version: '3.8'
 
+# EWS MCP Server with built-in OpenAPI/REST support
+# This unified architecture eliminates the need for MCPO or other OpenAPI adapters
+# The server provides both MCP SSE protocol and REST API on a single port (8000)
+
 services:
-  # EWS MCP Server with built-in OpenAPI/REST support
+  # EWS MCP Server - Unified MCP + REST API
   ews-mcp:
     build: .
     container_name: ews-mcp-server
     ports:
       - "8000:8000"  # Single port for both MCP SSE and REST API
     environment:
-      # Exchange credentials
+      # Exchange Server Configuration
       - EWS_EMAIL=${EWS_EMAIL}
       - EWS_PASSWORD=${EWS_PASSWORD}
       - EWS_SERVER_URL=${EWS_SERVER_URL}
       - EWS_AUTH_TYPE=${EWS_AUTH_TYPE:-basic}
 
-      # MCP configuration
+      # MCP Server Configuration
       - MCP_TRANSPORT=sse
       - MCP_HOST=0.0.0.0
       - MCP_PORT=8000
+      - MCP_SERVER_NAME=ews-mcp-server
 
-      # Timezone
+      # Timezone Configuration
       - TIMEZONE=${TIMEZONE:-Asia/Riyadh}
 
-      # Optional: Enable specific tools
+      # Tool Categories (Optional - enable/disable specific tool groups)
       - ENABLE_EMAIL=true
       - ENABLE_CALENDAR=true
       - ENABLE_CONTACTS=true
       - ENABLE_TASKS=true
+      - ENABLE_ATTACHMENTS=true
+      - ENABLE_SEARCH=true
+      - ENABLE_FOLDERS=true
+      - ENABLE_OOF=true
+
+      # AI Tools (Optional - requires AI provider configuration)
+      - ENABLE_AI_TOOLS=${ENABLE_AI_TOOLS:-false}
+      - AI_PROVIDER=${AI_PROVIDER:-}
+      - AI_API_KEY=${AI_API_KEY:-}
+
+      # Logging
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
     networks:
       - mcp-network
     restart: unless-stopped
@@ -35,8 +52,14 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+      start_period: 10s
 
-  # Open WebUI (Optional - uncomment if you need it)
+  # Open WebUI (Optional - uncomment to run alongside EWS MCP)
+  # Configuration for connecting to EWS MCP via REST API:
+  # 1. Access Open WebUI at http://localhost:3000
+  # 2. Go to Settings > Functions
+  # 3. Add External API: http://ews-mcp:8000
+  # 4. Auto-discovery will find all 43+ Exchange tools
   # open-webui:
   #   image: ghcr.io/open-webui/open-webui:main
   #   container_name: open-webui
@@ -45,18 +68,29 @@ services:
   #   volumes:
   #     - open-webui-data:/app/backend/data
   #   environment:
+  #     # LLM Configuration
   #     - OLLAMA_BASE_URL=http://host.docker.internal:11434
-  #     # Add MCPO as default connection
+  #
+  #     # Open WebUI Configuration
   #     - ENABLE_OAUTH_SIGNUP=false
   #     - ENABLE_SIGNUP=true
+  #     - DEFAULT_USER_ROLE=user
+  #
+  #     # Optional: Add EWS MCP as default external function
+  #     - EXTERNAL_FUNCTIONS=http://ews-mcp:8000/openapi.json
   #   networks:
   #     - mcp-network
   #   restart: unless-stopped
+  #   depends_on:
+  #     ews-mcp:
+  #       condition: service_healthy
 
 networks:
   mcp-network:
     driver: bridge
+    name: ews-mcp-network
 
 volumes:
   open-webui-data:
     driver: local
+    name: open-webui-data

--- a/docker-compose.openwebui.yml
+++ b/docker-compose.openwebui.yml
@@ -1,0 +1,62 @@
+version: '3.8'
+
+services:
+  # EWS MCP Server with built-in OpenAPI/REST support
+  ews-mcp:
+    build: .
+    container_name: ews-mcp-server
+    ports:
+      - "8000:8000"  # Single port for both MCP SSE and REST API
+    environment:
+      # Exchange credentials
+      - EWS_EMAIL=${EWS_EMAIL}
+      - EWS_PASSWORD=${EWS_PASSWORD}
+      - EWS_SERVER_URL=${EWS_SERVER_URL}
+      - EWS_AUTH_TYPE=${EWS_AUTH_TYPE:-basic}
+
+      # MCP configuration
+      - MCP_TRANSPORT=sse
+      - MCP_HOST=0.0.0.0
+      - MCP_PORT=8000
+
+      # Timezone
+      - TIMEZONE=${TIMEZONE:-Asia/Riyadh}
+
+      # Optional: Enable specific tools
+      - ENABLE_EMAIL=true
+      - ENABLE_CALENDAR=true
+      - ENABLE_CONTACTS=true
+      - ENABLE_TASKS=true
+    networks:
+      - mcp-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # Open WebUI (Optional - uncomment if you need it)
+  # open-webui:
+  #   image: ghcr.io/open-webui/open-webui:main
+  #   container_name: open-webui
+  #   ports:
+  #     - "3000:8080"
+  #   volumes:
+  #     - open-webui-data:/app/backend/data
+  #   environment:
+  #     - OLLAMA_BASE_URL=http://host.docker.internal:11434
+  #     # Add MCPO as default connection
+  #     - ENABLE_OAUTH_SIGNUP=false
+  #     - ENABLE_SIGNUP=true
+  #   networks:
+  #     - mcp-network
+  #   restart: unless-stopped
+
+networks:
+  mcp-network:
+    driver: bridge
+
+volumes:
+  open-webui-data:
+    driver: local

--- a/src/openapi_adapter.py
+++ b/src/openapi_adapter.py
@@ -1,0 +1,189 @@
+"""OpenAPI adapter for MCP tools - provides REST API compatibility."""
+
+import json
+from typing import Any, Dict, List
+from datetime import datetime
+
+
+class OpenAPIAdapter:
+    """Converts MCP tools to OpenAPI/REST endpoints."""
+
+    def __init__(self, server, tools: Dict[str, Any]):
+        """Initialize OpenAPI adapter.
+
+        Args:
+            server: MCP server instance
+            tools: Dictionary of tool name -> tool instance
+        """
+        self.server = server
+        self.tools = tools
+
+    def generate_openapi_schema(self) -> Dict[str, Any]:
+        """Generate OpenAPI 3.0 schema from MCP tools."""
+        paths = {}
+
+        for tool_name, tool in self.tools.items():
+            schema = tool.get_schema()
+
+            # Convert MCP tool schema to OpenAPI path
+            path = f"/api/tools/{tool_name}"
+            paths[path] = {
+                "post": {
+                    "operationId": tool_name,
+                    "summary": schema["description"],
+                    "description": schema["description"],
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/json": {
+                                "schema": self._convert_input_schema(schema["inputSchema"])
+                            }
+                        }
+                    },
+                    "responses": {
+                        "200": {
+                            "description": "Successful response",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "success": {"type": "boolean"},
+                                            "data": {"type": "object"},
+                                            "message": {"type": "string"}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "400": {
+                            "description": "Bad request",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "error": {"type": "string"}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "500": {
+                            "description": "Internal server error",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "error": {"type": "string"}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "tags": [self._get_tool_category(tool_name)]
+                }
+            }
+
+        return {
+            "openapi": "3.0.0",
+            "info": {
+                "title": "Exchange Web Services (EWS) MCP API",
+                "description": "REST API for Exchange operations via Model Context Protocol",
+                "version": "3.0.0",
+                "contact": {
+                    "name": "EWS MCP Server",
+                    "url": "https://github.com/azizmazrou/ews-mcp"
+                }
+            },
+            "servers": [
+                {
+                    "url": "http://localhost:8000",
+                    "description": "Local development server"
+                }
+            ],
+            "paths": paths,
+            "tags": [
+                {"name": "Email", "description": "Email operations"},
+                {"name": "Calendar", "description": "Calendar operations"},
+                {"name": "Contacts", "description": "Contact operations"},
+                {"name": "Tasks", "description": "Task operations"},
+                {"name": "Attachments", "description": "Attachment operations"},
+                {"name": "Search", "description": "Search operations"},
+                {"name": "Folders", "description": "Folder operations"},
+                {"name": "Out-of-Office", "description": "Out-of-office settings"}
+            ]
+        }
+
+    def _convert_input_schema(self, mcp_schema: Dict[str, Any]) -> Dict[str, Any]:
+        """Convert MCP input schema to OpenAPI schema."""
+        # MCP schemas are already JSON Schema compatible
+        return mcp_schema
+
+    def _get_tool_category(self, tool_name: str) -> str:
+        """Determine tool category from tool name."""
+        if any(x in tool_name for x in ["email", "send", "read", "search_email", "move_email", "delete_email", "update_email", "copy_email"]):
+            return "Email"
+        elif any(x in tool_name for x in ["appointment", "calendar", "meeting", "availability"]):
+            return "Calendar"
+        elif any(x in tool_name for x in ["contact", "person", "communication", "network"]):
+            return "Contacts"
+        elif any(x in tool_name for x in ["task", "complete"]):
+            return "Tasks"
+        elif any(x in tool_name for x in ["attachment", "download", "upload"]):
+            return "Attachments"
+        elif any(x in tool_name for x in ["search", "conversation", "full_text"]):
+            return "Search"
+        elif any(x in tool_name for x in ["folder", "rename", "move_folder"]):
+            return "Folders"
+        elif any(x in tool_name for x in ["oof", "out_of_office"]):
+            return "Out-of-Office"
+        return "Other"
+
+    async def handle_rest_request(self, tool_name: str, body: bytes) -> Dict[str, Any]:
+        """Handle REST API request for a tool.
+
+        Args:
+            tool_name: Name of the tool to execute
+            body: Request body bytes
+
+        Returns:
+            Response dictionary
+        """
+        try:
+            # Parse request body
+            try:
+                arguments = json.loads(body.decode('utf-8'))
+            except (json.JSONDecodeError, UnicodeDecodeError) as e:
+                return {
+                    "error": f"Invalid JSON in request body: {e}",
+                    "status": 400
+                }
+
+            # Check if tool exists
+            if tool_name not in self.tools:
+                return {
+                    "error": f"Tool '{tool_name}' not found",
+                    "available_tools": list(self.tools.keys()),
+                    "status": 404
+                }
+
+            # Execute tool
+            tool = self.tools[tool_name]
+            result = await tool.safe_execute(**arguments)
+
+            return {
+                "success": result.get("success", False),
+                "data": result,
+                "message": result.get("message", ""),
+                "status": 200
+            }
+
+        except Exception as e:
+            return {
+                "error": f"Tool execution failed: {str(e)}",
+                "tool": tool_name,
+                "status": 500
+            }

--- a/start-openwebui.sh
+++ b/start-openwebui.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}=== EWS MCP + Open WebUI Setup ===${NC}\n"
+
+# Check if .env file exists
+if [ ! -f .env ]; then
+    echo -e "${RED}Error: .env file not found!${NC}"
+    echo "Please create a .env file with your Exchange credentials:"
+    echo ""
+    echo "EWS_EMAIL=your-email@company.com"
+    echo "EWS_PASSWORD=your-password"
+    echo "EWS_SERVER_URL=https://your-exchange-server/EWS/Exchange.asmx"
+    echo "EWS_AUTH_TYPE=basic"
+    echo ""
+    exit 1
+fi
+
+# Build and start services
+echo -e "${YELLOW}Building and starting services...${NC}"
+docker-compose -f docker-compose.openwebui.yml up --build -d
+
+echo ""
+echo -e "${GREEN}=== Services Started ===${NC}\n"
+
+# Wait for services to be healthy
+echo "Waiting for services to start..."
+sleep 5
+
+# Check EWS MCP Server
+if curl -s http://localhost:8000/health > /dev/null 2>&1; then
+    echo -e "${GREEN}✓ EWS MCP Server: http://localhost:8000${NC}"
+    echo -e "${GREEN}  • MCP SSE: http://localhost:8000/sse${NC}"
+    echo -e "${GREEN}  • REST API: http://localhost:8000/api/tools/{tool_name}${NC}"
+    echo -e "${GREEN}  • OpenAPI: http://localhost:8000/openapi.json${NC}"
+else
+    echo -e "${RED}✗ EWS MCP Server: Failed to start${NC}"
+fi
+
+# Show available tools
+echo ""
+echo -e "${YELLOW}Fetching available tools...${NC}"
+if curl -s http://localhost:8000/openapi.json | jq -r '.paths | keys[]' 2>/dev/null; then
+    echo -e "${GREEN}✓ Server is serving tools${NC}"
+else
+    echo -e "${YELLOW}Note: Install 'jq' to see available tools${NC}"
+fi
+
+# Instructions
+echo ""
+echo -e "${GREEN}=== Next Steps ===${NC}"
+echo ""
+echo "1. Test REST API:"
+echo "   curl http://localhost:8000/openapi.json"
+echo "   curl -X POST http://localhost:8000/api/tools/read_emails \\"
+echo "        -H 'Content-Type: application/json' \\"
+echo "        -d '{\"max_results\": 5}'"
+echo ""
+echo "2. Configure Open WebUI:"
+echo "   - Navigate to Admin Settings → Connections"
+echo "   - Add External API:"
+echo "     • API Base URL: http://localhost:8000"
+echo "     • Name: Exchange Web Services"
+echo "   - OpenAPI schema will be auto-discovered"
+echo ""
+echo "3. View logs:"
+echo "   docker-compose -f docker-compose.openwebui.yml logs -f"
+echo ""
+echo "4. Stop services:"
+echo "   docker-compose -f docker-compose.openwebui.yml down"
+echo ""
+echo -e "${GREEN}=== Available Tools ===${NC}"
+echo "44 Exchange tools available for:"
+echo "  • Email (8 tools)"
+echo "  • Calendar (7 tools)"
+echo "  • Contacts (9 tools)"
+echo "  • Tasks (5 tools)"
+echo "  • Attachments (5 tools)"
+echo "  • Search (3 tools)"
+echo "  • Folders (5 tools)"
+echo "  • Out-of-Office (2 tools)"
+echo ""

--- a/start-openwebui.sh
+++ b/start-openwebui.sh
@@ -1,87 +1,218 @@
 #!/bin/bash
 
+# EWS MCP + Open WebUI Setup Script
+# This script starts the unified EWS MCP server with built-in OpenAPI/REST support
+# No MCPO or external adapters required!
+
 # Colors for output
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
+BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-echo -e "${GREEN}=== EWS MCP + Open WebUI Setup ===${NC}\n"
+echo -e "${BLUE}╔═══════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${BLUE}║       EWS MCP Server with OpenAPI/REST Support Setup         ║${NC}"
+echo -e "${BLUE}║         Unified Architecture - No MCPO Required               ║${NC}"
+echo -e "${BLUE}╚═══════════════════════════════════════════════════════════════╝${NC}\n"
 
 # Check if .env file exists
 if [ ! -f .env ]; then
     echo -e "${RED}Error: .env file not found!${NC}"
+    echo ""
     echo "Please create a .env file with your Exchange credentials:"
     echo ""
+    echo -e "${YELLOW}# Exchange Server Configuration${NC}"
     echo "EWS_EMAIL=your-email@company.com"
     echo "EWS_PASSWORD=your-password"
     echo "EWS_SERVER_URL=https://your-exchange-server/EWS/Exchange.asmx"
     echo "EWS_AUTH_TYPE=basic"
     echo ""
+    echo -e "${YELLOW}# Optional: Timezone Configuration${NC}"
+    echo "TIMEZONE=Asia/Riyadh"
+    echo ""
+    echo -e "${YELLOW}# Optional: Logging${NC}"
+    echo "LOG_LEVEL=INFO"
+    echo ""
+    exit 1
+fi
+
+# Check if docker is running
+if ! docker info > /dev/null 2>&1; then
+    echo -e "${RED}Error: Docker is not running!${NC}"
+    echo "Please start Docker and try again."
     exit 1
 fi
 
 # Build and start services
-echo -e "${YELLOW}Building and starting services...${NC}"
+echo -e "${YELLOW}Building and starting EWS MCP Server...${NC}"
+echo ""
 docker-compose -f docker-compose.openwebui.yml up --build -d
 
+if [ $? -ne 0 ]; then
+    echo -e "${RED}Error: Failed to start services${NC}"
+    echo "Check docker-compose logs for details:"
+    echo "  docker-compose -f docker-compose.openwebui.yml logs"
+    exit 1
+fi
+
 echo ""
-echo -e "${GREEN}=== Services Started ===${NC}\n"
+echo -e "${GREEN}✓ Docker containers started${NC}\n"
 
 # Wait for services to be healthy
-echo "Waiting for services to start..."
-sleep 5
+echo -e "${YELLOW}Waiting for services to initialize...${NC}"
+MAX_RETRIES=30
+RETRY_COUNT=0
 
-# Check EWS MCP Server
-if curl -s http://localhost:8000/health > /dev/null 2>&1; then
-    echo -e "${GREEN}✓ EWS MCP Server: http://localhost:8000${NC}"
-    echo -e "${GREEN}  • MCP SSE: http://localhost:8000/sse${NC}"
-    echo -e "${GREEN}  • REST API: http://localhost:8000/api/tools/{tool_name}${NC}"
-    echo -e "${GREEN}  • OpenAPI: http://localhost:8000/openapi.json${NC}"
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+    if curl -s http://localhost:8000/health > /dev/null 2>&1; then
+        echo -e "${GREEN}✓ EWS MCP Server is healthy${NC}\n"
+        break
+    fi
+
+    RETRY_COUNT=$((RETRY_COUNT + 1))
+    if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
+        echo -e "${RED}✗ Timeout waiting for server to start${NC}"
+        echo "Check logs: docker-compose -f docker-compose.openwebui.yml logs ews-mcp"
+        exit 1
+    fi
+
+    echo -n "."
+    sleep 2
+done
+
+# Display server status and endpoints
+echo -e "${BLUE}╔═══════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${BLUE}║                      Server Status                            ║${NC}"
+echo -e "${BLUE}╚═══════════════════════════════════════════════════════════════╝${NC}\n"
+
+# Get health status
+HEALTH_RESPONSE=$(curl -s http://localhost:8000/health)
+TOOL_COUNT=$(echo $HEALTH_RESPONSE | grep -o '"tools":[0-9]*' | grep -o '[0-9]*')
+
+echo -e "${GREEN}✓ EWS MCP Server Running${NC}"
+echo -e "  Base URL: ${BLUE}http://localhost:8000${NC}"
+echo -e "  Tools Available: ${YELLOW}${TOOL_COUNT:-44}${NC}"
+echo ""
+
+echo -e "${GREEN}Available Endpoints:${NC}"
+echo -e "  ${BLUE}GET${NC}  /health              - Health check"
+echo -e "  ${BLUE}GET${NC}  /sse                 - MCP SSE transport (for Claude Desktop)"
+echo -e "  ${BLUE}POST${NC} /messages            - MCP messages endpoint"
+echo -e "  ${BLUE}GET${NC}  /openapi.json        - OpenAPI 3.0 schema"
+echo -e "  ${BLUE}POST${NC} /api/tools/{tool}    - REST API tool execution"
+echo ""
+
+# Show available tools (if jq is installed)
+if command -v jq &> /dev/null; then
+    echo -e "${BLUE}╔═══════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${BLUE}║                     Available Tool Categories                 ║${NC}"
+    echo -e "${BLUE}╚═══════════════════════════════════════════════════════════════╝${NC}\n"
+
+    OPENAPI_SCHEMA=$(curl -s http://localhost:8000/openapi.json)
+
+    echo -e "${GREEN}Email Tools:${NC}"
+    echo "$OPENAPI_SCHEMA" | jq -r '.tags[] | select(.name == "Email") | .description'
+
+    echo -e "\n${GREEN}Calendar Tools:${NC}"
+    echo "$OPENAPI_SCHEMA" | jq -r '.tags[] | select(.name == "Calendar") | .description'
+
+    echo -e "\n${GREEN}Contact Tools:${NC}"
+    echo "$OPENAPI_SCHEMA" | jq -r '.tags[] | select(.name == "Contacts") | .description'
+
+    echo -e "\n${GREEN}Task Tools:${NC}"
+    echo "$OPENAPI_SCHEMA" | jq -r '.tags[] | select(.name == "Tasks") | .description'
+
+    echo -e "\n${GREEN}Other Categories:${NC}"
+    echo "  • Attachments, Search, Folders, Out-of-Office"
+    echo ""
 else
-    echo -e "${RED}✗ EWS MCP Server: Failed to start${NC}"
+    echo -e "${YELLOW}Tip: Install 'jq' to see detailed tool information${NC}\n"
 fi
 
-# Show available tools
-echo ""
-echo -e "${YELLOW}Fetching available tools...${NC}"
-if curl -s http://localhost:8000/openapi.json | jq -r '.paths | keys[]' 2>/dev/null; then
-    echo -e "${GREEN}✓ Server is serving tools${NC}"
-else
-    echo -e "${YELLOW}Note: Install 'jq' to see available tools${NC}"
-fi
+# Display examples
+echo -e "${BLUE}╔═══════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${BLUE}║                       Quick Start Examples                     ║${NC}"
+echo -e "${BLUE}╚═══════════════════════════════════════════════════════════════╝${NC}\n"
 
-# Instructions
+echo -e "${GREEN}1. View OpenAPI Schema:${NC}"
+echo -e "   ${YELLOW}curl http://localhost:8000/openapi.json | jq${NC}"
 echo ""
-echo -e "${GREEN}=== Next Steps ===${NC}"
+
+echo -e "${GREEN}2. Test REST API - Read Emails:${NC}"
+echo -e "   ${YELLOW}curl -X POST http://localhost:8000/api/tools/read_emails \\${NC}"
+echo -e "   ${YELLOW}     -H 'Content-Type: application/json' \\${NC}"
+echo -e "   ${YELLOW}     -d '{\"max_results\": 5}' | jq${NC}"
 echo ""
-echo "1. Test REST API:"
-echo "   curl http://localhost:8000/openapi.json"
-echo "   curl -X POST http://localhost:8000/api/tools/read_emails \\"
-echo "        -H 'Content-Type: application/json' \\"
-echo "        -d '{\"max_results\": 5}'"
+
+echo -e "${GREEN}3. Get Calendar Events:${NC}"
+echo -e "   ${YELLOW}curl -X POST http://localhost:8000/api/tools/get_calendar \\${NC}"
+echo -e "   ${YELLOW}     -H 'Content-Type: application/json' \\${NC}"
+echo -e "   ${YELLOW}     -d '{\"days\": 7}' | jq${NC}"
 echo ""
-echo "2. Configure Open WebUI:"
-echo "   - Navigate to Admin Settings → Connections"
-echo "   - Add External API:"
-echo "     • API Base URL: http://localhost:8000"
-echo "     • Name: Exchange Web Services"
-echo "   - OpenAPI schema will be auto-discovered"
+
+echo -e "${GREEN}4. Search Contacts:${NC}"
+echo -e "   ${YELLOW}curl -X POST http://localhost:8000/api/tools/search_contacts \\${NC}"
+echo -e "   ${YELLOW}     -H 'Content-Type: application/json' \\${NC}"
+echo -e "   ${YELLOW}     -d '{\"search_term\": \"John\"}' | jq${NC}"
 echo ""
-echo "3. View logs:"
-echo "   docker-compose -f docker-compose.openwebui.yml logs -f"
+
+# Open WebUI integration instructions
+echo -e "${BLUE}╔═══════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${BLUE}║                  Open WebUI Integration                       ║${NC}"
+echo -e "${BLUE}╚═══════════════════════════════════════════════════════════════╝${NC}\n"
+
+echo -e "${GREEN}To connect Open WebUI to EWS MCP:${NC}"
 echo ""
-echo "4. Stop services:"
-echo "   docker-compose -f docker-compose.openwebui.yml down"
+echo "1. Open Open WebUI in your browser"
+echo "2. Navigate to: ${YELLOW}Admin Settings → Functions → External APIs${NC}"
+echo "3. Click ${YELLOW}+ Add External API${NC}"
+echo "4. Configure:"
+echo "   • ${GREEN}API Base URL:${NC} http://ews-mcp:8000 (or http://localhost:8000)"
+echo "   • ${GREEN}Name:${NC} Exchange Web Services"
+echo "   • ${GREEN}Description:${NC} Access to Exchange emails, calendar, contacts"
+echo "5. Click ${YELLOW}Save${NC}"
+echo "6. The OpenAPI schema will be auto-discovered from /openapi.json"
+echo "7. All 44 tools will be available in your chats!"
 echo ""
-echo -e "${GREEN}=== Available Tools ===${NC}"
-echo "44 Exchange tools available for:"
-echo "  • Email (8 tools)"
-echo "  • Calendar (7 tools)"
-echo "  • Contacts (9 tools)"
-echo "  • Tasks (5 tools)"
-echo "  • Attachments (5 tools)"
-echo "  • Search (3 tools)"
-echo "  • Folders (5 tools)"
-echo "  • Out-of-Office (2 tools)"
+
+# Management commands
+echo -e "${BLUE}╔═══════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${BLUE}║                    Management Commands                        ║${NC}"
+echo -e "${BLUE}╚═══════════════════════════════════════════════════════════════╝${NC}\n"
+
+echo -e "${GREEN}View Logs:${NC}"
+echo -e "  ${YELLOW}docker-compose -f docker-compose.openwebui.yml logs -f ews-mcp${NC}"
 echo ""
+
+echo -e "${GREEN}Restart Server:${NC}"
+echo -e "  ${YELLOW}docker-compose -f docker-compose.openwebui.yml restart ews-mcp${NC}"
+echo ""
+
+echo -e "${GREEN}Stop All Services:${NC}"
+echo -e "  ${YELLOW}docker-compose -f docker-compose.openwebui.yml down${NC}"
+echo ""
+
+echo -e "${GREEN}Rebuild After Code Changes:${NC}"
+echo -e "  ${YELLOW}docker-compose -f docker-compose.openwebui.yml up --build -d${NC}"
+echo ""
+
+# Architecture info
+echo -e "${BLUE}╔═══════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${BLUE}║                        Architecture                           ║${NC}"
+echo -e "${BLUE}╚═══════════════════════════════════════════════════════════════╝${NC}\n"
+
+echo -e "${GREEN}Unified Server Architecture:${NC}"
+echo "  • Single server on port 8000"
+echo "  • Built-in OpenAPI/REST adapter"
+echo "  • No MCPO or external proxies needed"
+echo "  • Supports both MCP SSE and REST protocols"
+echo "  • Auto-generates OpenAPI 3.0 schema from MCP tools"
+echo ""
+
+echo -e "${GREEN}Documentation:${NC}"
+echo "  • See OPENWEBUI_SETUP.md for detailed setup guide"
+echo "  • See README.md for general MCP usage"
+echo ""
+
+echo -e "${GREEN}✓ Setup complete! Server is ready to use.${NC}\n"


### PR DESCRIPTION
Integrated OpenAPI adapter directly into EWS MCP server, eliminating the need for MCPO as a separate proxy. The server now provides both MCP SSE and REST API endpoints on the same port (8000).

New Features:
- src/openapi_adapter.py: Converts MCP tools to OpenAPI 3.0 schema and handles REST API requests
- GET /openapi.json: Auto-generated OpenAPI schema from MCP tools
- POST /api/tools/{tool_name}: Direct REST API tool invocation
- GET /health: Health check endpoint with tool count

Updated Files:
- src/main.py: Added OpenAPI adapter initialization and REST API routes to ASGI router alongside existing MCP SSE endpoints
- docker-compose.openwebui.yml: Removed MCPO container, simplified to single EWS MCP server on port 8000
- start-openwebui.sh: Updated to reflect unified architecture, removed MCPO API key generation
- OPENWEBUI_SETUP.md: Complete rewrite showing unified architecture, REST API examples, and simplified setup without MCPO

Benefits:
- Single server for both protocols
- No additional proxy needed
- Simplified deployment (one container vs two)
- Direct tool invocation via REST
- Same 44 Exchange tools available via both MCP and REST

Migration: Users can remove MCPO and point Open WebUI directly to port 8000.