### PR TITLE
feat: Make API base URLs fully configurable via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,16 @@ MCP_HOST=0.0.0.0     # Only used when MCP_TRANSPORT=sse
 MCP_PORT=8000        # Only used when MCP_TRANSPORT=sse
 LOG_LEVEL=INFO
 
+# OpenAPI/REST API Configuration (Optional - for custom API URLs)
+# External URL for API access (e.g., https://ews-api.company.com)
+# API_BASE_URL=https://ews-api.example.com
+# Internal Docker network URL (e.g., http://ews-mcp:8000)
+# API_BASE_URL_INTERNAL=http://ews-mcp:8000
+# Customize API metadata
+# API_TITLE=Exchange Web Services (EWS) MCP API
+# API_DESCRIPTION=REST API for Exchange operations via Model Context Protocol
+# API_VERSION=3.0.0
+
 # Timezone Configuration (CRITICAL for proper datetime handling)
 # Use IANA timezone names: UTC, America/New_York, Europe/London, Asia/Riyadh, etc.
 # Do NOT use UTC offsets like UTC+03:00 - they will cause errors

--- a/OPENWEBUI_SETUP.md
+++ b/OPENWEBUI_SETUP.md
@@ -118,10 +118,15 @@ curl -X POST http://localhost:8000/api/tools/search_contacts \
    - Click "+ Add External API"
    - Fill in the details:
      ```
-     API Base URL: http://ews-mcp:8000
+     API Base URL: http://ews-mcp:8000  (or your custom API_BASE_URL)
      Name: Exchange Web Services
      Description: Access to Exchange emails, calendar, contacts, and tasks
      ```
+   - **Note**: If you configured `API_BASE_URL` in your `.env`, use that URL instead
+   - **Examples**:
+     - Docker: `http://ews-mcp:8000`
+     - Localhost: `http://localhost:8000`
+     - Custom domain: `https://ews-api.company.com`
    - Click "Save"
 
 4. **Auto-Discovery**:
@@ -645,6 +650,75 @@ services:
     environment:
       - MCP_PORT=8000  # Keep internal port as 8000
 ```
+
+### Configurable API URLs
+
+**NEW!** You can now customize the API base URLs shown in the OpenAPI schema. This is useful for:
+- Production deployments behind reverse proxies
+- Custom domains (e.g., https://ews-api.company.com)
+- Different network configurations
+- Kubernetes or cloud deployments
+
+Add to `.env`:
+
+```env
+# External URL (shown in OpenAPI schema for public access)
+API_BASE_URL=https://ews-api.example.com
+
+# Internal Docker network URL (for container-to-container communication)
+API_BASE_URL_INTERNAL=http://ews-mcp:8000
+
+# Customize API metadata (optional)
+API_TITLE=My Company Exchange API
+API_VERSION=1.0.0
+API_DESCRIPTION=Internal Exchange Web Services API
+```
+
+Or set in `docker-compose.openwebui.yml`:
+
+```yaml
+services:
+  ews-mcp:
+    environment:
+      - API_BASE_URL=https://ews-api.example.com
+      - API_BASE_URL_INTERNAL=http://ews-mcp:8000
+      - API_TITLE=My Company Exchange API
+```
+
+**Defaults if not configured:**
+- `http://localhost:8000` (Local development)
+- `http://ews-mcp:8000` (Docker internal network)
+
+**Use Cases:**
+
+1. **Behind Nginx Reverse Proxy:**
+   ```env
+   API_BASE_URL=https://api.company.com/ews
+   ```
+
+2. **Custom Docker Network:**
+   ```env
+   API_BASE_URL_INTERNAL=http://exchange-api:9000
+   ```
+
+3. **Cloud Deployment:**
+   ```env
+   API_BASE_URL=https://ews-api.us-east-1.mycloud.com
+   ```
+
+4. **Multiple Environments:**
+   ```env
+   # Development
+   API_BASE_URL=http://localhost:8000
+
+   # Staging
+   API_BASE_URL=https://ews-api-staging.company.com
+
+   # Production
+   API_BASE_URL=https://ews-api.company.com
+   ```
+
+The OpenAPI schema at `/openapi.json` will automatically use these configured URLs, making it easy for Open WebUI and other clients to discover the correct endpoints.
 
 ### Enable AI Tools
 

--- a/docker-compose.openwebui.yml
+++ b/docker-compose.openwebui.yml
@@ -24,6 +24,15 @@ services:
       - MCP_PORT=8000
       - MCP_SERVER_NAME=ews-mcp-server
 
+      # OpenAPI/REST API Configuration (Optional - customize API URLs)
+      # External URL for accessing API from outside (e.g., https://api.example.com)
+      - API_BASE_URL=${API_BASE_URL:-}
+      # Internal Docker network URL (e.g., http://ews-mcp:8000)
+      - API_BASE_URL_INTERNAL=${API_BASE_URL_INTERNAL:-}
+      # Customize API metadata
+      - API_TITLE=${API_TITLE:-Exchange Web Services (EWS) MCP API}
+      - API_VERSION=${API_VERSION:-3.0.0}
+
       # Timezone Configuration
       - TIMEZONE=${TIMEZONE:-Asia/Riyadh}
 

--- a/src/config.py
+++ b/src/config.py
@@ -36,6 +36,13 @@ class Settings(BaseSettings):
     timezone: str = "UTC"
     log_level: str = "INFO"
 
+    # OpenAPI/REST API Configuration
+    api_base_url: Optional[str] = None  # External URL for API (e.g., https://api.example.com)
+    api_base_url_internal: Optional[str] = None  # Internal Docker URL (e.g., http://ews-mcp:8000)
+    api_title: str = "Exchange Web Services (EWS) MCP API"
+    api_description: str = "REST API for Exchange operations via Model Context Protocol"
+    api_version: str = "3.0.0"
+
     # Performance
     enable_cache: bool = True
     cache_ttl: int = 300
@@ -104,6 +111,43 @@ class Settings(BaseSettings):
                     self.ai_embedding_model = "text-embedding-3-small"
 
         return self
+
+    def get_api_base_urls(self) -> list[dict[str, str]]:
+        """Get API base URLs for OpenAPI schema.
+
+        Returns list of server URLs with descriptions.
+        Falls back to default localhost/docker URLs if not configured.
+        """
+        servers = []
+
+        # Add external URL if configured
+        if self.api_base_url:
+            servers.append({
+                "url": self.api_base_url,
+                "description": "External API endpoint"
+            })
+
+        # Add internal Docker URL if configured
+        if self.api_base_url_internal:
+            servers.append({
+                "url": self.api_base_url_internal,
+                "description": "Internal Docker network"
+            })
+
+        # If no URLs configured, use defaults
+        if not servers:
+            servers = [
+                {
+                    "url": f"http://localhost:{self.mcp_port}",
+                    "description": "Local development server"
+                },
+                {
+                    "url": f"http://ews-mcp:{self.mcp_port}",
+                    "description": "Docker container (internal network)"
+                }
+            ]
+
+        return servers
 
 
 # Singleton instance - lazy loading

--- a/src/main.py
+++ b/src/main.py
@@ -317,9 +317,9 @@ class EWSMCPServer:
 
         self.logger.info(f"Registered {len(self.tools)} tools: {', '.join(self.tools.keys())}")
 
-        # Initialize OpenAPI adapter
-        self.openapi_adapter = OpenAPIAdapter(self.server, self.tools)
-        self.logger.info("OpenAPI adapter initialized")
+        # Initialize OpenAPI adapter with settings for configurable URLs
+        self.openapi_adapter = OpenAPIAdapter(self.server, self.tools, self.settings)
+        self.logger.info("OpenAPI adapter initialized with dynamic configuration")
 
     async def run(self):
         """Run the MCP server with comprehensive logging."""


### PR DESCRIPTION
This commit addresses the issue of hardcoded URLs in the OpenAPI schema by making all API endpoints fully configurable through environment variables.

## Problem Solved
Previously, the OpenAPI schema had hardcoded URLs:
- http://localhost:8000
- http://ews-mcp:8000

This was inflexible for:
- Production deployments behind reverse proxies
- Custom domains and different network configurations
- Cloud deployments (AWS, Azure, GCP)
- Multiple environments (dev, staging, production)

## Changes Made

### 1. Configuration (src/config.py)
- Added `API_BASE_URL` - External/public API URL
- Added `API_BASE_URL_INTERNAL` - Internal Docker network URL
- Added `API_TITLE`, `API_DESCRIPTION`, `API_VERSION` - Customizable metadata
- Added `get_api_base_urls()` method with smart defaults

### 2. OpenAPI Adapter (src/openapi_adapter.py)
- Updated constructor to accept optional settings parameter
- Modified `generate_openapi_schema()` to use dynamic URLs from settings
- Falls back to sensible defaults if not configured
- Uses configured port from MCP_PORT setting

### 3. Main Server (src/main.py)
- Pass settings to OpenAPIAdapter during initialization
- Updated log message to indicate dynamic configuration

### 4. Docker Compose (docker-compose.openwebui.yml)
- Added new environment variables section for API configuration
- Documented with inline comments and examples
- All variables optional with smart defaults

### 5. Documentation (OPENWEBUI_SETUP.md)
- Added comprehensive "Configurable API URLs" section
- Included use cases for different deployment scenarios
- Examples for Nginx reverse proxy, cloud deployment, multi-env
- Updated Open WebUI integration instructions

### 6. Example Config (.env.example)
- Added new API configuration variables (commented out)
- Clear examples for different use cases

## Environment Variables

**New variables (all optional):**
```env
API_BASE_URL=https://ews-api.company.com
API_BASE_URL_INTERNAL=http://ews-mcp:8000
API_TITLE=My Company Exchange API
API_DESCRIPTION=Custom API description
API_VERSION=1.0.0
```

**Defaults if not set:**
- URLs: http://localhost:{MCP_PORT}, http://ews-mcp:{MCP_PORT}
- Title: "Exchange Web Services (EWS) MCP API"
- Description: "REST API for Exchange operations via Model Context Protocol"
- Version: "3.0.0"

## Use Cases

1. **Behind Reverse Proxy:** API_BASE_URL=https://api.company.com/ews

2. **Cloud Deployment:** API_BASE_URL=https://ews-api.us-east-1.mycloud.com

3. **Custom Docker Network:** API_BASE_URL_INTERNAL=http://exchange-api:9000

4. **Multiple Environments:**
   - Dev: http://localhost:8000
   - Staging: https://ews-api-staging.company.com
   - Production: https://ews-api.company.com

## Benefits

✅ Flexible deployment configurations
✅ No hardcoded URLs
✅ Backward compatible (uses smart defaults)
✅ Supports multiple environments
✅ Works with any reverse proxy setup
✅ Cloud-ready architecture
✅ Comprehensive documentation

## Testing

Test the configuration:
```bash
# Set custom URL
export API_BASE_URL=https://my-api.com
# Start server
./start-openwebui.sh
# Check OpenAPI schema
curl http://localhost:8000/openapi.json | jq '.servers'
```

This makes the EWS MCP server truly production-ready with enterprise-grade flexibility!