### PR TITLE
fix: Resolve JSON serialization error for EWS objects like ParentFold…

### DIFF
--- a/src/tools/calendar_tools.py
+++ b/src/tools/calendar_tools.py
@@ -7,7 +7,7 @@ from exchangelib import CalendarItem, Mailbox, Attendee
 from .base import BaseTool
 from ..models import CreateAppointmentRequest, MeetingResponse
 from ..exceptions import ToolExecutionError
-from ..utils import format_success_response, safe_get, parse_datetime_tz_aware, make_tz_aware, format_datetime
+from ..utils import format_success_response, safe_get, parse_datetime_tz_aware, make_tz_aware, format_datetime, ews_id_to_str
 
 
 class CreateAppointmentTool(BaseTool):
@@ -105,7 +105,7 @@ class CreateAppointmentTool(BaseTool):
 
             return format_success_response(
                 "Appointment created successfully",
-                item_id=item.id if hasattr(item, "id") else None,
+                item_id=ews_id_to_str(item.id) if hasattr(item, "id") else None,
                 subject=request.subject,
                 start_time=request.start_time.isoformat(),
                 end_time=request.end_time.isoformat()
@@ -200,7 +200,7 @@ class GetCalendarTool(BaseTool):
                 ]
 
                 event_data = {
-                    "item_id": safe_get(item, "id", "unknown"),
+                    "item_id": ews_id_to_str(safe_get(item, "id", None)) or "unknown",
                     "subject": safe_get(item, "subject", "") or "",
                     "start": safe_get(item, "start", datetime.now()).isoformat(),
                     "end": safe_get(item, "end", datetime.now()).isoformat(),

--- a/src/tools/contact_tools.py
+++ b/src/tools/contact_tools.py
@@ -7,7 +7,7 @@ from exchangelib.indexed_properties import EmailAddress, PhoneNumber
 from .base import BaseTool
 from ..models import CreateContactRequest
 from ..exceptions import ToolExecutionError
-from ..utils import format_success_response, safe_get
+from ..utils import format_success_response, safe_get, ews_id_to_str
 
 
 class CreateContactTool(BaseTool):
@@ -104,7 +104,7 @@ class CreateContactTool(BaseTool):
 
             return format_success_response(
                 "Contact created successfully",
-                item_id=contact.id if hasattr(contact, "id") else None,
+                item_id=ews_id_to_str(contact.id) if hasattr(contact, "id") else None,
                 display_name=f"{request.given_name} {request.surname}",
                 email=request.email_address
             )
@@ -178,7 +178,7 @@ class SearchContactsTool(BaseTool):
                     query_lower in email.lower()):
 
                     contact_data = {
-                        "item_id": safe_get(item, "id", "unknown"),
+                        "item_id": ews_id_to_str(safe_get(item, "id", None)) or "unknown",
                         "display_name": display_name or f"{given_name} {surname}".strip(),
                         "given_name": given_name,
                         "surname": surname,
@@ -242,7 +242,7 @@ class GetContactsTool(BaseTool):
                 email = email or ""  # Ensure email is never None
 
                 contact_data = {
-                    "item_id": safe_get(item, "id", "unknown"),
+                    "item_id": ews_id_to_str(safe_get(item, "id", None)) or "unknown",
                     "display_name": display_name or f"{given_name} {surname}".strip(),
                     "given_name": given_name,
                     "surname": surname,

--- a/src/tools/folder_tools.py
+++ b/src/tools/folder_tools.py
@@ -5,7 +5,7 @@ from exchangelib import Folder
 
 from .base import BaseTool
 from ..exceptions import ToolExecutionError
-from ..utils import format_success_response, safe_get
+from ..utils import format_success_response, safe_get, ews_id_to_str
 
 
 class ListFoldersTool(BaseTool):
@@ -80,11 +80,11 @@ class ListFoldersTool(BaseTool):
                 if current_depth > max_depth:
                     return None
 
-                # Get folder info
+                # Get folder info - use ews_id_to_str for ID fields to ensure JSON serializability
                 folder_info = {
-                    "id": safe_get(folder, 'id', ''),
+                    "id": ews_id_to_str(safe_get(folder, 'id', None)) or '',
                     "name": safe_get(folder, 'name', ''),
-                    "parent_folder_id": safe_get(folder, 'parent_folder_id', ''),
+                    "parent_folder_id": ews_id_to_str(safe_get(folder, 'parent_folder_id', None)) or '',
                     "folder_class": safe_get(folder, 'folder_class', ''),
                     "child_folder_count": safe_get(folder, 'child_folder_count', 0)
                 }
@@ -244,7 +244,7 @@ class CreateFolderTool(BaseTool):
 
             return format_success_response(
                 f"Folder '{folder_name}' created successfully",
-                folder_id=new_folder.id,
+                folder_id=ews_id_to_str(new_folder.id),
                 folder_name=folder_name,
                 parent_folder=parent_folder_name,
                 folder_class=folder_class
@@ -296,7 +296,8 @@ class DeleteFolderTool(BaseTool):
 
             def find_folder_by_id(parent, target_id):
                 """Recursively search for folder by ID."""
-                if safe_get(parent, 'id', '') == target_id:
+                parent_id = ews_id_to_str(safe_get(parent, 'id', None)) or ''
+                if parent_id == target_id:
                     return parent
 
                 if hasattr(parent, 'children') and parent.children:
@@ -373,7 +374,8 @@ class RenameFolderTool(BaseTool):
             # Find the folder by ID
             def find_folder_by_id(parent, target_id):
                 """Recursively search for folder by ID."""
-                if safe_get(parent, 'id', '') == target_id:
+                parent_id = ews_id_to_str(safe_get(parent, 'id', None)) or ''
+                if parent_id == target_id:
                     return parent
 
                 if hasattr(parent, 'children') and parent.children:
@@ -454,7 +456,8 @@ class MoveFolderTool(BaseTool):
             # Find the folder to move
             def find_folder_by_id(parent, target_id):
                 """Recursively search for folder by ID."""
-                if safe_get(parent, 'id', '') == target_id:
+                parent_id = ews_id_to_str(safe_get(parent, 'id', None)) or ''
+                if parent_id == target_id:
                     return parent
 
                 if hasattr(parent, 'children') and parent.children:

--- a/src/tools/search_tools.py
+++ b/src/tools/search_tools.py
@@ -5,7 +5,7 @@ from exchangelib.queryset import Q
 
 from .base import BaseTool
 from ..exceptions import ToolExecutionError
-from ..utils import format_success_response, safe_get, truncate_text, parse_datetime_tz_aware, find_message_across_folders
+from ..utils import format_success_response, safe_get, truncate_text, parse_datetime_tz_aware, find_message_across_folders, ews_id_to_str
 
 
 class AdvancedSearchTool(BaseTool):
@@ -369,7 +369,7 @@ class SearchByConversationTool(BaseTool):
 
                     for item in items:
                         result = {
-                            "id": safe_get(item, 'id', ''),
+                            "id": ews_id_to_str(safe_get(item, 'id', None)) or '',
                             "subject": safe_get(item, 'subject', ''),
                             "from": safe_get(safe_get(item, 'sender', {}), 'email_address', ''),
                             "to": [r.email_address for r in safe_get(item, 'to_recipients', []) if hasattr(r, 'email_address')],
@@ -542,7 +542,7 @@ class FullTextSearchTool(BaseTool):
                                 continue
 
                             result = {
-                                "id": safe_get(item, 'id', ''),
+                                "id": ews_id_to_str(safe_get(item, 'id', None)) or '',
                                 "subject": safe_get(item, 'subject', ''),
                                 "from": safe_get(safe_get(item, 'sender', {}), 'email_address', ''),
                                 "to": [r.email_address for r in safe_get(item, 'to_recipients', []) if hasattr(r, 'email_address')],

--- a/src/tools/task_tools.py
+++ b/src/tools/task_tools.py
@@ -8,7 +8,7 @@ from exchangelib import Task
 from .base import BaseTool
 from ..models import CreateTaskRequest
 from ..exceptions import ToolExecutionError
-from ..utils import format_success_response, safe_get, parse_datetime_tz_aware, parse_date_tz_aware
+from ..utils import format_success_response, safe_get, parse_datetime_tz_aware, parse_date_tz_aware, ews_id_to_str
 
 
 class CreateTaskTool(BaseTool):
@@ -90,7 +90,7 @@ class CreateTaskTool(BaseTool):
 
             return format_success_response(
                 "Task created successfully",
-                item_id=task.id if hasattr(task, "id") else None,
+                item_id=ews_id_to_str(task.id) if hasattr(task, "id") else None,
                 subject=request.subject
             )
 
@@ -142,7 +142,7 @@ class GetTasksTool(BaseTool):
             tasks = []
             for item in items[:max_results]:
                 task_data = {
-                    "item_id": safe_get(item, "id", "unknown"),
+                    "item_id": ews_id_to_str(safe_get(item, "id", None)) or "unknown",
                     "subject": safe_get(item, "subject", "") or "",
                     "status": safe_get(item, "status", "NotStarted") or "NotStarted",
                     "percent_complete": safe_get(item, "percent_complete", 0),


### PR DESCRIPTION
…erId

EWS objects such as FolderId, ItemId, and ParentFolderId are not directly JSON serializable, causing "Object of type ParentFolderId is not JSON serializable" errors when logging or returning responses.

Changes:
- Add ews_id_to_str() helper to safely convert EWS ID objects to strings
- Add make_json_serializable() for recursive conversion of complex objects
- Add EWSJSONEncoder custom JSON encoder class for use with json.dumps
- Add safe_json_dumps() convenience function
- Update all tool files to use ews_id_to_str() when extracting item IDs
- Update logging_system.py to use EWSJSONEncoder for all JSON operations
- Update _sanitize_data() to convert EWS objects before logging