### PR TITLE
fix: Improve EWS endpoint URL construction and update documentation

### DIFF
--- a/.env.ai.example
+++ b/.env.ai.example
@@ -4,7 +4,11 @@
 # ===========================================
 # Exchange Web Services Settings
 # ===========================================
-EWS_SERVER_URL=https://mail.company.com/EWS/Exchange.asmx
+# You can provide any of these formats - the server will construct the full EWS URL:
+#   - Full URL: https://mail.company.com/EWS/Exchange.asmx
+#   - Hostname with protocol: https://mail.company.com
+#   - Just hostname: mail.company.com
+EWS_SERVER_URL=mail.company.com
 EWS_EMAIL=user@company.com
 EWS_AUTODISCOVER=false
 

--- a/.env.basic.example
+++ b/.env.basic.example
@@ -5,10 +5,13 @@
 # Exchange Server Configuration
 # ============================================================================
 
-# Your Exchange EWS endpoint URL
-# For on-premises: https://mail.company.com/EWS/Exchange.asmx
-# For Office 365: https://outlook.office365.com/EWS/Exchange.asmx
-EWS_SERVER_URL=https://mail.company.com/EWS/Exchange.asmx
+# Your Exchange EWS server
+# You can provide any of these formats - the server will construct the full EWS URL:
+#   - Full URL: https://mail.company.com/EWS/Exchange.asmx
+#   - Hostname with protocol: https://mail.company.com
+#   - Just hostname: mail.company.com
+# For Office 365: outlook.office365.com
+EWS_SERVER_URL=mail.company.com
 
 # Your email address
 EWS_EMAIL=user@company.com

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,12 @@
 # Exchange Server Configuration
-EWS_SERVER_URL=https://outlook.office365.com/EWS/Exchange.asmx
+# You can provide any of these formats:
+#   - Full URL: https://mail.company.com/EWS/Exchange.asmx
+#   - Hostname with protocol: https://mail.company.com
+#   - Just hostname: mail.company.com
+# The server will automatically construct the full EWS endpoint URL
+EWS_SERVER_URL=mail.company.com
 EWS_EMAIL=user@company.com
-EWS_AUTODISCOVER=true
+EWS_AUTODISCOVER=false
 
 # Authentication (choose one)
 EWS_AUTH_TYPE=oauth2  # oauth2, basic, ntlm

--- a/.env.oauth2.example
+++ b/.env.oauth2.example
@@ -5,8 +5,12 @@
 # Exchange Server Configuration
 # ============================================================================
 
-# Office 365 EWS endpoint (usually this URL for all Office 365)
-EWS_SERVER_URL=https://outlook.office365.com/EWS/Exchange.asmx
+# Office 365 EWS server
+# You can provide any of these formats - the server will construct the full EWS URL:
+#   - Full URL: https://outlook.office365.com/EWS/Exchange.asmx
+#   - Hostname with protocol: https://outlook.office365.com
+#   - Just hostname: outlook.office365.com
+EWS_SERVER_URL=outlook.office365.com
 
 # Your Office 365 email address
 EWS_EMAIL=user@company.com

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ docker pull ghcr.io/azizmazrou/ews-mcp:latest
 
 # Create .env file with Basic Auth
 cat > .env <<EOF
-EWS_SERVER_URL=https://mail.company.com/EWS/Exchange.asmx
+# Just provide hostname - the server constructs the full EWS URL automatically
+EWS_SERVER_URL=mail.company.com
 EWS_EMAIL=user@company.com
 EWS_AUTODISCOVER=false
 EWS_AUTH_TYPE=basic
@@ -172,9 +173,10 @@ docker pull ghcr.io/azizmazrou/ews-mcp:latest
 
 # Create .env file with OAuth2
 cat > .env <<EOF
-EWS_SERVER_URL=https://outlook.office365.com/EWS/Exchange.asmx
+# Just provide hostname - the server constructs the full EWS URL automatically
+EWS_SERVER_URL=outlook.office365.com
 EWS_EMAIL=user@company.com
-EWS_AUTODISCOVER=true
+EWS_AUTODISCOVER=false
 EWS_AUTH_TYPE=oauth2
 EWS_CLIENT_ID=your-azure-app-client-id
 EWS_CLIENT_SECRET=your-azure-app-client-secret
@@ -248,7 +250,8 @@ python -m src.main
 
 ```bash
 cat > .env <<EOF
-EWS_SERVER_URL=https://mail.company.com/EWS/Exchange.asmx
+# Just provide hostname - the server constructs https://mail.company.com/EWS/Exchange.asmx
+EWS_SERVER_URL=mail.company.com
 EWS_EMAIL=user@company.com
 EWS_AUTODISCOVER=false
 EWS_AUTH_TYPE=basic
@@ -284,8 +287,10 @@ EOF
 
 4. **Update .env**:
    ```bash
-   EWS_SERVER_URL=https://outlook.office365.com/EWS/Exchange.asmx
+   # Just provide hostname - the server constructs the full EWS URL automatically
+   EWS_SERVER_URL=outlook.office365.com
    EWS_EMAIL=user@company.com
+   EWS_AUTODISCOVER=false
    EWS_AUTH_TYPE=oauth2
    EWS_CLIENT_ID=<your-client-id>
    EWS_CLIENT_SECRET=<your-client-secret>
@@ -322,13 +327,22 @@ EOF
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `EWS_SERVER_URL` | autodiscover | Exchange EWS endpoint |
-| `EWS_AUTODISCOVER` | `true` | Use autodiscovery |
+| `EWS_SERVER_URL` | autodiscover | Exchange server (hostname or full URL - see below) |
+| `EWS_AUTODISCOVER` | `false` | Use autodiscovery (not recommended - set to false with explicit server) |
 | `MCP_TRANSPORT` | `stdio` | Transport mode: `stdio` (Claude Desktop) or `sse` (HTTP/REST) |
 | `MCP_HOST` | `0.0.0.0` | Host for SSE server (when MCP_TRANSPORT=sse) |
 | `MCP_PORT` | `8000` | Port for SSE server (when MCP_TRANSPORT=sse) |
 | `TIMEZONE` | `UTC` | Timezone for operations (use IANA names: UTC, America/New_York) |
 | `LOG_LEVEL` | `INFO` | Logging level (DEBUG, INFO, WARNING, ERROR) |
+
+**EWS_SERVER_URL Formats** - The server automatically constructs the full EWS endpoint:
+
+| You Provide | Server Constructs |
+|-------------|-------------------|
+| `mail.company.com` | `https://mail.company.com/EWS/Exchange.asmx` |
+| `https://mail.company.com` | `https://mail.company.com/EWS/Exchange.asmx` |
+| `https://mail.company.com/EWS/Exchange.asmx` | (used as-is) |
+| `outlook.office365.com` | `https://outlook.office365.com/EWS/Exchange.asmx` |
 
 ### OpenAPI/REST API Variables (Optional)
 
@@ -860,7 +874,9 @@ bandit -r src/
 
 **Authentication failed**: Check credentials, verify OAuth2 permissions, ensure admin consent granted.
 
-**Connection timeout**: Verify server URL, check network, try autodiscovery.
+**Autodiscovery timeout**: Set `EWS_AUTODISCOVER=false` and provide explicit server URL. Just provide the hostname (e.g., `mail.company.com`) - the server automatically constructs the full EWS endpoint (`https://mail.company.com/EWS/Exchange.asmx`).
+
+**Connection timeout**: Verify server URL, check network. If using autodiscovery, switch to explicit server URL.
 
 **Rate limited**: Wait 60 seconds, reduce request frequency.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -84,17 +84,33 @@ ConnectionError: Failed to connect to Exchange
    REQUEST_TIMEOUT=60
    ```
 
-### Problem: "Autodiscovery failed"
+### Problem: "Autodiscovery failed" or "Autodiscovery timeout"
+
+**Symptoms:**
+```
+AutoDiscoverFailed: Autodiscovery failed with error
+ConnectionError: Autodiscovery timed out
+```
 
 **Solutions:**
 
-1. **Use Manual Configuration:**
+1. **Use Manual Configuration (Recommended):**
    ```bash
    EWS_AUTODISCOVER=false
-   EWS_SERVER_URL=https://mail.company.com/EWS/Exchange.asmx
+   # Just provide hostname - the server constructs the full EWS URL automatically
+   EWS_SERVER_URL=mail.company.com
+   # This becomes: https://mail.company.com/EWS/Exchange.asmx
    ```
 
-2. **Check DNS:**
+   You can provide any of these formats:
+   | You Provide | Server Constructs |
+   |-------------|-------------------|
+   | `mail.company.com` | `https://mail.company.com/EWS/Exchange.asmx` |
+   | `https://mail.company.com` | `https://mail.company.com/EWS/Exchange.asmx` |
+   | `https://mail.company.com/EWS/Exchange.asmx` | (used as-is) |
+   | `outlook.office365.com` | `https://outlook.office365.com/EWS/Exchange.asmx` |
+
+2. **Check DNS (if autodiscovery is required):**
    ```bash
    # Should return autodiscover endpoint
    nslookup autodiscover.company.com
@@ -103,6 +119,11 @@ ConnectionError: Failed to connect to Exchange
 3. **Verify Email Domain:**
    - Ensure EWS_EMAIL matches your Exchange domain
    - Check for typos
+
+4. **Network/Firewall Issues:**
+   - Autodiscovery endpoints may be blocked by firewall
+   - Using explicit EWS_SERVER_URL bypasses autodiscovery completely
+   - This is the recommended approach for most deployments
 
 ## Docker Issues
 


### PR DESCRIPTION
Changes:
- EWS client now automatically constructs full EWS endpoint URL from hostname
- Users can provide: hostname only, URL with protocol, or full endpoint
- Server always constructs: https://{server}/EWS/Exchange.asmx
- Always uses service_endpoint to bypass autodiscovery completely

Updated configuration examples to use generic server (mail.company.com):
- .env.example, .env.basic.example, .env.oauth2.example, .env.ai.example
- README.md quick start and configuration sections
- docs/TROUBLESHOOTING.md with autodiscovery timeout solutions

This makes the project generic and not specific to any organization. Users configure their own server via EWS_SERVER_URL environment variable.