### PR TITLE
feat: Add reply_email and forward_email tools

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -23,11 +23,12 @@ from .exceptions import EWSMCPException
 from .logging_system import get_logger
 from .openapi_adapter import OpenAPIAdapter
 
-# Import all tool classes (up to 47 tools total: 43 base + 4 AI)
+# Import all tool classes (up to 49 tools total: 45 base + 4 AI)
 from .tools import (
-    # Email tools (8)
+    # Email tools (10)
     SendEmailTool, ReadEmailsTool, SearchEmailsTool, GetEmailDetailsTool,
     DeleteEmailTool, MoveEmailTool, UpdateEmailTool, CopyEmailTool,
+    ReplyEmailTool, ForwardEmailTool,
     # Calendar tools (7)
     CreateAppointmentTool, GetCalendarTool, UpdateAppointmentTool,
     DeleteAppointmentTool, RespondToMeetingTool, CheckAvailabilityTool,
@@ -196,10 +197,10 @@ class EWSMCPServer:
                 )]
 
     def register_tools(self):
-        """Register all enabled tools (43 base tools, up to 47 with AI)."""
+        """Register all enabled tools (45 base tools, up to 49 with AI)."""
         tool_classes = []
 
-        # Email tools (8 tools)
+        # Email tools (10 tools)
         if self.settings.enable_email:
             tool_classes.extend([
                 SendEmailTool,
@@ -209,9 +210,11 @@ class EWSMCPServer:
                 DeleteEmailTool,
                 MoveEmailTool,
                 UpdateEmailTool,
-                CopyEmailTool
+                CopyEmailTool,
+                ReplyEmailTool,
+                ForwardEmailTool
             ])
-            self.logger.info("Email tools enabled (8 tools)")
+            self.logger.info("Email tools enabled (10 tools)")
 
         # Attachment tools (5 tools - email-related)
         if self.settings.enable_email:

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,6 +1,6 @@
 """MCP Tools for EWS operations."""
 
-from .email_tools import SendEmailTool, ReadEmailsTool, SearchEmailsTool, GetEmailDetailsTool, DeleteEmailTool, MoveEmailTool, UpdateEmailTool, CopyEmailTool
+from .email_tools import SendEmailTool, ReadEmailsTool, SearchEmailsTool, GetEmailDetailsTool, DeleteEmailTool, MoveEmailTool, UpdateEmailTool, CopyEmailTool, ReplyEmailTool, ForwardEmailTool
 from .calendar_tools import CreateAppointmentTool, GetCalendarTool, UpdateAppointmentTool, DeleteAppointmentTool, RespondToMeetingTool, CheckAvailabilityTool, FindMeetingTimesTool
 from .contact_tools import CreateContactTool, SearchContactsTool, GetContactsTool, UpdateContactTool, DeleteContactTool, ResolveNamesTool
 from .task_tools import CreateTaskTool, GetTasksTool, UpdateTaskTool, CompleteTaskTool, DeleteTaskTool
@@ -12,7 +12,7 @@ from .ai_tools import SemanticSearchEmailsTool, ClassifyEmailTool, SummarizeEmai
 from .contact_intelligence_tools import FindPersonTool, GetCommunicationHistoryTool, AnalyzeNetworkTool
 
 __all__ = [
-    # Email tools (8)
+    # Email tools (10)
     "SendEmailTool",
     "ReadEmailsTool",
     "SearchEmailsTool",
@@ -21,6 +21,8 @@ __all__ = [
     "MoveEmailTool",
     "UpdateEmailTool",
     "CopyEmailTool",
+    "ReplyEmailTool",
+    "ForwardEmailTool",
     # Calendar tools (7)
     "CreateAppointmentTool",
     "GetCalendarTool",


### PR DESCRIPTION
Add two new email tools to the EWS MCP Server:

- reply_email: Reply to existing emails while preserving conversation thread, In-Reply-To headers, and conversation ID. Supports reply-all and attachments.

- forward_email: Forward emails to new recipients while preserving original content, formatting, and attachments. Supports CC/BCC and additional attachments.

Both tools use exchangelib's built-in create_reply/create_forward methods to ensure proper thread handling and include quoted original messages with proper formatting.