### PR TITLE
fix: Remove invalid to_recipients param from create_reply_all()

### DIFF
--- a/src/tools/email_tools.py
+++ b/src/tools/email_tools.py
@@ -1388,7 +1388,7 @@ class ReplyEmailTool(BaseTool):
             # Create reply using exchangelib's built-in methods
             # This automatically preserves conversation ID, In-Reply-To, and References headers
             if reply_all:
-                reply = original_message.create_reply_all(subject=None, body=None, to_recipients=None)
+                reply = original_message.create_reply_all(subject=None, body=None)
                 self.logger.info("Creating reply-all message")
             else:
                 reply = original_message.create_reply(subject=None, body=None, to_recipients=None)


### PR DESCRIPTION
The exchangelib create_reply_all() method does not accept to_recipients parameter - it automatically determines recipients from the original message. This caused "unexpected keyword argument" error when using reply_all=True.

Keep to_recipients in create_reply() as it's valid there for overriding the default recipient.