### PR TITLE
fix: Use ForwardSection instead of second WordSection1 for Exclaimer

### DIFF
--- a/src/tools/email_tools.py
+++ b/src/tools/email_tools.py
@@ -1515,6 +1515,7 @@ class ReplyEmailTool(BaseTool):
 
                 # Build complete body with Outlook-compatible structure
                 # WordSection1 div is closed after user content - signature goes in the <br><br> gap
+                # Use ForwardSection (not WordSection1) for forward content so Exclaimer ignores it
                 complete_body = f'''<html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
@@ -1525,7 +1526,7 @@ class ReplyEmailTool(BaseTool):
 <div></div>
 </div>
 <br><br>
-<div class="WordSection1">
+<div class="ForwardSection">
 {quote_header}
 {original_body_html}
 </div>
@@ -1743,6 +1744,7 @@ class ForwardEmailTool(BaseTool):
 
                 # Build complete body with Outlook-compatible structure
                 # WordSection1 div is closed after user content - signature goes in the <br><br> gap
+                # Use ForwardSection (not WordSection1) for forward content so Exclaimer ignores it
                 complete_body = f'''<html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
@@ -1753,7 +1755,7 @@ class ForwardEmailTool(BaseTool):
 <div></div>
 </div>
 <br><br>
-<div class="WordSection1">
+<div class="ForwardSection">
 {forward_header_html}
 {original_body_html}
 </div>


### PR DESCRIPTION
Exclaimer places signature after the LAST WordSection1 closing tag. Having two WordSection1 divs caused signature to appear at the very end.

Changed structure from:
```html
<div class="WordSection1">[user]</div>
<br><br>
<div class="WordSection1">[forward]</div>  ← Signature went after this
```

To:
```html
<div class="WordSection1">[user]</div>
<br><br>                                   ← Signature goes HERE now
<div class="ForwardSection">[forward]</div>  ← Exclaimer ignores this
```

Applied to both ReplyEmailTool and ForwardEmailTool.