### PR TITLE
feat: Add base64 inline_attachments support to all email and calendar…

### DIFF
--- a/src/tools/calendar_tools.py
+++ b/src/tools/calendar_tools.py
@@ -7,7 +7,39 @@ from exchangelib import CalendarItem, Mailbox, Attendee
 from .base import BaseTool
 from ..models import CreateAppointmentRequest, MeetingResponse
 from ..exceptions import ToolExecutionError
-from ..utils import format_success_response, safe_get, parse_datetime_tz_aware, make_tz_aware, format_datetime, ews_id_to_str
+from ..utils import format_success_response, safe_get, parse_datetime_tz_aware, make_tz_aware, format_datetime, ews_id_to_str, attach_inline_files
+
+# Shared schema for inline_attachments parameter (base64-encoded files)
+INLINE_ATTACHMENTS_SCHEMA = {
+    "inline_attachments": {
+        "description": "Attachments as base64-encoded content (e.g. agendas, maps, barcodes for calendar invites).",
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "file_name": {
+                    "type": "string",
+                    "description": "File name with extension (e.g. 'agenda.pdf', 'barcode.png')"
+                },
+                "file_content": {
+                    "type": "string",
+                    "description": "Base64-encoded file content"
+                },
+                "content_type": {
+                    "type": "string",
+                    "default": "application/octet-stream",
+                    "description": "MIME type (e.g. 'image/png', 'application/pdf')"
+                },
+                "is_inline": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "True = embedded in body (use cid:file_name to reference in HTML)"
+                }
+            },
+            "required": ["file_name", "file_content"]
+        }
+    }
+}
 
 
 class CreateAppointmentTool(BaseTool):
@@ -55,6 +87,7 @@ class CreateAppointmentTool(BaseTool):
                         "description": "Reminder minutes before (optional)",
                         "default": 15
                     },
+                    **INLINE_ATTACHMENTS_SCHEMA,
                     "target_mailbox": {
                         "type": "string",
                         "description": "Email address to operate on (requires impersonation/delegate access)"
@@ -105,6 +138,11 @@ class CreateAppointmentTool(BaseTool):
                     Attendee(mailbox=Mailbox(email_address=email))
                     for email in request.attendees
                 ]
+
+            # Add inline (base64) attachments if provided
+            inline_count = attach_inline_files(item, kwargs.get("inline_attachments", []))
+            if inline_count > 0:
+                self.logger.info(f"Added {inline_count} inline (base64) attachment(s) to appointment")
 
             # Save the appointment
             item.save()
@@ -281,6 +319,7 @@ class UpdateAppointmentTool(BaseTool):
                         "type": "string",
                         "description": "New body (optional)"
                     },
+                    **INLINE_ATTACHMENTS_SCHEMA,
                     "target_mailbox": {
                         "type": "string",
                         "description": "Email address to operate on (requires impersonation/delegate access)"
@@ -317,6 +356,11 @@ class UpdateAppointmentTool(BaseTool):
 
             if "body" in kwargs:
                 item.body = kwargs["body"]
+
+            # Add inline (base64) attachments if provided
+            inline_count = attach_inline_files(item, kwargs.get("inline_attachments", []))
+            if inline_count > 0:
+                self.logger.info(f"Added {inline_count} inline (base64) attachment(s) to appointment")
 
             # Save changes
             item.save()

--- a/src/tools/email_tools.py
+++ b/src/tools/email_tools.py
@@ -27,7 +27,39 @@ import re
 from .base import BaseTool
 from ..models import SendEmailRequest, EmailSearchRequest, EmailDetails
 from ..exceptions import ToolExecutionError
-from ..utils import format_success_response, safe_get, truncate_text, parse_datetime_tz_aware, find_message_across_folders, find_message_for_account, ews_id_to_str
+from ..utils import format_success_response, safe_get, truncate_text, parse_datetime_tz_aware, find_message_across_folders, find_message_for_account, ews_id_to_str, attach_inline_files
+
+# Shared schema for inline_attachments parameter (base64-encoded files)
+INLINE_ATTACHMENTS_SCHEMA = {
+    "inline_attachments": {
+        "description": "Attachments as base64-encoded content. Use when file paths are not accessible (e.g. in cloud/Docker environments).",
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "file_name": {
+                    "type": "string",
+                    "description": "File name with extension (e.g. 'report.pdf', 'image.png')"
+                },
+                "file_content": {
+                    "type": "string",
+                    "description": "Base64-encoded file content"
+                },
+                "content_type": {
+                    "type": "string",
+                    "default": "application/octet-stream",
+                    "description": "MIME type (e.g. 'image/png', 'application/pdf')"
+                },
+                "is_inline": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "True = embedded in body (use cid:file_name to reference in HTML)"
+                }
+            },
+            "required": ["file_name", "file_content"]
+        }
+    }
+}
 
 
 def extract_body_html(message) -> str:
@@ -504,6 +536,7 @@ class SendEmailTool(BaseTool):
                         "items": {"type": "string"},
                         "description": "Attachment file paths (optional)"
                     },
+                    **INLINE_ATTACHMENTS_SCHEMA,
                     "target_mailbox": {
                         "type": "string",
                         "description": "Email address to send on behalf of (requires impersonation/delegate access)"
@@ -658,6 +691,12 @@ class SendEmailTool(BaseTool):
                         raise ToolExecutionError(f"Failed to attach file {file_path}: {e}")
 
                 self.logger.info(f"Total attachments added: {attachment_count}")
+
+            # Add inline (base64) attachments if provided
+            inline_count = attach_inline_files(message, kwargs.get("inline_attachments", []))
+            if inline_count > 0:
+                attachment_count += inline_count
+                self.logger.info(f"Added {inline_count} inline (base64) attachment(s)")
 
             # Send the message (attachments are included automatically)
             message.send()
@@ -1458,6 +1497,7 @@ class ReplyEmailTool(BaseTool):
                         "items": {"type": "string"},
                         "description": "File paths to attach to the reply (optional)"
                     },
+                    **INLINE_ATTACHMENTS_SCHEMA,
                     "target_mailbox": {
                         "type": "string",
                         "description": "Email address to reply from (requires impersonation/delegate access)"
@@ -1602,6 +1642,12 @@ class ReplyEmailTool(BaseTool):
                     except Exception as e:
                         raise ToolExecutionError(f"Failed to attach file {file_path}: {e}")
 
+            # Add inline (base64) attachments if provided
+            inline_b64_count = attach_inline_files(message, kwargs.get("inline_attachments", []))
+            if inline_b64_count > 0:
+                new_attachment_count += inline_b64_count
+                self.logger.info(f"Added {inline_b64_count} inline (base64) attachment(s)")
+
             # Send the message
             message.send()
             self.logger.info(f"Reply sent to {original_from_email} from mailbox: {mailbox}")
@@ -1669,6 +1715,7 @@ class ForwardEmailTool(BaseTool):
                         "items": {"type": "string"},
                         "description": "Additional file paths to attach (optional)"
                     },
+                    **INLINE_ATTACHMENTS_SCHEMA,
                     "target_mailbox": {
                         "type": "string",
                         "description": "Email address to forward from (requires impersonation/delegate access)"
@@ -1797,6 +1844,12 @@ class ForwardEmailTool(BaseTool):
                         raise ToolExecutionError(f"Permission denied reading attachment: {file_path}")
                     except Exception as e:
                         raise ToolExecutionError(f"Failed to attach file {file_path}: {e}")
+
+            # Add inline (base64) attachments if provided
+            inline_b64_count = attach_inline_files(message, kwargs.get("inline_attachments", []))
+            if inline_b64_count > 0:
+                additional_attachment_count += inline_b64_count
+                self.logger.info(f"Added {inline_b64_count} inline (base64) attachment(s)")
 
             # Send the message
             message.send()

--- a/src/utils.py
+++ b/src/utils.py
@@ -510,3 +510,41 @@ def find_message_across_folders(ews_client, message_id):
         ToolExecutionError if message not found in any folder
     """
     return find_message_for_account(ews_client.account, message_id)
+
+
+def attach_inline_files(message, inline_attachments: list) -> int:
+    """Attach base64-encoded files to an EWS message or calendar item.
+
+    Args:
+        message: An exchangelib Message or CalendarItem object
+        inline_attachments: List of dicts with file_name, file_content (base64),
+                           optional content_type and is_inline
+
+    Returns:
+        Number of attachments added
+    """
+    if not inline_attachments:
+        return 0
+
+    import base64
+    from exchangelib import FileAttachment
+
+    count = 0
+    for att in inline_attachments:
+        file_name = att.get("file_name")
+        file_content = att.get("file_content")
+        if not file_name or not file_content:
+            continue
+
+        is_inline = att.get("is_inline", False)
+        file_attachment = FileAttachment(
+            name=file_name,
+            content=base64.b64decode(file_content),
+            content_type=att.get("content_type", "application/octet-stream"),
+            is_inline=is_inline,
+            content_id=file_name if is_inline else None,
+        )
+        message.attach(file_attachment)
+        count += 1
+
+    return count


### PR DESCRIPTION
… tools

Cloud/Docker environments (e.g. Claude.ai, LibreChat) upload files to paths the MCP server cannot access. This adds an inline_attachments parameter that accepts base64-encoded file content directly.

Changes:
- Add attach_inline_files() helper in utils.py
- Add inline_attachments param to send_email, reply_email, forward_email
- Add inline_attachments param to create_appointment, update_appointment
- Supports is_inline for embedding images via cid: references in HTML
- Fully backward compatible: existing file path attachments still work