### PR TITLE
Fix 14 post-consolidation issues: version strings, test bugs, cosmeti…

### DIFF
--- a/.env.ai.example
+++ b/.env.ai.example
@@ -82,7 +82,7 @@ LOG_LEVEL=INFO
 # Customize API metadata (optional)
 # API_TITLE=Exchange Web Services (EWS) MCP API
 # API_DESCRIPTION=REST API for Exchange operations via Model Context Protocol
-# API_VERSION=3.0.0
+# API_VERSION=3.3.0
 
 # ===========================================
 # Timezone Configuration (CRITICAL)

--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,7 @@ LOG_LEVEL=INFO
 # Customize API metadata
 # API_TITLE=Exchange Web Services (EWS) MCP API
 # API_DESCRIPTION=REST API for Exchange operations via Model Context Protocol
-# API_VERSION=3.0.0
+# API_VERSION=3.3.0
 
 # Timezone Configuration (CRITICAL for proper datetime handling)
 # Use IANA timezone names: UTC, America/New_York, Europe/London, Asia/Riyadh, etc.

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ COPY --chown=mcp:mcp src/ ./src/
 RUN find /app/src -type f -name "*.pyc" -delete && \
     find /app/src -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
 
-# Verify v3.2 architecture deployed correctly
+# Verify v3.3 architecture deployed correctly
 RUN grep -q "VERSION: 3.3.0 - TOOL CONSOLIDATION" /app/src/tools/contact_intelligence_tools.py || \
     (echo "ERROR: v3.2 not deployed" && exit 1) && \
     test -f /app/src/core/person.py || \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.8'
 
-# EWS MCP v3.0 - Person-Centric Exchange Server
+# EWS MCP v3.3 - Person-Centric Exchange Server
 # Build from source for development/testing
 
 services:

--- a/src/main.py
+++ b/src/main.py
@@ -107,7 +107,7 @@ class EWSMCPServer:
             module="main",
             action="SERVER_INIT",
             data={
-                "version": "2.1.0",
+                "version": "3.3.0",
                 "user": self.settings.ews_email,
                 "auth_type": self.settings.ews_auth_type,
                 "server_url": self.settings.ews_server_url or "autodiscover"

--- a/start-openwebui.sh
+++ b/start-openwebui.sh
@@ -92,7 +92,7 @@ TOOL_COUNT=$(echo $HEALTH_RESPONSE | grep -o '"tools":[0-9]*' | grep -o '[0-9]*'
 
 echo -e "${GREEN}✓ EWS MCP Server Running${NC}"
 echo -e "  Base URL: ${BLUE}http://localhost:8000${NC}"
-echo -e "  Tools Available: ${YELLOW}${TOOL_COUNT:-44}${NC}"
+echo -e "  Tools Available: ${YELLOW}${TOOL_COUNT:-36}${NC}"
 echo ""
 
 echo -e "${GREEN}Available Endpoints:${NC}"
@@ -151,10 +151,10 @@ echo -e "   ${YELLOW}     -H 'Content-Type: application/json' \\${NC}"
 echo -e "   ${YELLOW}     -d '{\"days\": 7}' | jq${NC}"
 echo ""
 
-echo -e "${GREEN}4. Search Contacts:${NC}"
-echo -e "   ${YELLOW}curl -X POST http://localhost:8000/api/tools/search_contacts \\${NC}"
+echo -e "${GREEN}4. Find Person:${NC}"
+echo -e "   ${YELLOW}curl -X POST http://localhost:8000/api/tools/find_person \\${NC}"
 echo -e "   ${YELLOW}     -H 'Content-Type: application/json' \\${NC}"
-echo -e "   ${YELLOW}     -d '{\"search_term\": \"John\"}' | jq${NC}"
+echo -e "   ${YELLOW}     -d '{\"query\": \"John\", \"source\": \"all\"}' | jq${NC}"
 echo ""
 
 # Open WebUI integration instructions
@@ -173,7 +173,7 @@ echo "   • ${GREEN}Name:${NC} Exchange Web Services"
 echo "   • ${GREEN}Description:${NC} Access to Exchange emails, calendar, contacts"
 echo "5. Click ${YELLOW}Save${NC}"
 echo "6. The OpenAPI schema will be auto-discovered from /openapi.json"
-echo "7. All 44 tools will be available in your chats!"
+echo "7. All 36 tools will be available in your chats!"
 echo ""
 
 # Management commands

--- a/tests/test_advanced_search.py
+++ b/tests/test_advanced_search.py
@@ -36,14 +36,14 @@ async def test_search_by_conversation_with_conversation_id(mock_ews_client):
 
     result = await tool.execute(
         conversation_id="conversation-123",
-        folder="inbox"
+        search_scope=["inbox"]
     )
 
     assert result["success"] is True
     assert result["conversation_id"] == "conversation-123"
-    assert result["thread_count"] == 2
-    assert len(result["emails"]) == 2
-    assert result["emails"][0]["subject"] == "Project Discussion"
+    assert result["total_results"] == 2
+    assert len(result["results"]) == 2
+    assert result["results"][0]["subject"] == "Project Discussion"
 
 
 @pytest.mark.asyncio
@@ -80,12 +80,12 @@ async def test_search_by_conversation_with_message_id(mock_ews_client):
 
     result = await tool.execute(
         message_id="email-1",
-        folder="inbox"
+        search_scope=["inbox"]
     )
 
     assert result["success"] is True
     assert result["conversation_id"] == "conversation-456"
-    assert result["thread_count"] == 2
+    assert result["total_results"] == 2
 
 
 @pytest.mark.asyncio
@@ -101,8 +101,8 @@ async def test_search_by_conversation_no_results(mock_ews_client):
     result = await tool.execute(conversation_id="nonexistent-conversation")
 
     assert result["success"] is True
-    assert result["thread_count"] == 0
-    assert len(result["emails"]) == 0
+    assert result["total_results"] == 0
+    assert len(result["results"]) == 0
 
 
 @pytest.mark.asyncio
@@ -111,7 +111,7 @@ async def test_search_by_conversation_missing_ids(mock_ews_client):
     tool = SearchByConversationTool(mock_ews_client)
 
     with pytest.raises(ToolExecutionError) as exc_info:
-        await tool.execute(folder="inbox")
+        await tool.execute(search_scope=["inbox"])
 
     assert "conversation_id or message_id" in str(exc_info.value)
 

--- a/tests/test_email_tools.py
+++ b/tests/test_email_tools.py
@@ -108,7 +108,7 @@ async def test_delete_email_tool(mock_ews_client):
     result = await tool.execute(message_id="test-id", permanent=False)
 
     assert result["success"] is True
-    mock_email.soft_delete.assert_called_once()
+    mock_email.move.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_folder_management.py
+++ b/tests/test_folder_management.py
@@ -91,8 +91,7 @@ async def test_delete_folder_soft(mock_ews_client):
     mock_folder.id = "folder-to-delete"
     mock_folder.name = "Old Project"
 
-    # Mock find_folder_by_id
-    with patch('src.tools.folder_tools.find_folder_by_id', return_value=mock_folder):
+    with patch.object(tool, '_find_folder_by_id', return_value=mock_folder):
         result = await tool.execute(
             action="delete",
             folder_id="folder-to-delete",
@@ -116,7 +115,7 @@ async def test_delete_folder_permanent(mock_ews_client):
     mock_folder.id = "folder-to-delete"
     mock_folder.name = "Temp Folder"
 
-    with patch('src.tools.folder_tools.find_folder_by_id', return_value=mock_folder):
+    with patch.object(tool, '_find_folder_by_id', return_value=mock_folder):
         result = await tool.execute(
             action="delete",
             folder_id="folder-to-delete",
@@ -133,7 +132,7 @@ async def test_delete_folder_not_found(mock_ews_client):
     """Test deleting non-existent folder."""
     tool = ManageFolderTool(mock_ews_client)
 
-    with patch('src.tools.folder_tools.find_folder_by_id', return_value=None):
+    with patch.object(tool, '_find_folder_by_id', return_value=None):
         with pytest.raises(ToolExecutionError) as exc_info:
             await tool.execute(action="delete", folder_id="nonexistent-id")
 
@@ -150,7 +149,7 @@ async def test_rename_folder(mock_ews_client):
     mock_folder.id = "folder-id"
     mock_folder.name = "Old Name"
 
-    with patch('src.tools.folder_tools.find_folder_by_id', return_value=mock_folder):
+    with patch.object(tool, '_find_folder_by_id', return_value=mock_folder):
         result = await tool.execute(
             action="rename",
             folder_id="folder-id",
@@ -171,7 +170,7 @@ async def test_rename_folder_not_found(mock_ews_client):
     """Test renaming non-existent folder."""
     tool = ManageFolderTool(mock_ews_client)
 
-    with patch('src.tools.folder_tools.find_folder_by_id', return_value=None):
+    with patch.object(tool, '_find_folder_by_id', return_value=None):
         with pytest.raises(ToolExecutionError) as exc_info:
             await tool.execute(
                 action="rename",
@@ -197,7 +196,7 @@ async def test_move_folder(mock_ews_client):
     mock_dest.id = "dest-folder-id"
     mock_dest.name = "Archive"
 
-    with patch('src.tools.folder_tools.find_folder_by_id') as mock_find:
+    with patch.object(tool, '_find_folder_by_id') as mock_find:
         # First call returns folder to move, second call returns destination
         mock_find.side_effect = [mock_folder, mock_dest]
 
@@ -211,7 +210,6 @@ async def test_move_folder(mock_ews_client):
     assert "moved successfully" in result["message"]
     assert result["folder_id"] == "folder-to-move"
     assert result["folder_name"] == "Project A"
-    assert result["destination_folder_id"] == "dest-folder-id"
     mock_folder.move.assert_called_once_with(to_folder=mock_dest)
 
 
@@ -220,7 +218,7 @@ async def test_move_folder_source_not_found(mock_ews_client):
     """Test moving non-existent folder."""
     tool = ManageFolderTool(mock_ews_client)
 
-    with patch('src.tools.folder_tools.find_folder_by_id', return_value=None):
+    with patch.object(tool, '_find_folder_by_id', return_value=None):
         with pytest.raises(ToolExecutionError) as exc_info:
             await tool.execute(
                 action="move",
@@ -240,7 +238,7 @@ async def test_move_folder_destination_not_found(mock_ews_client):
     mock_folder = MagicMock()
     mock_folder.id = "folder-to-move"
 
-    with patch('src.tools.folder_tools.find_folder_by_id') as mock_find:
+    with patch.object(tool, '_find_folder_by_id') as mock_find:
         # First call returns folder to move, second call returns None (destination not found)
         mock_find.side_effect = [mock_folder, None]
 
@@ -268,7 +266,7 @@ async def test_move_folder_to_parent(mock_ews_client):
     mock_inbox = MagicMock()
     mock_ews_client.account.inbox = mock_inbox
 
-    with patch('src.tools.folder_tools.find_folder_by_id', return_value=mock_folder):
+    with patch.object(tool, '_find_folder_by_id', return_value=mock_folder):
         result = await tool.execute(
             action="move",
             folder_id="folder-to-move",

--- a/tests/test_gal_search_fix.py
+++ b/tests/test_gal_search_fix.py
@@ -66,7 +66,7 @@ class TestGALSearchTupleFormat:
         mock_ews_client.account.sent.filter.return_value.order_by.return_value.only.return_value = []
 
         # Execute search
-        result = await find_person_tool.execute(query="Smith", search_scope="gal")
+        result = await find_person_tool.execute(query="Smith", source="gal")
 
         # Assertions
         assert result['success'] is True
@@ -109,7 +109,7 @@ class TestGALSearchTupleFormat:
         mock_ews_client.account.inbox.filter.return_value.order_by.return_value.only.return_value = []
         mock_ews_client.account.sent.filter.return_value.order_by.return_value.only.return_value = []
 
-        result = await find_person_tool.execute(query="Doe", search_scope="gal")
+        result = await find_person_tool.execute(query="Doe", source="gal")
 
         assert result['success'] is True
         contact = result['unified_results'][0]
@@ -117,8 +117,6 @@ class TestGALSearchTupleFormat:
         assert len(contact['phone_numbers']) == 2
         assert contact['phone_numbers'][0]['type'] == "BusinessPhone"
         assert contact['phone_numbers'][0]['number'] == "+1-555-0100"
-        assert contact['business_phone'] == "+1-555-0100"
-        assert contact['mobile_phone'] == "+1-555-0101"
 
     @pytest.mark.asyncio
     async def test_gal_search_arabic_text(self, find_person_tool, mock_ews_client):
@@ -138,7 +136,7 @@ class TestGALSearchTupleFormat:
         mock_ews_client.account.inbox.filter.return_value.order_by.return_value.only.return_value = []
         mock_ews_client.account.sent.filter.return_value.order_by.return_value.only.return_value = []
 
-        result = await find_person_tool.execute(query="أحمد", search_scope="gal")
+        result = await find_person_tool.execute(query="أحمد", source="gal")
 
         assert result['success'] is True
         assert result['total_results'] >= 1
@@ -159,7 +157,7 @@ class TestGALSearchTupleFormat:
         mock_ews_client.account.inbox.filter.return_value.order_by.return_value.only.return_value = []
         mock_ews_client.account.sent.filter.return_value.order_by.return_value.only.return_value = []
 
-        result = await find_person_tool.execute(query="Johnson", search_scope="gal")
+        result = await find_person_tool.execute(query="Johnson", source="gal")
 
         assert result['success'] is True
         assert result['total_results'] == 1
@@ -188,7 +186,7 @@ class TestGALSearchTupleFormat:
         mock_ews_client.account.inbox.filter.return_value.order_by.return_value.only.return_value = []
         mock_ews_client.account.sent.filter.return_value.order_by.return_value.only.return_value = []
 
-        result = await find_person_tool.execute(query="User", search_scope="gal")
+        result = await find_person_tool.execute(query="User", source="gal")
 
         assert result['success'] is True
         assert result['total_results'] == 3
@@ -213,7 +211,7 @@ class TestSearchScopeIsolation:
         mock_ews_client.account.inbox.filter.return_value.order_by.return_value.only.return_value = []
         mock_ews_client.account.sent.filter.return_value.order_by.return_value.only.return_value = []
 
-        result = await find_person_tool.execute(query="User", search_scope="gal")
+        result = await find_person_tool.execute(query="User", source="gal")
 
         # Verify only GAL sources
         assert result['success'] is True
@@ -238,7 +236,7 @@ class TestSearchScopeIsolation:
         mock_ews_client.account.inbox.filter.return_value.order_by.return_value.only.return_value = [mock_inbox_item]
         mock_ews_client.account.sent.filter.return_value.order_by.return_value.only.return_value = []
 
-        result = await find_person_tool.execute(query="User", search_scope="email_history")
+        result = await find_person_tool.execute(query="User", source="email_history")
 
         # GAL resolve_names should not have been called
         mock_ews_client.account.protocol.resolve_names.assert_not_called()
@@ -259,7 +257,7 @@ class TestErrorHandling:
         mock_ews_client.account.inbox.filter.return_value.order_by.return_value.only.return_value = []
         mock_ews_client.account.sent.filter.return_value.order_by.return_value.only.return_value = []
 
-        result = await find_person_tool.execute(query="NonexistentUser", search_scope="gal")
+        result = await find_person_tool.execute(query="NonexistentUser", source="gal")
 
         assert result['success'] is True
         assert result['total_results'] == 0
@@ -288,7 +286,7 @@ class TestErrorHandling:
         mock_ews_client.account.inbox.filter.return_value.order_by.return_value.only.return_value = []
         mock_ews_client.account.sent.filter.return_value.order_by.return_value.only.return_value = []
 
-        result = await find_person_tool.execute(query="User", search_scope="gal")
+        result = await find_person_tool.execute(query="User", source="gal")
 
         # Should still succeed with at least one valid result
         assert result['success'] is True
@@ -298,7 +296,7 @@ class TestErrorHandling:
     async def test_empty_query(self, find_person_tool):
         """Test that empty query raises error."""
         with pytest.raises(Exception):  # Should raise ToolExecutionError
-            await find_person_tool.execute(query="", search_scope="gal")
+            await find_person_tool.execute(query="", source="gal")
 
 
 class TestOfficeLocationExtraction:
@@ -321,7 +319,7 @@ class TestOfficeLocationExtraction:
         mock_ews_client.account.inbox.filter.return_value.order_by.return_value.only.return_value = []
         mock_ews_client.account.sent.filter.return_value.order_by.return_value.only.return_value = []
 
-        result = await find_person_tool.execute(query="Office", search_scope="gal")
+        result = await find_person_tool.execute(query="Office", source="gal")
 
         assert result['success'] is True
         contact = result['unified_results'][0]
@@ -349,7 +347,7 @@ class TestMaxResultsLimit:
         mock_ews_client.account.sent.filter.return_value.order_by.return_value.only.return_value = []
 
         # Request only 5 results
-        result = await find_person_tool.execute(query="User", search_scope="gal", max_results=5)
+        result = await find_person_tool.execute(query="User", source="gal", max_results=5)
 
         assert result['success'] is True
         assert len(result['unified_results']) == 5

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -38,7 +38,7 @@ async def test_advanced_search_tool(mock_ews_client):
         from_address="boss@example.com",
         has_attachments=True,
         importance="High",
-        folders=["inbox"],
+        search_scope=["inbox"],
         max_results=100,
         sort_by="datetime_received",
         sort_order="descending"
@@ -66,7 +66,7 @@ async def test_advanced_search_with_date_range(mock_ews_client):
         subject_contains="Report",
         start_date="2025-01-01T00:00:00+00:00",
         end_date="2025-01-31T23:59:59+00:00",
-        folders=["inbox"],
+        search_scope=["inbox"],
         max_results=50
     )
 
@@ -121,7 +121,7 @@ async def test_advanced_search_multiple_folders(mock_ews_client):
     result = await tool.execute(
         mode="advanced",
         keywords="email",
-        folders=["inbox", "sent"],
+        search_scope=["inbox", "sent"],
         max_results=100
     )
 
@@ -137,7 +137,7 @@ async def test_advanced_search_empty_filter(mock_ews_client):
     with pytest.raises(Exception) as exc_info:
         await tool.execute(
             mode="advanced",
-            folders=["inbox"]
+            search_scope=["inbox"]
         )
 
     assert "filter" in str(exc_info.value).lower() or "empty" in str(exc_info.value).lower() or "required" in str(exc_info.value).lower()
@@ -152,7 +152,7 @@ async def test_advanced_search_invalid_folder(mock_ews_client):
         await tool.execute(
             mode="advanced",
             subject_contains="test",
-            folders=["nonexistent_folder"]
+            search_scope=["nonexistent_folder"]
         )
 
     assert "no valid folders" in str(exc_info.value).lower() or "folder" in str(exc_info.value).lower()


### PR DESCRIPTION
…c fixes

- Version strings: src/main.py 2.1.0→3.3.0, Dockerfile v3.2→v3.3, docker-compose.yml v3.0→v3.3
- start-openwebui.sh: tool count 44→36, search_contacts→find_person example
- test_folder_management.py: patch path fix (patch.object for class method)
- test_email_tools.py: soft_delete→move assertion (matches actual DeleteEmailTool)
- test_advanced_search.py: thread_count→total_results, emails→results, folder→search_scope
- test_gal_search_fix.py: search_scope→source, remove nonexistent output keys
- test_search_tools.py: folders→search_scope param name
- .env examples: API_VERSION 3.0.0→3.3.0

