### PR TITLE
feat: add draft email creation tool and local log path support

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd /Users/kon5i/ews-mcp
+exec /Users/kon5i/ews-mcp/venv/bin/python -m src.main

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,12 @@
 #!/bin/bash
-cd /Users/kon5i/ews-mcp
-exec /Users/kon5i/ews-mcp/venv/bin/python -m src.main
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [ -n "${VIRTUAL_ENV:-}" ] && [ -x "$VIRTUAL_ENV/bin/python" ]; then
+    exec "$VIRTUAL_ENV/bin/python" -m src.main
+elif [ -x "venv/bin/python" ]; then
+    exec "venv/bin/python" -m src.main
+else
+    exec python -m src.main
+fi

--- a/src/log_analyzer.py
+++ b/src/log_analyzer.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 class LogAnalyzer:
     """Analyze logs for patterns, issues, and insights."""
 
-    def __init__(self, log_dir: Path = Path("/app/logs")):
+    def __init__(self, log_dir: Path = Path("logs")):
         """Initialize the log analyzer.
 
         Args:

--- a/src/log_rotation.py
+++ b/src/log_rotation.py
@@ -13,7 +13,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def rotate_logs(log_dir: Path = Path("/app/logs"), keep_days: int = 30):
+def rotate_logs(log_dir: Path = Path("logs"), keep_days: int = 30):
     """Rotate old logs to daily archives.
 
     Args:
@@ -79,7 +79,7 @@ def rotate_logs(log_dir: Path = Path("/app/logs"), keep_days: int = 30):
     }
 
 
-def get_disk_usage(log_dir: Path = Path("/app/logs")) -> Dict[str, Any]:
+def get_disk_usage(log_dir: Path = Path("logs")) -> Dict[str, Any]:
     """Get disk usage statistics for log directory.
 
     Args:

--- a/src/logging_system.py
+++ b/src/logging_system.py
@@ -16,11 +16,11 @@ from .utils import EWSJSONEncoder, make_json_serializable
 class LogManager:
     """Central logging management for EWS MCP Server."""
 
-    def __init__(self, log_dir: Path = Path("/app/logs")):
+    def __init__(self, log_dir: Path = Path("logs")):
         """Initialize the logging system.
 
         Args:
-            log_dir: Directory for log files (default: /app/logs)
+            log_dir: Directory for log files (default: logs)
         """
         self.log_dir = log_dir
         self.session_id = f"sess_{uuid.uuid4().hex[:8]}"
@@ -32,7 +32,7 @@ class LogManager:
             self.log_dir.mkdir(parents=True, exist_ok=True)
         except PermissionError as e:
             logging.warning(f"Cannot create log directory {self.log_dir}: {e}")
-            # Fall back to /tmp if /app/logs is not writable
+            # Fall back to /tmp if logs is not writable
             self.log_dir = Path("/tmp/ews_mcp_logs")
             self.log_dir.mkdir(parents=True, exist_ok=True)
             logging.info(f"Using fallback log directory: {self.log_dir}")

--- a/src/logging_system.py
+++ b/src/logging_system.py
@@ -30,9 +30,9 @@ class LogManager:
         """Initialize all log files and handlers."""
         try:
             self.log_dir.mkdir(parents=True, exist_ok=True)
-        except PermissionError as e:
+        except OSError as e:
             logging.warning(f"Cannot create log directory {self.log_dir}: {e}")
-            # Fall back to /tmp if logs is not writable
+            # Fall back to /tmp if logs is not writable or otherwise unavailable
             self.log_dir = Path("/tmp/ews_mcp_logs")
             self.log_dir.mkdir(parents=True, exist_ok=True)
             logging.info(f"Using fallback log directory: {self.log_dir}")
@@ -48,7 +48,7 @@ class LogManager:
         self.context_file = self.log_dir / "analysis" / "conversation_context.json"
         try:
             self.context_file.parent.mkdir(parents=True, exist_ok=True)
-        except PermissionError as e:
+        except OSError as e:
             logging.warning(f"Cannot create analysis directory {self.context_file.parent}: {e}")
             # Disable context file if we can't create the directory
             self.context_file = None

--- a/src/main.py
+++ b/src/main.py
@@ -25,6 +25,7 @@ from .openapi_adapter import OpenAPIAdapter
 
 # Import all tool classes (up to 40 tools total: 36 base + 4 AI)
 from .tools import (
+    CreateDraftTool,
     SendEmailTool, ReadEmailsTool, SearchEmailsTool, GetEmailDetailsTool,
     DeleteEmailTool, MoveEmailTool, UpdateEmailTool, CopyEmailTool,
     ReplyEmailTool, ForwardEmailTool,
@@ -53,7 +54,6 @@ from .tools import (
     FindPersonTool, AnalyzeContactsTool
 )
 
-from .tools.email_tools_draft import CreateDraftTool
 class EWSMCPServer:
     """MCP Server for Exchange Web Services with comprehensive logging."""
 

--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,6 @@ from .openapi_adapter import OpenAPIAdapter
 
 # Import all tool classes (up to 40 tools total: 36 base + 4 AI)
 from .tools import (
-    # Email tools (10) — includes unified search_emails with quick/advanced/full_text modes
     SendEmailTool, ReadEmailsTool, SearchEmailsTool, GetEmailDetailsTool,
     DeleteEmailTool, MoveEmailTool, UpdateEmailTool, CopyEmailTool,
     ReplyEmailTool, ForwardEmailTool,
@@ -54,7 +53,7 @@ from .tools import (
     FindPersonTool, AnalyzeContactsTool
 )
 
-
+from .tools.email_tools_draft import CreateDraftTool
 class EWSMCPServer:
     """MCP Server for Exchange Web Services with comprehensive logging."""
 
@@ -198,9 +197,10 @@ class EWSMCPServer:
         """Register all enabled tools (36 base tools, up to 40 with AI)."""
         tool_classes = []
 
-        # Email tools (10 tools — search_emails includes quick/advanced/full_text modes)
+        # Email tools (11 tools — search_emails includes quick/advanced/full_text modes)
         if self.settings.enable_email:
             tool_classes.extend([
+                CreateDraftTool,
                 SendEmailTool,
                 ReadEmailsTool,
                 SearchEmailsTool,
@@ -212,7 +212,7 @@ class EWSMCPServer:
                 ReplyEmailTool,
                 ForwardEmailTool
             ])
-            self.logger.info("Email tools enabled (10 tools)")
+            self.logger.info("Email tools enabled (11 tools)")
 
         # Attachment tools (5 tools)
         if self.settings.enable_email:

--- a/src/middleware/logging.py
+++ b/src/middleware/logging.py
@@ -2,10 +2,26 @@
 
 import logging
 import sys
-import os
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Any, Dict
+
+
+DEFAULT_LOG_DIR = Path("logs")
+FALLBACK_LOG_DIR = Path("/tmp/ews_mcp_logs")
+
+
+def resolve_log_dir(preferred: Path = DEFAULT_LOG_DIR) -> Path:
+    """Return a writable log directory, falling back to /tmp when needed."""
+    try:
+        preferred.mkdir(parents=True, exist_ok=True)
+        return preferred
+    except OSError as e:
+        fallback = FALLBACK_LOG_DIR
+        logging.warning(f"Cannot create log directory {preferred}: {e}")
+        fallback.mkdir(parents=True, exist_ok=True)
+        logging.info(f"Using fallback log directory: {fallback}")
+        return fallback
 
 
 def setup_logging(log_level: str = "INFO") -> None:
@@ -15,8 +31,7 @@ def setup_logging(log_level: str = "INFO") -> None:
     - File (rotating): Complete troubleshooting logs
     - MCP requires stdout clean for JSON-RPC protocol
     """
-    log_dir = Path("logs")
-    log_dir.mkdir(parents=True, exist_ok=True)
+    log_dir = resolve_log_dir()
 
     # Console handler: INFO level for monitoring
     console_handler = logging.StreamHandler(sys.stderr)
@@ -72,8 +87,7 @@ class AuditLogger:
         self.logger = logging.getLogger("audit")
 
         # Add dedicated audit log file
-        log_dir = Path("logs")
-        log_dir.mkdir(parents=True, exist_ok=True)
+        log_dir = resolve_log_dir()
 
         audit_handler = RotatingFileHandler(
             log_dir / "audit.log",

--- a/src/middleware/logging.py
+++ b/src/middleware/logging.py
@@ -15,7 +15,7 @@ def setup_logging(log_level: str = "INFO") -> None:
     - File (rotating): Complete troubleshooting logs
     - MCP requires stdout clean for JSON-RPC protocol
     """
-    log_dir = Path("/app/logs")
+    log_dir = Path("logs")
     log_dir.mkdir(parents=True, exist_ok=True)
 
     # Console handler: INFO level for monitoring
@@ -72,7 +72,7 @@ class AuditLogger:
         self.logger = logging.getLogger("audit")
 
         # Add dedicated audit log file
-        log_dir = Path("/app/logs")
+        log_dir = Path("logs")
         log_dir.mkdir(parents=True, exist_ok=True)
 
         audit_handler = RotatingFileHandler(

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,6 +1,7 @@
 """MCP Tools for EWS operations."""
 
 from .email_tools import SendEmailTool, ReadEmailsTool, SearchEmailsTool, GetEmailDetailsTool, DeleteEmailTool, MoveEmailTool, UpdateEmailTool, CopyEmailTool, ReplyEmailTool, ForwardEmailTool
+from .email_tools_draft import CreateDraftTool
 from .calendar_tools import CreateAppointmentTool, GetCalendarTool, UpdateAppointmentTool, DeleteAppointmentTool, RespondToMeetingTool, CheckAvailabilityTool, FindMeetingTimesTool
 from .contact_tools import CreateContactTool, UpdateContactTool, DeleteContactTool
 from .task_tools import CreateTaskTool, GetTasksTool, UpdateTaskTool, CompleteTaskTool, DeleteTaskTool
@@ -12,7 +13,8 @@ from .ai_tools import SemanticSearchEmailsTool, ClassifyEmailTool, SummarizeEmai
 from .contact_intelligence_tools import FindPersonTool, AnalyzeContactsTool
 
 __all__ = [
-    # Email tools (10)
+    # Email tools (11)
+    "CreateDraftTool",
     "SendEmailTool",
     "ReadEmailsTool",
     "SearchEmailsTool",

--- a/src/tools/email_tools_draft.py
+++ b/src/tools/email_tools_draft.py
@@ -1,0 +1,150 @@
+"""Draft email tool for EWS MCP Server."""
+import os
+import re
+from typing import Any, Dict
+from datetime import datetime
+from exchangelib import Message, Mailbox, FileAttachment, HTMLBody, Body
+
+from .base import BaseTool
+from ..models import SendEmailRequest
+from ..exceptions import ToolExecutionError
+from ..utils import format_success_response, ews_id_to_str, attach_inline_files, INLINE_ATTACHMENTS_SCHEMA
+
+
+class CreateDraftTool(BaseTool):
+    """Tool for creating draft emails in the Drafts folder."""
+
+    def get_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "create_draft",
+            "description": "Create a draft email in the Drafts folder for review before sending. The draft appears in OWA/Outlook and can be edited and sent manually.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "to": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Recipient email addresses"
+                    },
+                    "subject": {
+                        "type": "string",
+                        "description": "Email subject"
+                    },
+                    "body": {
+                        "type": "string",
+                        "description": "Email body (HTML supported)"
+                    },
+                    "cc": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "CC recipients (optional)"
+                    },
+                    "bcc": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "BCC recipients (optional)"
+                    },
+                    "importance": {
+                        "type": "string",
+                        "enum": ["Low", "Normal", "High"],
+                        "description": "Email importance level (optional)"
+                    },
+                    "attachments": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Attachment file paths (optional)"
+                    },
+                    **INLINE_ATTACHMENTS_SCHEMA,
+                    "target_mailbox": {
+                        "type": "string",
+                        "description": "Email address to create draft on behalf of (requires impersonation/delegate access)"
+                    }
+                },
+                "required": ["to", "subject", "body"]
+            }
+        }
+
+    async def execute(self, **kwargs) -> Dict[str, Any]:
+        """Create draft email via EWS and save to Drafts folder."""
+        target_mailbox = kwargs.pop("target_mailbox", None)
+        request = self.validate_input(SendEmailRequest, **kwargs)
+
+        try:
+            account = self.get_account(target_mailbox)
+            mailbox = self.get_mailbox_info(target_mailbox)
+
+            email_body = request.body.strip()
+
+            # Strip CDATA wrapper if present
+            if email_body.startswith('<![CDATA[') and email_body.endswith(']]>'):
+                email_body = email_body[9:-3].strip()
+
+            if not email_body:
+                raise ToolExecutionError("Email body is empty after processing")
+
+            is_html = bool(re.search(r'<[^>]+>', email_body))
+
+            # Create message with appropriate body type
+            if is_html:
+                message = Message(
+                    account=account,
+                    subject=request.subject,
+                    body=HTMLBody(email_body),
+                    to_recipients=[Mailbox(email_address=email) for email in request.to],
+                    folder=account.drafts,
+                )
+            else:
+                message = Message(
+                    account=account,
+                    subject=request.subject,
+                    body=Body(email_body),
+                    to_recipients=[Mailbox(email_address=email) for email in request.to],
+                    folder=account.drafts,
+                )
+
+            # Add CC/BCC
+            if request.cc:
+                message.cc_recipients = [Mailbox(email_address=email) for email in request.cc]
+            if request.bcc:
+                message.bcc_recipients = [Mailbox(email_address=email) for email in request.bcc]
+
+            # Set importance
+            message.importance = request.importance.value
+
+            # Add file attachments
+            attachment_count = 0
+            if request.attachments:
+                for file_path in request.attachments:
+                    try:
+                        file_name = os.path.basename(file_path)
+                        with open(file_path, 'rb') as f:
+                            content = f.read()
+                            attachment = FileAttachment(name=file_name, content=content)
+                            message.attach(attachment)
+                            attachment_count += 1
+                    except FileNotFoundError:
+                        raise ToolExecutionError(f"Attachment file not found: {file_path}")
+                    except Exception as e:
+                        raise ToolExecutionError(f"Failed to attach file {file_path}: {e}")
+
+            # Add inline attachments
+            inline_count = attach_inline_files(message, kwargs.get("inline_attachments", []))
+            attachment_count += inline_count
+
+            # Save as draft instead of sending
+            message.save()
+
+            self.logger.info(f"Draft saved for {', '.join(request.to)} with {attachment_count} attachment(s)")
+
+            return format_success_response(
+                "Draft created successfully — check your Drafts folder in OWA/Outlook",
+                message_id=ews_id_to_str(message.id) if hasattr(message, 'id') else None,
+                created_time=datetime.now().isoformat(),
+                recipients=request.to,
+                subject=request.subject,
+                mailbox=mailbox
+            )
+
+        except Exception as e:
+            self.logger.error(f"Failed to create draft: {e}")
+            raise ToolExecutionError(f"Failed to create draft: {e}")

--- a/tests/test_email_tools.py
+++ b/tests/test_email_tools.py
@@ -13,6 +13,7 @@ from src.tools.email_tools import (
     UpdateEmailTool,
     CopyEmailTool
 )
+from src.tools.email_tools_draft import CreateDraftTool
 
 
 @pytest.mark.asyncio
@@ -44,6 +45,28 @@ async def test_send_email_validation_error(mock_ews_client):
             subject="",
             body=""
         )
+
+
+@pytest.mark.asyncio
+async def test_create_draft_tool_saves_draft(mock_ews_client, sample_email):
+    """Test creating a draft saves to Drafts instead of sending."""
+    tool = CreateDraftTool(mock_ews_client)
+    mock_ews_client.get_account = Mock(return_value=mock_ews_client.account)
+    mock_ews_client.account.drafts = MagicMock()
+
+    with patch('src.tools.email_tools_draft.Message') as mock_message:
+        mock_msg = MagicMock()
+        mock_msg.id = "draft-message-id"
+        mock_message.return_value = mock_msg
+
+        result = await tool.execute(**sample_email)
+
+        assert result["success"] is True
+        assert "draft created successfully" in result["message"].lower()
+        assert result["subject"] == sample_email["subject"]
+        assert result["recipients"] == sample_email["to"]
+        mock_msg.save.assert_called_once()
+        mock_msg.send.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This pull request introduces a dedicated `create_draft` email tool and updates the logging path defaults so the project works more cleanly in local, non-containerized environments.

The main goal is to support a safer mail workflow: creating reviewable drafts in Exchange/OWA/Outlook instead of sending immediately. In parallel, the logging changes remove the hard-coded `/app/logs` assumption and switch the default log location to a local `logs/` directory, while preserving the existing fallback to `/tmp` when needed.

## What changed

### 1) Added a new `create_draft` EWS tool

A new tool class, `CreateDraftTool`, was added in:

- `src/tools/email_tools_draft.py`

This tool:

- creates a draft message in the Exchange Drafts folder instead of sending it
- supports `to`, `cc`, `bcc`, `subject`, `body`, and `importance`
- supports normal file attachments
- supports inline attachments via the existing inline attachment schema/helpers
- supports delegated/impersonated draft creation via `target_mailbox`
- returns a structured success payload including recipients, subject, mailbox, timestamp, and draft message id when available

This is especially useful for agent-driven or automation-assisted workflows where humans should still review the final email before it is sent.

### 2) Registered the draft tool in the main tool surface

The new draft tool is now exported and registered so it becomes part of the server's email tool set:

- `src/tools/__init__.py`
- `src/main.py`

This update also adjusts the internal email tool count from 10 to 11.

### 3) Switched default log paths from `/app/logs` to `logs`

The logging-related modules previously assumed a container-style writable path at `/app/logs`.
This PR changes those defaults to a project-local `logs` directory:

- `src/log_analyzer.py`
- `src/log_rotation.py`
- `src/logging_system.py`
- `src/middleware/logging.py`

This makes the project friendlier for local development and ad-hoc runtime usage on regular workstations where `/app/logs` may not exist or may not be writable.

The existing safety fallback to `/tmp/ews_mcp_logs` remains in place in `LogManager` if the configured/default log directory cannot be created.

### 4) Added a small local runner script

- `run.sh`

This script starts the server from the local virtualenv:

```bash
#!/bin/bash
cd /Users/kon5i/ews-mcp
exec /Users/kon5i/ews-mcp/venv/bin/python -m src.main
```

This is mainly a convenience helper for local execution.

## Why this is useful

### Safer outbound mail workflows

In many assistant/MCP scenarios, "send immediately" is not the right default behavior. Draft creation offers a much safer middle ground:

- automation can prepare the message
- the human can review/edit in Outlook or OWA
- the final send decision stays manual

That makes the mail workflow more aligned with approval-first environments.

### Better local developer ergonomics

Hard-coding `/app/logs` works well in Docker-style deployments, but it is inconvenient for local development, quick testing, and workstation-based operation. Using `logs/` as the default makes the runtime behavior more predictable when running the project directly from a checkout.

## Files changed

- `src/tools/email_tools_draft.py` *(new)*
- `src/tools/__init__.py`
- `src/main.py`
- `src/log_analyzer.py`
- `src/log_rotation.py`
- `src/logging_system.py`
- `src/middleware/logging.py`
- `run.sh` *(new)*

## Notes

- This PR is intentionally focused on functionality and runtime behavior; it does **not** attempt to redesign the existing mail tool architecture.
- The draft tool reuses existing request validation and attachment helper patterns to stay consistent with the current codebase.
- I also cleaned up the tool registration so the draft tool is registered once and the email tool count stays accurate.

## Suggested follow-up

A useful next step could be to define a clear policy split between:

- `send_email` for explicit immediate-send workflows
- `create_draft` for approval/review-first workflows

That would make the intended usage model even clearer for MCP clients and automation layers.
