### PR TITLE
Add find_folder tool for folder discovery

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -43,8 +43,8 @@ from .tools import (
     AddAttachmentTool, DeleteAttachmentTool, ReadAttachmentTool,
     # Search tools (1) — advanced_search/full_text_search merged into search_emails
     SearchByConversationTool,
-    # Folder tools (2) — create/delete/rename/move merged into manage_folder
-    ListFoldersTool, ManageFolderTool,
+    # Folder tools (3) — create/delete/rename/move merged into manage_folder
+    ListFoldersTool, FindFolderTool, ManageFolderTool,
     # Out-of-Office tools (1) — get/set merged into oof_settings
     OofSettingsTool,
     # AI tools (4 - conditionally enabled)
@@ -272,12 +272,13 @@ class EWSMCPServer:
         ])
         self.logger.info("Search tools enabled (1 tool)")
 
-        # Folder tools (2 tools — list_folders + manage_folder)
+        # Folder tools (3 tools — list_folders + find_folder + manage_folder)
         tool_classes.extend([
             ListFoldersTool,
+            FindFolderTool,
             ManageFolderTool
         ])
-        self.logger.info("Folder tools enabled (2 tools)")
+        self.logger.info("Folder tools enabled (3 tools)")
 
         # Out-of-Office tools (1 tool — oof_settings with get/set)
         tool_classes.extend([

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -7,7 +7,7 @@ from .contact_tools import CreateContactTool, UpdateContactTool, DeleteContactTo
 from .task_tools import CreateTaskTool, GetTasksTool, UpdateTaskTool, CompleteTaskTool, DeleteTaskTool
 from .attachment_tools import ListAttachmentsTool, DownloadAttachmentTool, AddAttachmentTool, DeleteAttachmentTool, ReadAttachmentTool
 from .search_tools import SearchByConversationTool
-from .folder_tools import ListFoldersTool, ManageFolderTool
+from .folder_tools import ListFoldersTool, FindFolderTool, ManageFolderTool
 from .oof_tools import OofSettingsTool
 from .ai_tools import SemanticSearchEmailsTool, ClassifyEmailTool, SummarizeEmailTool, SuggestRepliesTool
 from .contact_intelligence_tools import FindPersonTool, AnalyzeContactsTool
@@ -51,8 +51,9 @@ __all__ = [
     "ReadAttachmentTool",
     # Search tools (1)
     "SearchByConversationTool",
-    # Folder tools (2)
+    # Folder tools (3)
     "ListFoldersTool",
+    "FindFolderTool",
     "ManageFolderTool",
     # Out-of-Office tools (1)
     "OofSettingsTool",

--- a/src/tools/email_tools.py
+++ b/src/tools/email_tools.py
@@ -1354,53 +1354,58 @@ class MoveEmailTool(BaseTool):
                     },
                     "destination_folder": {
                         "type": "string",
-                        "description": "Destination folder (inbox, sent, drafts, deleted, junk)"
+                        "description": "Destination folder name or path (e.g. inbox, Inbox/Projects)"
+                    },
+                    "destination_folder_id": {
+                        "type": "string",
+                        "description": "Destination folder ID (alternative to destination_folder)"
                     },
                     "target_mailbox": {
                         "type": "string",
                         "description": "Email address to operate on (requires impersonation/delegate access)"
                     }
                 },
-                "required": ["message_id", "destination_folder"]
+                "required": ["message_id"]
             }
         }
 
     async def execute(self, **kwargs) -> Dict[str, Any]:
         """Move email to folder."""
         message_id = kwargs.get("message_id")
-        dest_folder_name = kwargs.get("destination_folder", "").lower()
+        destination_folder = kwargs.get("destination_folder")
+        destination_folder_id = kwargs.get("destination_folder_id")
         target_mailbox = kwargs.get("target_mailbox")
+
+        if not message_id:
+            raise ToolExecutionError("message_id is required")
+        if not destination_folder and not destination_folder_id:
+            raise ToolExecutionError("Either destination_folder or destination_folder_id is required")
 
         try:
             # Get account (primary or impersonated)
             account = self.get_account(target_mailbox)
             mailbox = self.get_mailbox_info(target_mailbox)
 
-            # Get destination folder
-            folder_map = {
-                "inbox": account.inbox,
-                "sent": account.sent,
-                "drafts": account.drafts,
-                "deleted": account.trash,
-                "junk": account.junk
-            }
-
-            dest_folder = folder_map.get(dest_folder_name)
-            if not dest_folder:
-                raise ToolExecutionError(f"Unknown folder: {dest_folder_name}")
+            # Folder ID takes precedence over folder name/path when both are provided.
+            destination_identifier = destination_folder_id or destination_folder
+            dest_folder = await resolve_folder_for_account(account, destination_identifier)
+            dest_name = safe_get(dest_folder, "name", destination_identifier)
 
             # Find message across all folders (including custom subfolders)
             item = find_message_for_account(account, message_id)
             item.move(dest_folder)
 
-            self.logger.info(f"Email {message_id} moved to {dest_folder_name} in mailbox: {mailbox}")
+            self.logger.info(f"Email {message_id} moved to {dest_name} in mailbox: {mailbox}")
 
             return format_success_response(
-                f"Email moved to {dest_folder_name}",
+                f"Email moved to {dest_name}",
                 message_id=message_id,
+                destination_folder=dest_name,
                 mailbox=mailbox
             )
 
+        except ToolExecutionError:
+            raise
         except Exception as e:
             self.logger.error(f"Failed to move email: {e}")
             raise ToolExecutionError(f"Failed to move email: {e}")

--- a/src/tools/folder_tools.py
+++ b/src/tools/folder_tools.py
@@ -8,6 +8,49 @@ from ..exceptions import ToolExecutionError
 from ..utils import format_success_response, safe_get, ews_id_to_str
 
 
+def get_standard_folder_map(account):
+    """Get standard folder name to object mapping."""
+    return {
+        "root": account.root,
+        "inbox": account.inbox,
+        "sent": account.sent,
+        "drafts": account.drafts,
+        "deleted": account.trash,
+        "junk": account.junk,
+        "calendar": account.calendar,
+        "contacts": account.contacts,
+        "tasks": account.tasks
+    }
+
+
+def find_folder_by_id(parent, target_id):
+    """Recursively search for folder by ID."""
+    parent_id = ews_id_to_str(safe_get(parent, 'id', None)) or ''
+    if parent_id == target_id:
+        return parent
+    if hasattr(parent, 'children') and parent.children:
+        for child in parent.children:
+            result = find_folder_by_id(child, target_id)
+            if result:
+                return result
+    return None
+
+
+def resolve_parent_folder(account, parent_folder=None, parent_folder_id=None, default_name="root"):
+    """Resolve parent folder from ID or standard folder name."""
+    if parent_folder_id:
+        folder = find_folder_by_id(account.root, parent_folder_id)
+        if not folder:
+            raise ToolExecutionError(f"Parent folder not found: {parent_folder_id}")
+        return folder, safe_get(folder, "name", parent_folder_id)
+
+    parent_folder_name = (parent_folder or default_name).lower()
+    folder = get_standard_folder_map(account).get(parent_folder_name)
+    if not folder:
+        raise ToolExecutionError(f"Unknown parent folder: {parent_folder_name}")
+    return folder, parent_folder_name
+
+
 class ListFoldersTool(BaseTool):
     """Tool for listing mailbox folder hierarchy."""
 
@@ -23,6 +66,10 @@ class ListFoldersTool(BaseTool):
                         "description": "Parent folder to start from (default: root)",
                         "default": "root",
                         "enum": ["root", "inbox", "sent", "drafts", "deleted", "junk", "calendar", "contacts", "tasks"]
+                    },
+                    "parent_folder_id": {
+                        "type": "string",
+                        "description": "Parent folder ID (alternative to parent_folder)"
                     },
                     "depth": {
                         "type": "integer",
@@ -51,7 +98,8 @@ class ListFoldersTool(BaseTool):
 
     async def execute(self, **kwargs) -> Dict[str, Any]:
         """List folders recursively."""
-        parent_folder_name = kwargs.get("parent_folder", "root").lower()
+        parent_folder_name = kwargs.get("parent_folder")
+        parent_folder_id = kwargs.get("parent_folder_id")
         depth = kwargs.get("depth", 2)
         include_hidden = kwargs.get("include_hidden", False)
         include_counts = kwargs.get("include_counts", True)
@@ -63,22 +111,12 @@ class ListFoldersTool(BaseTool):
         try:
             account = self.get_account(target_mailbox)
             mailbox = self.get_mailbox_info(target_mailbox)
-
-            folder_map = {
-                "root": account.root,
-                "inbox": account.inbox,
-                "sent": account.sent,
-                "drafts": account.drafts,
-                "deleted": account.trash,
-                "junk": account.junk,
-                "calendar": account.calendar,
-                "contacts": account.contacts,
-                "tasks": account.tasks
-            }
-
-            parent_folder = folder_map.get(parent_folder_name)
-            if not parent_folder:
-                raise ToolExecutionError(f"Unknown parent folder: {parent_folder_name}")
+            parent_folder, resolved_parent = resolve_parent_folder(
+                account,
+                parent_folder=parent_folder_name,
+                parent_folder_id=parent_folder_id,
+                default_name="root"
+            )
 
             def list_folder_tree(folder, current_depth, max_depth):
                 if current_depth > max_depth:
@@ -156,7 +194,7 @@ class ListFoldersTool(BaseTool):
                 f"Listed {total_folders} folder(s)",
                 folder_tree=folder_tree,
                 total_folders=total_folders,
-                parent_folder=parent_folder_name,
+                parent_folder=resolved_parent,
                 depth=depth,
                 mailbox=mailbox
             )
@@ -200,6 +238,10 @@ class ManageFolderTool(BaseTool):
                         "default": "inbox",
                         "enum": ["root", "inbox", "sent", "drafts", "deleted", "junk", "calendar", "contacts", "tasks"]
                     },
+                    "parent_folder_id": {
+                        "type": "string",
+                        "description": "Parent folder ID for create action (alternative to parent_folder)"
+                    },
                     "folder_class": {
                         "type": "string",
                         "description": "Folder class for create (type of items)",
@@ -231,29 +273,11 @@ class ManageFolderTool(BaseTool):
 
     def _get_folder_map(self, account):
         """Get standard folder name to object mapping."""
-        return {
-            "root": account.root,
-            "inbox": account.inbox,
-            "sent": account.sent,
-            "drafts": account.drafts,
-            "deleted": account.trash,
-            "junk": account.junk,
-            "calendar": account.calendar,
-            "contacts": account.contacts,
-            "tasks": account.tasks
-        }
+        return get_standard_folder_map(account)
 
     def _find_folder_by_id(self, parent, target_id):
         """Recursively search for folder by ID."""
-        parent_id = ews_id_to_str(safe_get(parent, 'id', None)) or ''
-        if parent_id == target_id:
-            return parent
-        if hasattr(parent, 'children') and parent.children:
-            for child in parent.children:
-                result = self._find_folder_by_id(child, target_id)
-                if result:
-                    return result
-        return None
+        return find_folder_by_id(parent, target_id)
 
     async def execute(self, **kwargs) -> Dict[str, Any]:
         """Route to appropriate folder action."""
@@ -275,7 +299,8 @@ class ManageFolderTool(BaseTool):
     async def _create(self, **kwargs) -> Dict[str, Any]:
         """Create a new folder."""
         folder_name = kwargs.get("folder_name")
-        parent_folder_name = kwargs.get("parent_folder", "inbox").lower()
+        parent_folder_name = kwargs.get("parent_folder")
+        parent_folder_id = kwargs.get("parent_folder_id")
         folder_class = kwargs.get("folder_class", "IPF.Note")
         target_mailbox = kwargs.get("target_mailbox")
 
@@ -285,11 +310,12 @@ class ManageFolderTool(BaseTool):
         try:
             account = self.get_account(target_mailbox)
             mailbox = self.get_mailbox_info(target_mailbox)
-
-            folder_map = self._get_folder_map(account)
-            parent_folder = folder_map.get(parent_folder_name)
-            if not parent_folder:
-                raise ToolExecutionError(f"Unknown parent folder: {parent_folder_name}")
+            parent_folder, resolved_parent = resolve_parent_folder(
+                account,
+                parent_folder=parent_folder_name,
+                parent_folder_id=parent_folder_id,
+                default_name="inbox"
+            )
 
             new_folder = Folder(parent=parent_folder, name=folder_name, folder_class=folder_class)
             new_folder.save()
@@ -298,7 +324,7 @@ class ManageFolderTool(BaseTool):
                 f"Folder '{folder_name}' created successfully",
                 folder_id=ews_id_to_str(new_folder.id),
                 folder_name=folder_name,
-                parent_folder=parent_folder_name,
+                parent_folder=resolved_parent,
                 folder_class=folder_class,
                 mailbox=mailbox
             )

--- a/src/tools/folder_tools.py
+++ b/src/tools/folder_tools.py
@@ -1,6 +1,7 @@
 """Folder management tools for EWS MCP Server."""
 
-from typing import Any, Dict, List
+from difflib import SequenceMatcher
+from typing import Any, Dict
 from exchangelib import Folder
 
 from .base import BaseTool
@@ -49,6 +50,36 @@ def resolve_parent_folder(account, parent_folder=None, parent_folder_id=None, de
     if not folder:
         raise ToolExecutionError(f"Unknown parent folder: {parent_folder_name}")
     return folder, parent_folder_name
+
+
+def is_user_visible_folder(folder) -> bool:
+    """Check whether a folder should be visible in user-facing listings."""
+    folder_name = safe_get(folder, "name", "")
+    folder_class = safe_get(folder, "folder_class", "")
+
+    system_folder_names = {
+        "recoverable items", "recoverable items deletions",
+        "recoverable items purges", "recoverable items versions",
+        "calendar logging", "conversation action settings",
+        "quick step settings", "suggested contacts",
+        "sync issues", "conflicts", "local failures",
+        "server failures", "deletions", "purges", "versions",
+        "audits", "administrativeaudits", "conversationhistory",
+        "mycontacts", "peopleconnect", "quickcontacts",
+        "recipientcache", "skypetelemetry", "teamchat",
+        "workingset", "companies", "organizational contacts"
+    }
+
+    if folder_name.lower() in system_folder_names:
+        return False
+    if folder_name.startswith("~") or folder_name.startswith("_"):
+        return False
+    if folder_class:
+        user_facing_classes = ["IPF.Note", "IPF.Appointment", "IPF.Contact", "IPF.Task"]
+        if not any(cls in folder_class for cls in user_facing_classes):
+            return False
+
+    return True
 
 
 class ListFoldersTool(BaseTool):
@@ -143,30 +174,8 @@ class ListFoldersTool(BaseTool):
                     if hasattr(folder, 'children') and folder.children:
                         for child in folder.children:
                             if not include_hidden:
-                                child_name = safe_get(child, 'name', '')
-                                child_class = safe_get(child, 'folder_class', '')
-
-                                system_folder_names = {
-                                    'recoverable items', 'recoverable items deletions',
-                                    'recoverable items purges', 'recoverable items versions',
-                                    'calendar logging', 'conversation action settings',
-                                    'quick step settings', 'suggested contacts',
-                                    'sync issues', 'conflicts', 'local failures',
-                                    'server failures', 'deletions', 'purges', 'versions',
-                                    'audits', 'administrativeaudits', 'conversationhistory',
-                                    'mycontacts', 'peopleconnect', 'quickcontacts',
-                                    'recipientcache', 'skypetelemetry', 'teamchat',
-                                    'workingset', 'companies', 'organizational contacts'
-                                }
-
-                                if child_name.lower() in system_folder_names:
+                                if not is_user_visible_folder(child):
                                     continue
-                                if child_name.startswith('~') or child_name.startswith('_'):
-                                    continue
-                                if child_class:
-                                    user_facing_classes = ['IPF.Note', 'IPF.Appointment', 'IPF.Contact', 'IPF.Task']
-                                    if not any(cls in child_class for cls in user_facing_classes):
-                                        continue
 
                             child_info = list_folder_tree(child, current_depth + 1, max_depth)
                             if child_info:
@@ -204,6 +213,188 @@ class ListFoldersTool(BaseTool):
         except Exception as e:
             self.logger.error(f"Failed to list folders: {e}")
             raise ToolExecutionError(f"Failed to list folders: {e}")
+
+
+class FindFolderTool(BaseTool):
+    """Tool for discovering and searching mailbox folders."""
+
+    def get_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "find_folder",
+            "description": "Find folder candidates by name/path with exact, prefix, contains, or fuzzy matching.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Folder name or path query. If omitted, returns folders in scope."
+                    },
+                    "parent_folder": {
+                        "type": "string",
+                        "description": "Parent folder scope (default: root)",
+                        "default": "root",
+                        "enum": ["root", "inbox", "sent", "drafts", "deleted", "junk", "calendar", "contacts", "tasks"]
+                    },
+                    "parent_folder_id": {
+                        "type": "string",
+                        "description": "Parent folder ID scope (alternative to parent_folder)"
+                    },
+                    "depth": {
+                        "type": "integer",
+                        "description": "Maximum depth to traverse (1-10)",
+                        "default": 5,
+                        "minimum": 1,
+                        "maximum": 10
+                    },
+                    "match_mode": {
+                        "type": "string",
+                        "description": "Matching strategy for query",
+                        "default": "auto",
+                        "enum": ["auto", "exact", "prefix", "contains", "fuzzy"]
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "description": "Maximum number of candidates to return (1-100)",
+                        "default": 20,
+                        "minimum": 1,
+                        "maximum": 100
+                    },
+                    "include_hidden": {
+                        "type": "boolean",
+                        "description": "Include hidden/system folders in search",
+                        "default": False
+                    },
+                    "target_mailbox": {
+                        "type": "string",
+                        "description": "Email address to operate on (requires impersonation/delegate access)"
+                    }
+                }
+            }
+        }
+
+    async def execute(self, **kwargs) -> Dict[str, Any]:
+        """Find folder candidates in a folder tree scope."""
+        query = (kwargs.get("query") or "").strip()
+        parent_folder_name = kwargs.get("parent_folder")
+        parent_folder_id = kwargs.get("parent_folder_id")
+        depth = kwargs.get("depth", 5)
+        match_mode = kwargs.get("match_mode", "auto")
+        max_results = kwargs.get("max_results", 20)
+        include_hidden = kwargs.get("include_hidden", False)
+        target_mailbox = kwargs.get("target_mailbox")
+
+        if depth < 1 or depth > 10:
+            raise ToolExecutionError("depth must be between 1 and 10")
+        if max_results < 1 or max_results > 100:
+            raise ToolExecutionError("max_results must be between 1 and 100")
+        if match_mode not in {"auto", "exact", "prefix", "contains", "fuzzy"}:
+            raise ToolExecutionError("match_mode must be one of: auto, exact, prefix, contains, fuzzy")
+
+        try:
+            account = self.get_account(target_mailbox)
+            mailbox = self.get_mailbox_info(target_mailbox)
+            parent_folder, resolved_parent = resolve_parent_folder(
+                account,
+                parent_folder=parent_folder_name,
+                parent_folder_id=parent_folder_id,
+                default_name="root"
+            )
+
+            all_entries = []
+
+            def walk_folders(folder, current_depth, current_path):
+                if current_depth > depth:
+                    return
+
+                folder_name = safe_get(folder, "name", "")
+                folder_path = f"{current_path}/{folder_name}" if current_path else folder_name
+                all_entries.append({
+                    "id": ews_id_to_str(safe_get(folder, "id", None)) or "",
+                    "name": folder_name,
+                    "path": folder_path,
+                    "parent_folder_id": ews_id_to_str(safe_get(folder, "parent_folder_id", None)) or "",
+                    "folder_class": safe_get(folder, "folder_class", ""),
+                    "child_folder_count": safe_get(folder, "child_folder_count", 0)
+                })
+
+                if not hasattr(folder, "children") or not folder.children:
+                    return
+
+                for child in folder.children:
+                    if not include_hidden and not is_user_visible_folder(child):
+                        continue
+                    walk_folders(child, current_depth + 1, folder_path)
+
+            walk_folders(parent_folder, 1, "")
+
+            query_lower = query.lower()
+
+            def match_entry(entry):
+                if not query:
+                    return "all", 1.0
+
+                name_value = entry["name"].lower()
+                path_value = entry["path"].lower()
+
+                if match_mode in {"auto", "exact"}:
+                    if name_value == query_lower or path_value == query_lower:
+                        return "exact", 1.0
+
+                if match_mode in {"auto", "prefix"}:
+                    if name_value.startswith(query_lower) or path_value.startswith(query_lower):
+                        return "prefix", 0.9
+
+                if match_mode in {"auto", "contains"}:
+                    if query_lower in name_value or query_lower in path_value:
+                        return "contains", 0.8
+
+                if match_mode in {"auto", "fuzzy"}:
+                    name_ratio = SequenceMatcher(None, query_lower, name_value).ratio()
+                    path_ratio = SequenceMatcher(None, query_lower, path_value).ratio()
+                    best_ratio = max(name_ratio, path_ratio)
+                    threshold = 0.6 if match_mode == "fuzzy" else 0.72
+                    if best_ratio >= threshold:
+                        return "fuzzy", round(best_ratio, 3)
+
+                return None, 0.0
+
+            matches = []
+            for entry in all_entries:
+                match_type, score = match_entry(entry)
+                if match_type:
+                    matches.append({
+                        **entry,
+                        "match_type": match_type,
+                        "score": score
+                    })
+
+            match_rank = {"exact": 4, "prefix": 3, "contains": 2, "fuzzy": 1, "all": 0}
+            matches.sort(
+                key=lambda item: (
+                    match_rank.get(item["match_type"], 0),
+                    item["score"],
+                    -len(item["path"])
+                ),
+                reverse=True
+            )
+            matches = matches[:max_results]
+
+            return format_success_response(
+                f"Found {len(matches)} folder candidate(s)",
+                query=query,
+                match_mode=match_mode,
+                parent_folder=resolved_parent,
+                depth=depth,
+                total_scanned=len(all_entries),
+                total_matches=len(matches),
+                matches=matches,
+                mailbox=mailbox
+            )
+        except ToolExecutionError:
+            raise
+        except Exception as e:
+            self.logger.error(f"Failed to find folders: {e}")
+            raise ToolExecutionError(f"Failed to find folders: {e}")
 
 
 class ManageFolderTool(BaseTool):

--- a/tests/test_email_tools.py
+++ b/tests/test_email_tools.py
@@ -1,7 +1,7 @@
 """Tests for email tools."""
 
 import pytest
-from unittest.mock import Mock, MagicMock, patch
+from unittest.mock import ANY, Mock, MagicMock, patch
 
 from src.tools.email_tools import (
     SendEmailTool,
@@ -174,7 +174,7 @@ async def test_move_email_tool_with_destination_folder_id(mock_ews_client):
 
     assert result["success"] is True
     assert result["destination_folder"] == "Archive 2026"
-    mock_resolve.assert_called_once_with(mock_ews_client.account, folder_id)
+    mock_resolve.assert_called_once_with(ANY, folder_id)
     mock_email.move.assert_called_once_with(mock_folder)
 
 

--- a/tests/test_email_tools.py
+++ b/tests/test_email_tools.py
@@ -139,17 +139,54 @@ async def test_move_email_tool(mock_ews_client):
     """Test moving email."""
     tool = MoveEmailTool(mock_ews_client)
 
-    # Mock email
     mock_email = MagicMock()
-    mock_ews_client.account.inbox.get.return_value = mock_email
+    mock_folder = MagicMock()
+    mock_folder.name = "Sent"
 
-    result = await tool.execute(
-        message_id="test-id",
-        destination_folder="sent"
-    )
+    with patch("src.tools.email_tools.find_message_for_account", return_value=mock_email):
+        with patch("src.tools.email_tools.resolve_folder_for_account", return_value=mock_folder):
+            result = await tool.execute(
+                message_id="test-id",
+                destination_folder="sent"
+            )
 
     assert result["success"] is True
-    mock_email.move.assert_called_once()
+    assert result["destination_folder"] == "Sent"
+    mock_email.move.assert_called_once_with(mock_folder)
+
+
+@pytest.mark.asyncio
+async def test_move_email_tool_with_destination_folder_id(mock_ews_client):
+    """Test moving email using destination folder ID."""
+    tool = MoveEmailTool(mock_ews_client)
+
+    mock_email = MagicMock()
+    mock_folder = MagicMock()
+    mock_folder.name = "Archive 2026"
+    folder_id = "AAMk" + ("x" * 60)
+
+    with patch("src.tools.email_tools.find_message_for_account", return_value=mock_email):
+        with patch("src.tools.email_tools.resolve_folder_for_account", return_value=mock_folder) as mock_resolve:
+            result = await tool.execute(
+                message_id="test-id",
+                destination_folder_id=folder_id
+            )
+
+    assert result["success"] is True
+    assert result["destination_folder"] == "Archive 2026"
+    mock_resolve.assert_called_once_with(mock_ews_client.account, folder_id)
+    mock_email.move.assert_called_once_with(mock_folder)
+
+
+@pytest.mark.asyncio
+async def test_move_email_tool_requires_destination(mock_ews_client):
+    """Test move_email requires folder name or folder ID."""
+    tool = MoveEmailTool(mock_ews_client)
+
+    with pytest.raises(Exception) as exc_info:
+        await tool.execute(message_id="test-id")
+
+    assert "either destination_folder or destination_folder_id is required" in str(exc_info.value).lower()
 
 
 @pytest.mark.asyncio

--- a/tests/test_folder_management.py
+++ b/tests/test_folder_management.py
@@ -82,6 +82,40 @@ async def test_create_folder_invalid_parent(mock_ews_client):
 
 
 @pytest.mark.asyncio
+async def test_create_folder_with_parent_folder_id(mock_ews_client):
+    """Test creating folder using parent folder ID."""
+    tool = ManageFolderTool(mock_ews_client)
+
+    folder_id = "AAMk" + ("p" * 60)
+    mock_parent = MagicMock()
+    mock_parent.id = folder_id
+    mock_parent.name = "Applications"
+    mock_parent.children = []
+
+    mock_root = MagicMock()
+    mock_root.id = "root-id"
+    mock_root.children = [mock_parent]
+    mock_ews_client.account.root = mock_root
+
+    with patch('src.tools.folder_tools.Folder') as mock_folder_class:
+        mock_folder = MagicMock()
+        mock_folder.id = "new-folder-id"
+        mock_folder.name = "ISA"
+        mock_folder_class.return_value = mock_folder
+
+        result = await tool.execute(
+            action="create",
+            folder_name="ISA",
+            parent_folder_id=folder_id
+        )
+
+    assert result["success"] is True
+    assert result["folder_name"] == "ISA"
+    assert result["parent_folder"] == "Applications"
+    mock_folder.save.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_delete_folder_soft(mock_ews_client):
     """Test soft deleting a folder."""
     tool = ManageFolderTool(mock_ews_client)

--- a/tests/test_folder_management.py
+++ b/tests/test_folder_management.py
@@ -85,6 +85,7 @@ async def test_create_folder_invalid_parent(mock_ews_client):
 async def test_create_folder_with_parent_folder_id(mock_ews_client):
     """Test creating folder using parent folder ID."""
     tool = ManageFolderTool(mock_ews_client)
+    mock_ews_client.get_account.return_value = mock_ews_client.account
 
     folder_id = "AAMk" + ("p" * 60)
     mock_parent = MagicMock()

--- a/tests/test_folder_tools.py
+++ b/tests/test_folder_tools.py
@@ -169,3 +169,67 @@ async def test_list_folders_unknown_parent(mock_ews_client):
         )
 
     assert "unknown parent folder" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_list_folders_with_parent_folder_id(mock_ews_client):
+    """Test listing folders using parent folder ID."""
+    tool = ListFoldersTool(mock_ews_client)
+
+    folder_id = "AAMk" + ("y" * 60)
+
+    mock_child = MagicMock()
+    mock_child.id = "child-1"
+    mock_child.name = "Sub"
+    mock_child.parent_folder_id = folder_id
+    mock_child.folder_class = "IPF.Note"
+    mock_child.child_folder_count = 0
+    mock_child.children = []
+
+    mock_parent = MagicMock()
+    mock_parent.id = folder_id
+    mock_parent.name = "Applications"
+    mock_parent.parent_folder_id = "root-id"
+    mock_parent.folder_class = "IPF.Note"
+    mock_parent.child_folder_count = 1
+    mock_parent.children = [mock_child]
+
+    mock_root = MagicMock()
+    mock_root.id = "root-id"
+    mock_root.name = "Root"
+    mock_root.parent_folder_id = ""
+    mock_root.folder_class = "IPF.Root"
+    mock_root.child_folder_count = 1
+    mock_root.children = [mock_parent]
+
+    mock_ews_client.account.root = mock_root
+
+    result = await tool.execute(
+        parent_folder_id=folder_id,
+        depth=2,
+        include_hidden=False,
+        include_counts=False
+    )
+
+    assert result["success"] is True
+    assert result["folder_tree"]["name"] == "Applications"
+    assert result["parent_folder"] == "Applications"
+
+
+@pytest.mark.asyncio
+async def test_list_folders_unknown_parent_folder_id(mock_ews_client):
+    """Test listing folders with unknown parent folder ID."""
+    tool = ListFoldersTool(mock_ews_client)
+
+    mock_root = MagicMock()
+    mock_root.id = "root-id"
+    mock_root.children = []
+    mock_ews_client.account.root = mock_root
+
+    with pytest.raises(Exception) as exc_info:
+        await tool.execute(
+            parent_folder_id="AAMk" + ("z" * 60),
+            depth=1
+        )
+
+    assert "parent folder not found" in str(exc_info.value).lower()

--- a/tests/test_folder_tools.py
+++ b/tests/test_folder_tools.py
@@ -175,6 +175,7 @@ async def test_list_folders_unknown_parent(mock_ews_client):
 async def test_list_folders_with_parent_folder_id(mock_ews_client):
     """Test listing folders using parent folder ID."""
     tool = ListFoldersTool(mock_ews_client)
+    mock_ews_client.get_account.return_value = mock_ews_client.account
 
     folder_id = "AAMk" + ("y" * 60)
 
@@ -220,6 +221,7 @@ async def test_list_folders_with_parent_folder_id(mock_ews_client):
 async def test_list_folders_unknown_parent_folder_id(mock_ews_client):
     """Test listing folders with unknown parent folder ID."""
     tool = ListFoldersTool(mock_ews_client)
+    mock_ews_client.get_account.return_value = mock_ews_client.account
 
     mock_root = MagicMock()
     mock_root.id = "root-id"

--- a/tests/test_folder_tools.py
+++ b/tests/test_folder_tools.py
@@ -3,7 +3,7 @@
 import pytest
 from unittest.mock import MagicMock
 
-from src.tools.folder_tools import ListFoldersTool
+from src.tools.folder_tools import ListFoldersTool, FindFolderTool
 
 
 @pytest.mark.asyncio
@@ -235,3 +235,128 @@ async def test_list_folders_unknown_parent_folder_id(mock_ews_client):
         )
 
     assert "parent folder not found" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_find_folder_exact_and_path_matches(mock_ews_client):
+    """Test folder discovery with exact and path matching."""
+    tool = FindFolderTool(mock_ews_client)
+    mock_ews_client.get_account.return_value = mock_ews_client.account
+
+    isa = MagicMock()
+    isa.id = "isa-id"
+    isa.name = "ISA"
+    isa.parent_folder_id = "apps-id"
+    isa.folder_class = "IPF.Note"
+    isa.child_folder_count = 0
+    isa.children = []
+
+    apps = MagicMock()
+    apps.id = "apps-id"
+    apps.name = "Applications"
+    apps.parent_folder_id = "root-id"
+    apps.folder_class = "IPF.Note"
+    apps.child_folder_count = 1
+    apps.children = [isa]
+
+    root = MagicMock()
+    root.id = "root-id"
+    root.name = "Root"
+    root.parent_folder_id = ""
+    root.folder_class = "IPF.Root"
+    root.child_folder_count = 1
+    root.children = [apps]
+    mock_ews_client.account.root = root
+
+    result = await tool.execute(
+        query="Root/Applications/ISA",
+        depth=4,
+        match_mode="auto"
+    )
+
+    assert result["success"] is True
+    assert result["total_matches"] >= 1
+    assert result["matches"][0]["id"] == "isa-id"
+    assert result["matches"][0]["match_type"] in {"exact", "prefix", "contains"}
+
+
+@pytest.mark.asyncio
+async def test_find_folder_fuzzy_match(mock_ews_client):
+    """Test fuzzy folder matching."""
+    tool = FindFolderTool(mock_ews_client)
+    mock_ews_client.get_account.return_value = mock_ews_client.account
+
+    reports = MagicMock()
+    reports.id = "reports-id"
+    reports.name = "Quarterly Reports"
+    reports.parent_folder_id = "root-id"
+    reports.folder_class = "IPF.Note"
+    reports.child_folder_count = 0
+    reports.children = []
+
+    root = MagicMock()
+    root.id = "root-id"
+    root.name = "Root"
+    root.parent_folder_id = ""
+    root.folder_class = "IPF.Root"
+    root.child_folder_count = 1
+    root.children = [reports]
+    mock_ews_client.account.root = root
+
+    result = await tool.execute(
+        query="Quarter report",
+        match_mode="fuzzy",
+        depth=3
+    )
+
+    assert result["success"] is True
+    assert result["total_matches"] >= 1
+    assert result["matches"][0]["id"] == "reports-id"
+    assert result["matches"][0]["match_type"] == "fuzzy"
+
+
+@pytest.mark.asyncio
+async def test_find_folder_without_query_returns_scoped_list(mock_ews_client):
+    """Test folder discovery without query (list mode)."""
+    tool = FindFolderTool(mock_ews_client)
+    mock_ews_client.get_account.return_value = mock_ews_client.account
+
+    sub = MagicMock()
+    sub.id = "sub-id"
+    sub.name = "Sub"
+    sub.parent_folder_id = "inbox-id"
+    sub.folder_class = "IPF.Note"
+    sub.child_folder_count = 0
+    sub.children = []
+
+    inbox = MagicMock()
+    inbox.id = "inbox-id"
+    inbox.name = "Inbox"
+    inbox.parent_folder_id = "root-id"
+    inbox.folder_class = "IPF.Note"
+    inbox.child_folder_count = 1
+    inbox.children = [sub]
+
+    root = MagicMock()
+    root.id = "root-id"
+    root.name = "Root"
+    root.parent_folder_id = ""
+    root.folder_class = "IPF.Root"
+    root.child_folder_count = 1
+    root.children = [inbox]
+
+    mock_ews_client.account.root = root
+    mock_ews_client.account.inbox = inbox
+
+    result = await tool.execute(
+        parent_folder="inbox",
+        depth=2,
+        max_results=10
+    )
+
+    assert result["success"] is True
+    assert result["query"] == ""
+    assert result["total_matches"] >= 2
+    paths = [entry["path"] for entry in result["matches"]]
+    assert "Inbox" in paths
+    assert "Inbox/Sub" in paths


### PR DESCRIPTION
## Summary
- add `find_folder` for live folder discovery by name or path
- support exact, prefix, contains, and fuzzy matching for folder lookup
- make folder discovery usable as the first step before ID-based folder operations

## Details
- add new `find_folder` tool in `folder_tools.py`
- return folder candidates with ID, name, path, parent folder ID, folder class, and child folder count
- support scoped search via `parent_folder` or `parent_folder_id`
- support list mode when no query is provided
- reuse user-visible folder filtering so hidden/system folders are excluded by default
- register `find_folder` in tool exports and server startup

## Automated Tests
- add tests for exact and path-based matches
- add tests for fuzzy matching
- add tests for scoped listing without a query
- keep the folder-ID tests from the previous branch green on the combined branch

## Manual Validation
Validated successfully against a real mailbox on `issue-2`:

- `find_folder(query="Project Alpha")` returned multiple real candidates for similarly named folders
- `find_folder(query="Nested Team Folder")` returned the correct deep folder as the top exact match
- the discovered parent folder ID was reused successfully with `list_folders(parent_folder_id=...)`
- the discovered folder ID was reused successfully with `manage_folder(action="create", parent_folder_id=...)`
- this confirms the intended end-to-end flow:
  - discover folder
  - take returned folder ID
  - use that ID in folder operations

## Notes
- this branch builds directly on top of the previous folder-ID support branch
- manual validation shows that `find_folder` is especially useful when folder names are ambiguous or when the target folder is nested
- `list_folders(include_counts=true)` also returned plausible counts during final live validation

Closes #81
