### PR TITLE
Add Windows wrapper entrypoint for Claude Desktop MSIX cwd issue

### DIFF
--- a/run_server.py
+++ b/run_server.py
@@ -1,0 +1,7 @@
+import os
+import sys
+import runpy
+
+os.chdir(r"C:\Tools\ews-mcp")
+sys.path.insert(0, r"C:\Tools\ews-mcp")
+runpy.run_module("src.main", run_name="__main__")


### PR DESCRIPTION
## Summary
- add `run_server.py` as a Windows wrapper entrypoint for local Claude Desktop setups
- ensure the repository root is used as working directory before starting `src.main`
- ensure the repository root is inserted into `sys.path` before module startup

## Problem
On the Windows Store / MSIX version of Claude Desktop, the configured `cwd` may not always be applied correctly to the spawned Python process.

Without a wrapper entrypoint, local startup can fail with errors such as:
- `ModuleNotFoundError: No module named 'src'`

## Solution
- add a tiny `run_server.py` wrapper
- call `os.chdir()` to switch into the repository root
- call `sys.path.insert(0, ...)` so `src.main` can be imported reliably
- start the actual server via `runpy.run_module("src.main", run_name="__main__")`

## Validation
- local startup with `venv\Scripts\python.exe run_server.py` succeeds
- the server connects successfully and registers the MCP tools
- this matches the documented local setup workaround for Claude Desktop on Windows

## Notes
- this is intentionally separate from the folder feature PRs
- this change is a startup compatibility fix for local Windows/MSIX usage

Closes #83
