### PR TITLE
feat: add draft reply and forward tools with Outlook-compatible HTML body generation

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,7 @@ from .openapi_adapter import OpenAPIAdapter
 
 # Import all tool classes (up to 40 tools total: 36 base + 4 AI)
 from .tools import (
-    CreateDraftTool,
+    CreateDraftTool, CreateReplyDraftTool,
     SendEmailTool, ReadEmailsTool, SearchEmailsTool, GetEmailDetailsTool,
     DeleteEmailTool, MoveEmailTool, UpdateEmailTool, CopyEmailTool,
     ReplyEmailTool, ForwardEmailTool,
@@ -201,6 +201,7 @@ class EWSMCPServer:
         if self.settings.enable_email:
             tool_classes.extend([
                 CreateDraftTool,
+                CreateReplyDraftTool,
                 SendEmailTool,
                 ReadEmailsTool,
                 SearchEmailsTool,
@@ -212,7 +213,7 @@ class EWSMCPServer:
                 ReplyEmailTool,
                 ForwardEmailTool
             ])
-            self.logger.info("Email tools enabled (11 tools)")
+            self.logger.info("Email tools enabled (12 tools)")
 
         # Attachment tools (5 tools)
         if self.settings.enable_email:

--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,7 @@ from .openapi_adapter import OpenAPIAdapter
 
 # Import all tool classes (up to 40 tools total: 36 base + 4 AI)
 from .tools import (
-    CreateDraftTool, CreateReplyDraftTool,
+    CreateDraftTool, CreateReplyDraftTool, CreateForwardDraftTool,
     SendEmailTool, ReadEmailsTool, SearchEmailsTool, GetEmailDetailsTool,
     DeleteEmailTool, MoveEmailTool, UpdateEmailTool, CopyEmailTool,
     ReplyEmailTool, ForwardEmailTool,
@@ -202,6 +202,7 @@ class EWSMCPServer:
             tool_classes.extend([
                 CreateDraftTool,
                 CreateReplyDraftTool,
+                CreateForwardDraftTool,
                 SendEmailTool,
                 ReadEmailsTool,
                 SearchEmailsTool,
@@ -213,7 +214,7 @@ class EWSMCPServer:
                 ReplyEmailTool,
                 ForwardEmailTool
             ])
-            self.logger.info("Email tools enabled (12 tools)")
+            self.logger.info("Email tools enabled (13 tools)")
 
         # Attachment tools (5 tools)
         if self.settings.enable_email:

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,7 +1,7 @@
 """MCP Tools for EWS operations."""
 
 from .email_tools import SendEmailTool, ReadEmailsTool, SearchEmailsTool, GetEmailDetailsTool, DeleteEmailTool, MoveEmailTool, UpdateEmailTool, CopyEmailTool, ReplyEmailTool, ForwardEmailTool
-from .email_tools_draft import CreateDraftTool
+from .email_tools_draft import CreateDraftTool, CreateReplyDraftTool
 from .calendar_tools import CreateAppointmentTool, GetCalendarTool, UpdateAppointmentTool, DeleteAppointmentTool, RespondToMeetingTool, CheckAvailabilityTool, FindMeetingTimesTool
 from .contact_tools import CreateContactTool, UpdateContactTool, DeleteContactTool
 from .task_tools import CreateTaskTool, GetTasksTool, UpdateTaskTool, CompleteTaskTool, DeleteTaskTool
@@ -15,6 +15,7 @@ from .contact_intelligence_tools import FindPersonTool, AnalyzeContactsTool
 __all__ = [
     # Email tools (11)
     "CreateDraftTool",
+    "CreateReplyDraftTool",
     "SendEmailTool",
     "ReadEmailsTool",
     "SearchEmailsTool",

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,7 +1,7 @@
 """MCP Tools for EWS operations."""
 
 from .email_tools import SendEmailTool, ReadEmailsTool, SearchEmailsTool, GetEmailDetailsTool, DeleteEmailTool, MoveEmailTool, UpdateEmailTool, CopyEmailTool, ReplyEmailTool, ForwardEmailTool
-from .email_tools_draft import CreateDraftTool, CreateReplyDraftTool
+from .email_tools_draft import CreateDraftTool, CreateReplyDraftTool, CreateForwardDraftTool
 from .calendar_tools import CreateAppointmentTool, GetCalendarTool, UpdateAppointmentTool, DeleteAppointmentTool, RespondToMeetingTool, CheckAvailabilityTool, FindMeetingTimesTool
 from .contact_tools import CreateContactTool, UpdateContactTool, DeleteContactTool
 from .task_tools import CreateTaskTool, GetTasksTool, UpdateTaskTool, CompleteTaskTool, DeleteTaskTool
@@ -16,6 +16,7 @@ __all__ = [
     # Email tools (11)
     "CreateDraftTool",
     "CreateReplyDraftTool",
+    "CreateForwardDraftTool",
     "SendEmailTool",
     "ReadEmailsTool",
     "SearchEmailsTool",

--- a/src/tools/email_tools_draft.py
+++ b/src/tools/email_tools_draft.py
@@ -1,4 +1,4 @@
-"""Draft email tool for EWS MCP Server."""
+"""Draft email tools for EWS MCP Server."""
 import os
 import re
 from typing import Any, Dict
@@ -6,9 +6,22 @@ from datetime import datetime
 from exchangelib import Message, Mailbox, FileAttachment, HTMLBody, Body
 
 from .base import BaseTool
+from .email_tools import (
+    extract_body_html,
+    clean_original_body_for_signature,
+    format_forward_header,
+    copy_attachments_to_message,
+)
 from ..models import SendEmailRequest
 from ..exceptions import ToolExecutionError
-from ..utils import format_success_response, ews_id_to_str, attach_inline_files, INLINE_ATTACHMENTS_SCHEMA
+from ..utils import (
+    format_success_response,
+    safe_get,
+    find_message_for_account,
+    ews_id_to_str,
+    attach_inline_files,
+    INLINE_ATTACHMENTS_SCHEMA,
+)
 
 
 class CreateDraftTool(BaseTool):
@@ -148,3 +161,164 @@ class CreateDraftTool(BaseTool):
         except Exception as e:
             self.logger.error(f"Failed to create draft: {e}")
             raise ToolExecutionError(f"Failed to create draft: {e}")
+
+
+class CreateReplyDraftTool(BaseTool):
+    """Tool for creating reply drafts in the Drafts folder."""
+
+    def get_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "create_reply_draft",
+            "description": "Create a reply draft in the Drafts folder for review before sending.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "message_id": {
+                        "type": "string",
+                        "description": "The Exchange message ID of the email to reply to"
+                    },
+                    "body": {
+                        "type": "string",
+                        "description": "Optional reply body to include in the draft"
+                    },
+                    "reply_all": {
+                        "type": "boolean",
+                        "description": "If true, create a reply-all draft; otherwise create a reply draft",
+                        "default": False
+                    },
+                    "attachments": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "File paths to attach to the draft reply (optional)"
+                    },
+                    **INLINE_ATTACHMENTS_SCHEMA,
+                    "target_mailbox": {
+                        "type": "string",
+                        "description": "Email address to create the draft on behalf of (requires impersonation/delegate access)"
+                    }
+                },
+                "required": ["message_id"]
+            }
+        }
+
+    async def execute(self, **kwargs) -> Dict[str, Any]:
+        """Create a reply draft via EWS and save it to Drafts."""
+        message_id = kwargs.get("message_id")
+        reply_all = kwargs.get("reply_all", False)
+        attachments = kwargs.get("attachments", [])
+        target_mailbox = kwargs.get("target_mailbox")
+        body = (kwargs.get("body") or "").strip()
+
+        if not message_id:
+            raise ToolExecutionError("message_id is required")
+
+        try:
+            account = self.get_account(target_mailbox)
+            mailbox = self.get_mailbox_info(target_mailbox)
+
+            original_message = find_message_for_account(account, message_id)
+            original_subject = safe_get(original_message, "subject", "") or ""
+            reply_subject = f"RE: {original_subject}" if original_subject else "RE:"
+            original_sender = safe_get(original_message, "sender", None)
+            original_from_email = ""
+            if original_sender and hasattr(original_sender, "email_address"):
+                original_from_email = original_sender.email_address or ""
+
+            original_to = [
+                r.email_address
+                for r in (safe_get(original_message, "to_recipients", []) or [])
+                if r and hasattr(r, "email_address") and r.email_address
+            ]
+            original_cc = [
+                r.email_address
+                for r in (safe_get(original_message, "cc_recipients", []) or [])
+                if r and hasattr(r, "email_address") and r.email_address
+            ]
+
+            if reply_all:
+                seen = set()
+                reply_to_recipients = []
+                for email in [original_from_email] + original_to + original_cc:
+                    if not email or email == account.primary_smtp_address or email in seen:
+                        continue
+                    seen.add(email)
+                    reply_to_recipients.append(Mailbox(email_address=email))
+            else:
+                reply_to_recipients = [Mailbox(email_address=original_from_email)]
+
+            header = format_forward_header(original_message)
+            original_body_html = extract_body_html(original_message)
+            original_body_html = clean_original_body_for_signature(original_body_html)
+
+            headers_html = f'''<p style="font-size:11pt;font-family:Calibri,sans-serif;">
+<b>From:</b> {header['from']}<br/>
+<b>Sent:</b> {header['sent']}<br/>'''
+            if header["to"]:
+                headers_html += f'''<b>To:</b> {header['to']}<br/>'''
+            if header["cc"]:
+                headers_html += f'''<b>Cc:</b> {header['cc']}<br/>'''
+            headers_html += f'''<b>Subject:</b> {header['subject']}
+</p>'''
+
+            complete_body = f'''<div class="WordSection1">
+<p class="MsoNormal" style="font-size:11pt;font-family:Calibri,sans-serif;">{body}</p>
+</div>
+<div style="border:none;border-top:solid #E1E1E1 1.0pt;padding:3.0pt 0in 0in 0in">
+{headers_html}
+</div>
+{original_body_html}'''
+
+            message = Message(
+                account=account,
+                subject=reply_subject,
+                body=HTMLBody(complete_body),
+                to_recipients=reply_to_recipients,
+                folder=account.drafts,
+            )
+
+            inline_count, _ = copy_attachments_to_message(original_message, message)
+            attachment_count = 0
+
+            for file_path in attachments:
+                try:
+                    file_name = os.path.basename(file_path)
+                    with open(file_path, "rb") as f:
+                        content = f.read()
+                    message.attach(FileAttachment(name=file_name, content=content))
+                    attachment_count += 1
+                except FileNotFoundError:
+                    raise ToolExecutionError(f"Attachment file not found: {file_path}")
+                except PermissionError:
+                    raise ToolExecutionError(f"Permission denied reading attachment: {file_path}")
+                except Exception as e:
+                    raise ToolExecutionError(f"Failed to attach file {file_path}: {e}")
+
+            inline_b64_count = attach_inline_files(message, kwargs.get("inline_attachments", []))
+            attachment_count += inline_b64_count
+            attachment_count += inline_count
+
+            message.save()
+            draft_message_id = ews_id_to_str(message.id)
+            reply_to = header.get("from", "")
+
+            self.logger.info(f"Reply draft saved for message {message_id} in mailbox: {mailbox}")
+
+            return format_success_response(
+                "Reply draft created successfully - check your Drafts folder in OWA/Outlook",
+                message_id=draft_message_id,
+                original_message_id=message_id,
+                original_subject=original_subject,
+                reply_subject=reply_subject,
+                reply_to=reply_to,
+                reply_all=reply_all,
+                attachments_count=attachment_count,
+                inline_attachments_preserved=inline_count,
+                created_time=datetime.now().isoformat(),
+                mailbox=mailbox
+            )
+
+        except ToolExecutionError:
+            raise
+        except Exception as e:
+            self.logger.error(f"Failed to create reply draft: {e}")
+            raise ToolExecutionError(f"Failed to create reply draft: {e}")

--- a/src/tools/email_tools_draft.py
+++ b/src/tools/email_tools_draft.py
@@ -322,3 +322,158 @@ class CreateReplyDraftTool(BaseTool):
         except Exception as e:
             self.logger.error(f"Failed to create reply draft: {e}")
             raise ToolExecutionError(f"Failed to create reply draft: {e}")
+
+
+class CreateForwardDraftTool(BaseTool):
+    """Tool for creating forward drafts in the Drafts folder."""
+
+    def get_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "create_forward_draft",
+            "description": "Create a forward draft in the Drafts folder for review before sending.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "message_id": {
+                        "type": "string",
+                        "description": "The Exchange message ID of the email to forward"
+                    },
+                    "to": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "List of recipient email addresses"
+                    },
+                    "body": {
+                        "type": "string",
+                        "description": "Optional message to add before the forwarded content"
+                    },
+                    "cc": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "CC recipients (optional)"
+                    },
+                    "bcc": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "BCC recipients (optional)"
+                    },
+                    "attachments": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Additional file paths to attach to the draft (optional)"
+                    },
+                    **INLINE_ATTACHMENTS_SCHEMA,
+                    "target_mailbox": {
+                        "type": "string",
+                        "description": "Email address to create the draft on behalf of (requires impersonation/delegate access)"
+                    }
+                },
+                "required": ["message_id", "to"]
+            }
+        }
+
+    async def execute(self, **kwargs) -> Dict[str, Any]:
+        """Create a forward draft via EWS and save it to Drafts."""
+        message_id = kwargs.get("message_id")
+        to_recipients = kwargs.get("to", [])
+        body = (kwargs.get("body") or "").strip()
+        cc_recipients = kwargs.get("cc", [])
+        bcc_recipients = kwargs.get("bcc", [])
+        attachments = kwargs.get("attachments", [])
+        target_mailbox = kwargs.get("target_mailbox")
+
+        if not message_id:
+            raise ToolExecutionError("message_id is required")
+        if not to_recipients:
+            raise ToolExecutionError("to recipients are required")
+
+        try:
+            account = self.get_account(target_mailbox)
+            mailbox = self.get_mailbox_info(target_mailbox)
+
+            original_message = find_message_for_account(account, message_id)
+            original_subject = safe_get(original_message, "subject", "") or ""
+            forward_subject = f"FW: {original_subject}" if original_subject else "FW:"
+
+            header = format_forward_header(original_message)
+            original_body_html = extract_body_html(original_message)
+            original_body_html = clean_original_body_for_signature(original_body_html)
+
+            headers_html = f'''<p style="font-size:11pt;font-family:Calibri,sans-serif;">
+<b>From:</b> {header['from']}<br/>
+<b>Date:</b> {header['sent']}<br/>
+<b>Subject:</b> {header['subject']}<br/>'''
+            if header["to"]:
+                headers_html += f'''<b>To:</b> {header['to']}<br/>'''
+            if header["cc"]:
+                headers_html += f'''<b>Cc:</b> {header['cc']}<br/>'''
+            headers_html += "</p>"
+
+            complete_body = f'''<div class="WordSection1">
+<p class="MsoNormal" style="font-size:11pt;font-family:Calibri,sans-serif;">{body}</p>
+</div>
+<div style="border:none;border-top:solid #E1E1E1 1.0pt;padding:3.0pt 0in 0in 0in">
+{headers_html}
+</div>
+{original_body_html}'''
+
+            message = Message(
+                account=account,
+                subject=forward_subject,
+                body=HTMLBody(complete_body),
+                to_recipients=[Mailbox(email_address=email) for email in to_recipients],
+                folder=account.drafts,
+            )
+
+            if cc_recipients:
+                message.cc_recipients = [Mailbox(email_address=email) for email in cc_recipients]
+            if bcc_recipients:
+                message.bcc_recipients = [Mailbox(email_address=email) for email in bcc_recipients]
+
+            inline_count, regular_count = copy_attachments_to_message(original_message, message)
+            original_attachment_count = inline_count + regular_count
+            additional_attachment_count = 0
+
+            for file_path in attachments:
+                try:
+                    file_name = os.path.basename(file_path)
+                    with open(file_path, "rb") as f:
+                        content = f.read()
+                    message.attach(FileAttachment(name=file_name, content=content))
+                    additional_attachment_count += 1
+                except FileNotFoundError:
+                    raise ToolExecutionError(f"Attachment file not found: {file_path}")
+                except PermissionError:
+                    raise ToolExecutionError(f"Permission denied reading attachment: {file_path}")
+                except Exception as e:
+                    raise ToolExecutionError(f"Failed to attach file {file_path}: {e}")
+
+            inline_b64_count = attach_inline_files(message, kwargs.get("inline_attachments", []))
+            additional_attachment_count += inline_b64_count
+
+            message.save()
+            draft_message_id = ews_id_to_str(message.id)
+
+            self.logger.info(f"Forward draft saved for message {message_id} in mailbox: {mailbox}")
+
+            return format_success_response(
+                "Forward draft created successfully - check your Drafts folder in OWA/Outlook",
+                message_id=draft_message_id,
+                original_message_id=message_id,
+                original_subject=original_subject,
+                forward_subject=forward_subject,
+                forwarded_to=to_recipients,
+                cc=cc_recipients if cc_recipients else None,
+                bcc=bcc_recipients if bcc_recipients else None,
+                attachments_included=original_attachment_count,
+                inline_attachments_preserved=inline_count,
+                additional_attachments=additional_attachment_count,
+                created_time=datetime.now().isoformat(),
+                mailbox=mailbox
+            )
+
+        except ToolExecutionError:
+            raise
+        except Exception as e:
+            self.logger.error(f"Failed to create forward draft: {e}")
+            raise ToolExecutionError(f"Failed to create forward draft: {e}")

--- a/tests/test_email_tools.py
+++ b/tests/test_email_tools.py
@@ -1,6 +1,7 @@
 """Tests for email tools."""
 
 import pytest
+from datetime import datetime
 from unittest.mock import ANY, Mock, MagicMock, patch
 
 from src.tools.email_tools import (
@@ -13,7 +14,7 @@ from src.tools.email_tools import (
     UpdateEmailTool,
     CopyEmailTool
 )
-from src.tools.email_tools_draft import CreateDraftTool
+from src.tools.email_tools_draft import CreateDraftTool, CreateReplyDraftTool
 
 
 @pytest.mark.asyncio
@@ -67,6 +68,93 @@ async def test_create_draft_tool_saves_draft(mock_ews_client, sample_email):
         assert result["recipients"] == sample_email["to"]
         mock_msg.save.assert_called_once()
         mock_msg.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_reply_draft_tool_saves_html_draft(mock_ews_client):
+    """Test creating a reply draft saves a Message to Drafts instead of sending."""
+    tool = CreateReplyDraftTool(mock_ews_client)
+    mock_ews_client.get_account = Mock(return_value=mock_ews_client.account)
+    mock_ews_client.account.drafts = MagicMock()
+    mock_ews_client.account.primary_smtp_address = "test@example.com"
+
+    original_message = MagicMock()
+    original_message.subject = "Original Subject"
+    original_message.sender.email_address = "sender@example.com"
+    original_message.sender.name = "Sender Name"
+    original_message.to_recipients = [MagicMock(email_address="test@example.com", name="Test User")]
+    original_message.cc_recipients = []
+    original_message.datetime_sent = datetime(2025, 1, 1, 10, 0, 0)
+    original_message.body = MagicMock()
+    original_message.body.body = "<html><body><p>Original HTML</p></body></html>"
+    original_message.attachments = []
+
+    with patch("src.tools.email_tools_draft.find_message_for_account", return_value=original_message):
+        with patch("src.tools.email_tools_draft.Message") as mock_message:
+            mock_msg = MagicMock()
+            mock_msg.id = "reply-draft-id"
+            mock_message.return_value = mock_msg
+
+            result = await tool.execute(
+                message_id="orig-id",
+                body="Reply body"
+            )
+
+    assert result["success"] is True
+    assert "reply draft created successfully" in result["message"].lower()
+    assert result["original_subject"] == "Original Subject"
+    assert result["reply_subject"] == "RE: Original Subject"
+    assert result["message_id"] == "reply-draft-id"
+    mock_msg.save.assert_called_once()
+    mock_msg.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_reply_draft_tool_reply_all_uses_all_recipients(mock_ews_client):
+    """Test reply-all draft includes sender and original recipients except self."""
+    tool = CreateReplyDraftTool(mock_ews_client)
+    mock_ews_client.get_account = Mock(return_value=mock_ews_client.account)
+    mock_ews_client.account.drafts = MagicMock()
+    mock_ews_client.account.primary_smtp_address = "me@example.com"
+
+    def mailbox(name, email):
+        recipient = MagicMock()
+        recipient.name = name
+        recipient.email_address = email
+        return recipient
+
+    original_message = MagicMock()
+    original_message.subject = "Original Subject"
+    original_message.sender.email_address = "sender@example.com"
+    original_message.sender.name = "Sender Name"
+    original_message.to_recipients = [
+        mailbox("Me", "me@example.com"),
+        mailbox("Teammate", "team@example.com"),
+    ]
+    original_message.cc_recipients = [
+        mailbox("Other", "other@example.com"),
+        mailbox("Teammate", "team@example.com"),
+    ]
+    original_message.datetime_sent = datetime(2025, 1, 1, 10, 0, 0)
+    original_message.body = MagicMock()
+    original_message.body.body = "<p>Original HTML</p>"
+    original_message.attachments = []
+
+    with patch("src.tools.email_tools_draft.find_message_for_account", return_value=original_message):
+        with patch("src.tools.email_tools_draft.Message") as mock_message:
+            mock_msg = MagicMock()
+            mock_msg.id = "reply-all-draft-id"
+            mock_message.return_value = mock_msg
+
+            await tool.execute(
+                message_id="orig-id",
+                body="Reply all body",
+                reply_all=True
+            )
+
+    called_kwargs = mock_message.call_args.kwargs
+    recipients = [recipient.email_address for recipient in called_kwargs["to_recipients"]]
+    assert recipients == ["sender@example.com", "team@example.com", "other@example.com"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_email_tools.py
+++ b/tests/test_email_tools.py
@@ -14,7 +14,7 @@ from src.tools.email_tools import (
     UpdateEmailTool,
     CopyEmailTool
 )
-from src.tools.email_tools_draft import CreateDraftTool, CreateReplyDraftTool
+from src.tools.email_tools_draft import CreateDraftTool, CreateReplyDraftTool, CreateForwardDraftTool
 
 
 @pytest.mark.asyncio
@@ -155,6 +155,84 @@ async def test_create_reply_draft_tool_reply_all_uses_all_recipients(mock_ews_cl
     called_kwargs = mock_message.call_args.kwargs
     recipients = [recipient.email_address for recipient in called_kwargs["to_recipients"]]
     assert recipients == ["sender@example.com", "team@example.com", "other@example.com"]
+
+
+@pytest.mark.asyncio
+async def test_create_forward_draft_tool_saves_html_draft(mock_ews_client):
+    """Test creating a forward draft saves a Message to Drafts instead of sending."""
+    tool = CreateForwardDraftTool(mock_ews_client)
+    mock_ews_client.get_account = Mock(return_value=mock_ews_client.account)
+    mock_ews_client.account.drafts = MagicMock()
+
+    original_message = MagicMock()
+    original_message.subject = "Original Subject"
+    original_message.sender.email_address = "sender@example.com"
+    original_message.sender.name = "Sender Name"
+    original_message.to_recipients = [MagicMock(email_address="me@example.com", name="Me")]
+    original_message.cc_recipients = []
+    original_message.datetime_sent = datetime(2025, 1, 1, 10, 0, 0)
+    original_message.body = MagicMock()
+    original_message.body.body = "<html><body><p>Original HTML</p></body></html>"
+    original_message.attachments = []
+
+    with patch("src.tools.email_tools_draft.find_message_for_account", return_value=original_message):
+        with patch("src.tools.email_tools_draft.Message") as mock_message:
+            mock_msg = MagicMock()
+            mock_msg.id = "forward-draft-id"
+            mock_message.return_value = mock_msg
+
+            result = await tool.execute(
+                message_id="orig-id",
+                to=["target@example.com"],
+                body="Forward body"
+            )
+
+    assert result["success"] is True
+    assert "forward draft created successfully" in result["message"].lower()
+    assert result["original_subject"] == "Original Subject"
+    assert result["forward_subject"] == "FW: Original Subject"
+    assert result["message_id"] == "forward-draft-id"
+    assert result["forwarded_to"] == ["target@example.com"]
+    mock_msg.save.assert_called_once()
+    mock_msg.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_forward_draft_tool_sets_cc_and_bcc(mock_ews_client):
+    """Test forward draft includes CC and BCC recipients."""
+    tool = CreateForwardDraftTool(mock_ews_client)
+    mock_ews_client.get_account = Mock(return_value=mock_ews_client.account)
+    mock_ews_client.account.drafts = MagicMock()
+
+    original_message = MagicMock()
+    original_message.subject = "Original Subject"
+    original_message.sender.email_address = "sender@example.com"
+    original_message.sender.name = "Sender Name"
+    original_message.to_recipients = []
+    original_message.cc_recipients = []
+    original_message.datetime_sent = datetime(2025, 1, 1, 10, 0, 0)
+    original_message.body = MagicMock()
+    original_message.body.body = "<p>Original HTML</p>"
+    original_message.attachments = []
+
+    with patch("src.tools.email_tools_draft.find_message_for_account", return_value=original_message):
+        with patch("src.tools.email_tools_draft.Message") as mock_message:
+            mock_msg = MagicMock()
+            mock_msg.id = "forward-draft-id"
+            mock_message.return_value = mock_msg
+
+            await tool.execute(
+                message_id="orig-id",
+                to=["target@example.com"],
+                cc=["cc@example.com"],
+                bcc=["bcc@example.com"],
+                body="Forward body"
+            )
+
+    called_kwargs = mock_message.call_args.kwargs
+    assert [recipient.email_address for recipient in called_kwargs["to_recipients"]] == ["target@example.com"]
+    assert [recipient.email_address for recipient in mock_msg.cc_recipients] == ["cc@example.com"]
+    assert [recipient.email_address for recipient in mock_msg.bcc_recipients] == ["bcc@example.com"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds two new draft-first email tools:

- `create_reply_draft`
- `create_forward_draft`

These tools create reply/forward drafts in the Drafts folder instead of sending immediately, while preserving Outlook-compatible HTML quoting/body structure for review-before-send workflows.

Closes #88.

## What changed

- added `CreateReplyDraftTool`
- added `CreateForwardDraftTool`
- registered both tools in the tool exports and server tool list
- added tests covering reply-all behavior, HTML draft creation, and cc/bcc handling for forwards

## Validation

Passed:
- `python -m pytest tests/test_email_tools.py -v -k "reply_draft or forward_draft"`

Known baseline noise in this repo when running the broader file-level suite:
- `python -m pytest tests/test_email_tools.py -v`
- 5 older failures in unrelated mocked paths: `read_emails`, `search_emails`, `delete_email`, `update_email`, `update_email_not_found`

## Notes

This PR intentionally contains only the draft reply/forward feature work. The unrelated Windows/MSIX wrapper fix was not included here.
