### PR TITLE
docs: refresh README, CHANGELOG, and guides to match actual code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## Unreleased — Drafts, folder discovery, availability fixes
+
+### New Tools (+4)
+
+Base tool count: **42** (38 → 42 with the additions below). Total with AI: **46**.
+
+- `create_draft` — create an email draft in the Drafts folder without sending
+- `create_reply_draft` — build a reply draft (quoted original, signature placeholder) for AI preview-before-send
+- `create_forward_draft` — build a forward draft for AI preview-before-send
+- `find_folder` — locate a folder by name or ID anywhere in the mailbox hierarchy
+
+### New Features
+
+- **HTML reply/forward drafts** (`src/tools/email_tools_draft.py`): preserve the original conversation, inline images, CDATA blocks, and Outlook-style quoted headers when composing a reply or forward.
+- **Folder-ID support** on `move_email`, `copy_email`, and `manage_folder`: pass `destination_folder_id` / `parent_folder_id` to resolve by stable Exchange ID instead of display name or path.
+- **Email MIME export** (`get_email_mime`): return the raw RFC-822 MIME of a message.
+- **Attach email to draft** (`attach_email_to_draft`): attach another message as an `.eml` file to a draft.
+- **Windows MSIX wrapper**: new entrypoint script corrects the Claude Desktop MSIX working-directory bug on Windows.
+
+### Bug Fixes
+
+- **Availability parsing** (`check_availability`): correctly parse exchangelib `merged_free_busy` responses.
+- **Availability coverage**: include the current authenticated mailbox in availability checks by default.
+- **Scheduling responses**: clarify free/busy output so the AI can act on the result without a second round-trip.
+- **Reply / forward drafts**: fix threading metadata, signature placement, and duplicate `RE:` / `FW:` prefixes; preserve styles and CDATA in quoted HTML bodies.
+- **Draft attachments**: attachment flow on drafts was failing in certain edge cases; fixed as part of the backlog-folder / availability / draft-attachment work.
+
+### Documentation
+
+- README fully refreshed: accurate tool counts (42 base + 4 AI = 46), full tool tables per category, complete environment-variable reference, corrected architecture diagram, new "Known limitations" section.
+- New draft-workflow and folder-discovery examples.
+
+### Known Limitations (unchanged from v3.4.0)
+
+- The four AI tools (`semantic_search_emails`, `classify_email`, `summarize_email`, `suggest_replies`) do not honor `target_mailbox`; they always act on the primary authenticated mailbox.
+- `read_attachment` extracts PDF / DOCX / XLSX only.
+- The SSE/HTTP transport is unauthenticated and binds `0.0.0.0` by default — put it behind an auth-enforcing reverse proxy for any non-local deployment.
+
+---
+
 ## v3.4.0 — Phase 3+4: Reliability & Code Quality (2026-03-15)
 
 ### New Features
@@ -76,10 +116,12 @@
 | `get_communication_history` | `analyze_contacts` with `analysis_type: "communication_history"` | Add `analysis_type: "communication_history"` |
 | `analyze_network` | `analyze_contacts` with `analysis_type: "overview"` etc. | Use `analyze_contacts(analysis_type="...")` |
 
-### Tool Count
+### Tool Count (at v3.3 release)
 - **Before:** 46 tools (42 base + 4 AI)
-- **After:** 36 tools (32 base + 4 AI)
+- **After v3.3:** 36 tools (32 base + 4 AI)
 - **Reduction:** -10 tools
+
+> **Note:** The base tool count has since grown back to 42 with the addition of `create_draft`, `create_reply_draft`, `create_forward_draft`, `find_folder`, `get_email_mime`, and `attach_email_to_draft` in later releases (see the Unreleased section at the top of this file).
 
 ### New Merged Tools
 

--- a/OPENWEBUI_SETUP.md
+++ b/OPENWEBUI_SETUP.md
@@ -132,7 +132,7 @@ curl -X POST http://localhost:8000/api/tools/find_person \
 
 4. **Auto-Discovery**:
    - Open WebUI will automatically fetch `/openapi.json`
-   - All 36 tools will be discovered and made available
+   - All base tools (42, plus 4 AI tools if enabled) will be discovered and made available
    - Tools will appear in the function picker during chats
 
 5. **Start Using**:

--- a/README.md
+++ b/README.md
@@ -1,21 +1,51 @@
-# EWS MCP Server v3.4
+# EWS MCP Server
 
 <div align="center">
 
-**The Most Powerful AI-Exchange Integration**
+**Microsoft Exchange integration for the Model Context Protocol**
 
-*Transform how AI assistants interact with Microsoft Exchange*
+*Give AI assistants first-class access to mail, calendar, contacts, tasks, and directory services*
 
-[![Version](https://img.shields.io/badge/version-3.4.0-blue.svg)](https://github.com/azizmazrou/ews-mcp)
+[![Version](https://img.shields.io/badge/version-3.4.x-blue.svg)](https://github.com/azizmazrou/ews-mcp)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/azizmazrou/ews-mcp)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-compatible-purple.svg)](https://modelcontextprotocol.io)
 
-[Quick Start](#-quick-start) | [Features](#-feature-highlights) | [Documentation](#-documentation) | [Examples](#-usage-examples)
+[Quick Start](#quick-start) | [Tools](#all-tools) | [Configuration](#configuration) | [Documentation](#documentation)
 
 </div>
 
 ---
+
+## Overview
+
+An MCP server that wraps [exchangelib](https://github.com/ecederstrand/exchangelib) to expose Microsoft Exchange Web Services (EWS) to MCP clients such as Claude Desktop, Open WebUI, or any custom client.
+
+- **46 tools** across email, drafts, attachments, calendar, contacts, directory (GAL), tasks, search, folders, out-of-office, and optional AI helpers
+- **3 auth modes**: OAuth2 (client credentials), Basic, NTLM
+- **Impersonation / delegation**: every non-AI tool accepts a `target_mailbox` to act on shared, delegated, or other users' mailboxes
+- **Two transports**: `stdio` (default, for Claude Desktop) and `sse` (HTTP server with OpenAPI schema, for Open WebUI and REST clients)
+- **Enterprise middleware**: rate limiter, circuit breaker, structured logging, audit log
+
+---
+
+## What's New (since v3.4.0)
+
+### Drafts workflow
+- `create_draft`, `create_reply_draft`, `create_forward_draft` — build reviewable HTML drafts in the Drafts folder before sending
+- HTML reply/forward prototypes preserve the original conversation, inline images, CDATA blocks, and Outlook-style quoted headers
+
+### Folder discovery & IDs
+- New `find_folder` tool — locate a folder by name or ID across the full hierarchy
+- `move_email` and `manage_folder` now accept `destination_folder_id` / `parent_folder_id` to resolve folders by stable Exchange ID rather than by display name
+
+### Availability & scheduling
+- `check_availability` now correctly parses exchangelib free/busy responses and includes the current mailbox by default
+- Scheduling responses clarified so the AI can act on the result without re-prompting
+
+### Platform
+- Windows wrapper entrypoint fixes the Claude Desktop MSIX working-directory issue
+- Signature placement, separator format, and duplicate `RE:` / `FW:` prefixes fixed in reply/forward
 
 ## What's New in v3.4
 
@@ -30,9 +60,9 @@
 
 ## What's New in v3.3
 
-### Tool Consolidation — 46 → 36 Tools
+### Tool Consolidation
 
-v3.3 merges 10 tools into 5 unified tools, reducing token cost by **~55%** per `list_tools` call:
+v3.3 merged 10 redundant tools into 5 unified tools (search, find_person, manage_folder, oof_settings, analyze_contacts). The base tool count later grew again as new features (drafts, find_folder, email MIME, attach-email-to-draft) were added.
 
 | Merge | Before | After |
 |-------|--------|-------|
@@ -56,7 +86,7 @@ manage_folder(action="create", folder_name="Archive")
 manage_folder(action="rename", folder_id="AAMk...", new_name="Old Projects")
 ```
 
-> All **36 tools** support `target_mailbox` parameter!
+> Every **base tool (42)** accepts `target_mailbox` for impersonation/delegation. The 4 optional AI tools currently act only on the primary mailbox — see [Known limitations](#known-limitations).
 
 ---
 
@@ -66,21 +96,18 @@ manage_folder(action="rename", folder_id="AAMk...", new_name="Old Projects")
 <tr>
 <td width="50%">
 
-### Email Operations (10 tools)
-- Send, read, search, delete emails
-- **Reply** with thread preservation
-- **Forward** with inline images intact
-- Move, copy, update email properties
-- **Unified search**: quick, advanced, full-text modes
+### Email (10 tools) + Drafts (3 tools)
+- Send, read, search (quick / advanced / full-text), delete, move, copy, update
+- Reply / Forward with thread + inline-image preservation
+- Draft variants (`create_draft`, `create_reply_draft`, `create_forward_draft`) for AI-review-before-send flows
 
 </td>
 <td width="50%">
 
-### Calendar Management (7 tools)
-- Create/update appointments
-- Meeting invitations & responses
-- Free/busy availability check
-- **AI-powered meeting time finder**
+### Calendar (7 tools)
+- Create, update, delete appointments
+- Accept / decline / tentative responses
+- Free/busy availability + multi-attendee time-finder
 - Timezone-aware scheduling
 
 </td>
@@ -88,18 +115,39 @@ manage_folder(action="rename", folder_id="AAMk...", new_name="Old Projects")
 <tr>
 <td>
 
-### Contact Intelligence (2 tools)
-- **find_person**: Multi-source search (GAL + Contacts + Email)
-- **analyze_contacts**: Network analysis, communication history, VIP detection
+### Contacts + Intelligence (5 tools)
+- `create_contact` / `update_contact` / `delete_contact`
+- `find_person` — unified GAL + contacts + email-history search
+- `analyze_contacts` — communication history, top contacts, domains, dormant, VIPs
+
+</td>
+<td>
+
+### Attachments (7 tools)
+- `list_attachments`, `download_attachment`, `add_attachment`, `delete_attachment`
+- `read_attachment` — text extraction for PDF, DOCX, XLSX
+- `get_email_mime` — raw RFC-822 MIME
+- `attach_email_to_draft` — attach an existing message as `.eml`
+
+</td>
+</tr>
+<tr>
+<td>
+
+### Folders (3) + Tasks (5) + Search (1) + OOF (1)
+- `list_folders`, `find_folder`, `manage_folder` (create/delete/rename/move)
+- Full task CRUD + `complete_task`
+- `search_by_conversation`, `oof_settings` (get/set)
 
 </td>
 <td>
 
 ### Enterprise Features
-- **Impersonation** - Access any mailbox
-- OAuth2 / Basic / NTLM auth
-- Intelligent caching (70% less API calls)
-- Enterprise logging & audit trails
+- Impersonation / delegation on every base tool
+- OAuth2 / Basic / NTLM
+- stdio + SSE/HTTP transports with OpenAPI 3.0 schema
+- Rate limiter, circuit breaker, structured logs, audit log
+- Optional AI layer (OpenAI / Anthropic / OpenAI-compatible)
 
 </td>
 </tr>
@@ -155,89 +203,112 @@ python -m src.main
 
 ---
 
-## All 36 Tools
+## All Tools
 
-### Email Tools (11)
+**Grand total: 46** — 42 base tools (always on, subject to category flags) + 4 optional AI tools.
+
+### Email (10)
 
 | Tool | Description |
 |------|-------------|
-| `send_email` | Send with attachments, CC/BCC, importance levels |
-| `read_emails` | Read from any folder with pagination |
-| `search_emails` | **Unified search** — `mode: "quick"` (default), `"advanced"`, `"full_text"` |
+| `send_email` | Send with attachments, CC/BCC, importance, inline base64 attachments |
+| `read_emails` | Read from any folder with pagination and `unread_only` filter |
+| `search_emails` | Unified search — `mode: "quick"` / `"advanced"` / `"full_text"` |
 | `get_email_details` | Full email content including HTML body |
-| `delete_email` | Soft delete (trash) or permanent removal |
-| `move_email` | Move between folders |
-| `copy_email` | Duplicate to another folder |
-| `update_email` | Mark read/unread, flag, categorize |
-| `reply_email` | Reply with thread & signature preservation |
-| `forward_email` | Forward with full body & inline images |
-| `list_attachments` | List all email attachments |
+| `delete_email` | Soft delete (trash) or `hard_delete: true` for permanent removal |
+| `move_email` | Move to another folder by name or `destination_folder_id` |
+| `copy_email` | Copy to another folder by name or `destination_folder_id` |
+| `update_email` | Mark read/unread, flag status, categories, importance |
+| `reply_email` | Reply with thread + signature + inline-image preservation |
+| `forward_email` | Forward with full body and inline images |
 
-### Attachment Tools (5)
-
-| Tool | Description |
-|------|-------------|
-| `list_attachments` | List attachments with metadata |
-| `download_attachment` | Download as base64 or save to file |
-| `add_attachment` | Attach files to draft emails |
-| `delete_attachment` | Remove attachments |
-| `read_attachment` | Extract text from PDF, DOCX, XLSX, PPTX, CSV, TXT, HTML, ZIP |
-
-### Calendar Tools (7)
+### Email Drafts (3)
 
 | Tool | Description |
 |------|-------------|
-| `create_appointment` | Schedule meetings with attendees |
-| `get_calendar` | Retrieve events for date range |
-| `update_appointment` | Modify existing appointments |
-| `delete_appointment` | Cancel meetings |
-| `respond_to_meeting` | Accept/decline/tentative responses |
-| `check_availability` | Get free/busy information |
-| `find_meeting_times` | AI-powered optimal time suggestions |
+| `create_draft` | Save a draft in `Drafts` for later review/send |
+| `create_reply_draft` | Build a reply draft (quoted original + signature placeholder) without sending |
+| `create_forward_draft` | Build a forward draft without sending |
 
-### Contact Tools (3)
+### Attachments (7)
 
 | Tool | Description |
 |------|-------------|
-| `create_contact` | Add new contacts with full details |
-| `update_contact` | Modify contact information |
-| `delete_contact` | Remove contacts |
+| `list_attachments` | List attachments with metadata (name, size, MIME, inline flag) |
+| `download_attachment` | Download as base64 or save to file (see security note in docs) |
+| `add_attachment` | Attach files to a draft email |
+| `delete_attachment` | Remove attachments from a message |
+| `read_attachment` | Extract text from PDF / DOCX / XLSX |
+| `get_email_mime` | Return full RFC-822 MIME content of a message |
+| `attach_email_to_draft` | Attach another message (as `.eml`) to a draft |
 
-### Contact Intelligence Tools (2)
-
-| Tool | Description |
-|------|-------------|
-| `find_person` | **Unified lookup** — `source: "all"` (default), `"gal"`, `"contacts"`, `"email_history"`, `"domain"` |
-| `analyze_contacts` | **Unified analysis** — `analysis_type: "communication_history"`, `"overview"`, `"top_contacts"`, `"by_domain"`, `"dormant"`, `"vip"` |
-
-### Task Tools (5)
+### Calendar (7)
 
 | Tool | Description |
 |------|-------------|
-| `create_task` | Create tasks with due dates |
-| `get_tasks` | List tasks by status |
-| `update_task` | Modify task details |
-| `complete_task` | Mark as complete |
-| `delete_task` | Remove tasks |
+| `create_appointment` | Schedule meetings with attendees, body, location, reminders |
+| `get_calendar` | Retrieve events for a date range |
+| `update_appointment` | Modify time, attendees, location, or cancel |
+| `delete_appointment` | Cancel meeting (with optional cancellation notification) |
+| `respond_to_meeting` | Accept / Decline / Tentative responses with optional body |
+| `check_availability` | Free/busy for attendees over a time window |
+| `find_meeting_times` | Suggested slots across multiple attendees |
 
-### Search Tools (1)
-
-| Tool | Description |
-|------|-------------|
-| `search_by_conversation` | Find all emails in a thread |
-
-### Folder Tools (2)
+### Contacts (3)
 
 | Tool | Description |
 |------|-------------|
-| `list_folders` | Get folder hierarchy with counts |
-| `manage_folder` | **Unified management** — `action: "create"`, `"delete"`, `"rename"`, `"move"` |
+| `create_contact` | Add a contact with email, phones, company, title, department |
+| `update_contact` | Modify contact fields |
+| `delete_contact` | Remove a contact |
 
-### Out-of-Office Tools (1)
+### Contact Intelligence (2)
 
 | Tool | Description |
 |------|-------------|
-| `oof_settings` | **Unified OOF** — `action: "get"` or `"set"` |
+| `find_person` | Unified lookup — `source: "all" / "gal" / "contacts" / "email_history" / "domain"` |
+| `analyze_contacts` | Unified analysis — `analysis_type: "communication_history" / "overview" / "top_contacts" / "by_domain" / "dormant" / "vip"` |
+
+### Tasks (5)
+
+| Tool | Description |
+|------|-------------|
+| `create_task` | Create task with due date, status, importance, reminder |
+| `get_tasks` | List tasks filtered by status / include_completed |
+| `update_task` | Modify task fields |
+| `complete_task` | Mark task complete |
+| `delete_task` | Remove a task |
+
+### Search (1)
+
+| Tool | Description |
+|------|-------------|
+| `search_by_conversation` | Find all messages sharing a conversation/thread ID |
+
+### Folders (3)
+
+| Tool | Description |
+|------|-------------|
+| `list_folders` | Folder hierarchy with optional counts, depth, hidden-folder toggle |
+| `find_folder` | Locate a folder by name or ID anywhere in the mailbox |
+| `manage_folder` | Unified management — `action: "create" / "delete" / "rename" / "move"` |
+
+### Out-of-Office (1)
+
+| Tool | Description |
+|------|-------------|
+| `oof_settings` | `action: "get"` / `"set"` — internal/external reply, scheduling |
+
+### AI (4, optional)
+
+Enabled per-feature via `enable_ai=true` plus individual flags. These tools currently act on the **primary mailbox only** (they do not honor `target_mailbox` — see [Known limitations](#known-limitations)).
+
+| Tool | Description | Feature flag |
+|------|-------------|--------------|
+| `semantic_search_emails` | Natural-language email search via embeddings | `enable_semantic_search` |
+| `classify_email` | Priority / sentiment / optional spam classification | `enable_email_classification` |
+| `summarize_email` | AI summary of a message (configurable length) | `enable_email_summarization` |
+| `suggest_replies` | Generate N draft reply variants | `enable_smart_replies` |
 
 ---
 
@@ -333,16 +404,52 @@ person = find_person(
 ### Smart Meeting Scheduling
 
 ```python
-# AI-powered meeting time finder
+# Suggest slots that work for every attendee in a date range
 find_meeting_times(
     attendees=["alice@company.com", "bob@company.com"],
     duration_minutes=60,
-    preferences={
-        "prefer_morning": True,
-        "working_hours_start": 9,
-        "working_hours_end": 17,
-        "avoid_lunch": True
-    }
+    start_date="2026-04-20",
+    end_date="2026-04-22",
+    time_slots_per_day=3,
+    min_confidence_percent=80,
+)
+```
+
+### Draft-before-send workflow
+
+Drafts give the AI assistant a safe "preview and confirm" step. Nothing leaves the mailbox until the user explicitly sends.
+
+```python
+# Create a reply draft
+draft = create_reply_draft(
+    message_id="AAMkAGI...",
+    body="<p>Thanks for the update — will review by Friday.</p>",
+    to_all=False,
+)
+# draft["draft_id"] → open in client / add attachments / send later
+
+# Attach files to the draft
+add_attachment(
+    message_id=draft["draft_id"],
+    attachment_paths=["/path/to/report.pdf"],
+)
+
+# Or attach another message as .eml
+attach_email_to_draft(
+    draft_id=draft["draft_id"],
+    message_id_to_attach="AAMkAGI-some-other-msg",
+)
+```
+
+### Folder discovery
+
+```python
+# Find a folder anywhere in the hierarchy by name
+folder = find_folder(folder_name="Archive/Q1 Reports")
+# Use the returned stable folder_id instead of a fragile display path
+move_email(
+    message_id="AAMkAGI...",
+    destination_folder_id=folder["folder_id"],
 )
 ```
 
@@ -377,68 +484,151 @@ Add to your Claude Desktop config:
 
 ### Environment Variables
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `EWS_EMAIL` | Yes | Your email address |
-| `EWS_AUTH_TYPE` | Yes | `oauth2`, `basic`, or `ntlm` |
-| `EWS_SERVER_URL` | No | Exchange server (auto-constructs EWS URL) |
+All settings are parsed by `src/config.py` (Pydantic `Settings`). Examples live in `.env.example`, `.env.basic.example`, `.env.oauth2.example`, `.env.ai.example`.
 
-**OAuth2 (Office 365):**
+#### Required
+
+| Variable | Description |
+|----------|-------------|
+| `EWS_EMAIL` | Primary mailbox email address |
+| `EWS_AUTH_TYPE` | `oauth2` (default), `basic`, or `ntlm` |
+
+#### EWS connection
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `EWS_SERVER_URL` | — | Explicit server URL; if empty, autodiscover is used |
+| `EWS_AUTODISCOVER` | `true` | Enable Exchange autodiscover |
+
+#### Auth — OAuth2 (Office 365)
+
 | Variable | Description |
 |----------|-------------|
 | `EWS_CLIENT_ID` | Azure AD app client ID |
-| `EWS_CLIENT_SECRET` | Azure AD app secret |
+| `EWS_CLIENT_SECRET` | Azure AD app client secret |
 | `EWS_TENANT_ID` | Azure AD tenant ID |
 
-**Basic/NTLM:**
+#### Auth — Basic / NTLM
+
 | Variable | Description |
 |----------|-------------|
-| `EWS_USERNAME` | Username |
+| `EWS_USERNAME` | Username (email or `DOMAIN\\user`) |
 | `EWS_PASSWORD` | Password |
 
-**Impersonation (Optional):**
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `EWS_IMPERSONATION_ENABLED` | `false` | Enable multi-mailbox access |
-| `EWS_IMPERSONATION_TYPE` | `impersonation` | `impersonation` or `delegate` |
+#### Impersonation / delegation
 
-**Advanced:**
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `TIMEZONE` | `UTC` | IANA timezone (e.g., `America/New_York`) |
+| `EWS_IMPERSONATION_ENABLED` | `false` | Enable `target_mailbox` on base tools |
+| `EWS_IMPERSONATION_TYPE` | `impersonation` | `impersonation` (service account with `ApplicationImpersonation`) or `delegate` |
+
+#### Transport
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MCP_TRANSPORT` | `stdio` | `stdio` or `sse` (HTTP + Server-Sent Events) |
+| `MCP_HOST` | `0.0.0.0` | Bind address for SSE (override to `127.0.0.1` for local-only) |
+| `MCP_PORT` | `8000` | Port for SSE |
+| `MCP_SERVER_NAME` | `ews-mcp-server` | Identifier advertised to MCP clients |
+
+#### OpenAPI (SSE transport)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `API_BASE_URL` | — | Public URL advertised in the OpenAPI `servers` array |
+| `API_BASE_URL_INTERNAL` | — | Internal container URL (e.g. `http://ews-mcp:8000`) |
+| `API_TITLE` | `Exchange Web Services (EWS) MCP API` | OpenAPI title |
+| `API_VERSION` | `3.4.0` | OpenAPI version |
+
+#### Category feature flags
+
+All default to `true`. Set to `false` to skip registering a whole category:
+
+| Variable | Toggles |
+|----------|---------|
+| `ENABLE_EMAIL` | Email, drafts, attachments |
+| `ENABLE_CALENDAR` | Calendar |
+| `ENABLE_CONTACTS` | Contacts + contact intelligence |
+| `ENABLE_TASKS` | Tasks |
+| `ENABLE_FOLDERS` | Folder tools (folders are always loaded, but can be disabled here) |
+| `ENABLE_ATTACHMENTS` | Attachment tools |
+
+#### AI (all optional, off by default)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ENABLE_AI` | `false` | Master switch |
+| `AI_PROVIDER` | `openai` | `openai`, `anthropic`, or `local` (OpenAI-compatible) |
+| `AI_API_KEY` | — | Provider API key |
+| `AI_MODEL` | auto | e.g. `gpt-4o-mini`, `claude-3-5-sonnet-20241022` |
+| `AI_EMBEDDING_MODEL` | auto | e.g. `text-embedding-3-small` |
+| `AI_BASE_URL` | — | Custom base URL (local / proxy) |
+| `AI_MAX_TOKENS` | `4096` | Completion tokens |
+| `AI_TEMPERATURE` | `0.7` | Sampling temperature |
+| `ENABLE_SEMANTIC_SEARCH` | `false` | Enables `semantic_search_emails` |
+| `ENABLE_EMAIL_CLASSIFICATION` | `false` | Enables `classify_email` |
+| `ENABLE_EMAIL_SUMMARIZATION` | `false` | Enables `summarize_email` |
+| `ENABLE_SMART_REPLIES` | `false` | Enables `suggest_replies` |
+
+#### Performance / reliability
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ENABLE_CACHE` | `true` | Response caching |
+| `CACHE_TTL` | `300` | Cache TTL seconds |
+| `CONNECTION_POOL_SIZE` | `10` | EWS connection pool size |
+| `REQUEST_TIMEOUT` | `30` | HTTP timeout seconds |
+| `RATE_LIMIT_ENABLED` | `true` | Enable rate limiter |
+| `RATE_LIMIT_REQUESTS_PER_MINUTE` | `25` | Sliding-window limit |
+| `ENABLE_AUDIT_LOG` | `true` | Emit audit-log entries |
+| `MAX_ATTACHMENT_SIZE` | `157286400` | 150 MB default |
+
+#### Misc
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TIMEZONE` | `UTC` | IANA timezone (e.g. `America/New_York`) |
 | `LOG_LEVEL` | `INFO` | `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `MCP_TRANSPORT` | `stdio` | `stdio` or `sse` (HTTP/REST) |
-| `MCP_PORT` | `8000` | Port for SSE transport |
 
 ---
 
 ## Architecture
 
 ```
-EWS MCP Server v3.4
-├── MCP Protocol Layer (stdio/SSE)
-├── Tool Registry (36 tools)
-│   ├── Email Tools (11) ─────────── send, read, search (3 modes), reply, forward...
-│   ├── Calendar Tools (7) ──────── appointments, meetings, availability
-│   ├── Contact Tools (3) ───────── create, update, delete
-│   ├── Intelligence Tools (2) ──── find_person (5 sources), analyze_contacts (6 types)
-│   ├── Task Tools (5) ──────────── task management
-│   ├── Search Tools (1) ────────── conversation threads
-│   ├── Folder Tools (2) ────────── list + manage_folder (4 actions)
-│   ├── Attachment Tools (5) ────── read, download, content extraction
-│   └── OOF Tools (1) ───────────── oof_settings (get/set)
-├── Service Layer
-│   ├── PersonService ───────────── person discovery & ranking
-│   ├── EmailService ────────────── email operations
-│   ├── ThreadService ───────────── conversation threading
-│   └── AttachmentService ───────── format support (PDF, DOCX, XLSX...)
-├── Adapter Layer
-│   ├── GALAdapter ──────────────── multi-strategy directory search
-│   └── CacheAdapter ────────────── intelligent TTL caching
-├── EWS Client (exchangelib)
-│   └── Impersonation Support ───── multi-mailbox access
-├── Authentication (OAuth2/Basic/NTLM)
-└── Exchange Web Services API
+EWS MCP Server
+├── MCP Protocol Layer             stdio  •  SSE (HTTP + /openapi.json)
+├── Middleware
+│   ├── RateLimiter                25 req/min sliding window (configurable)
+│   ├── CircuitBreaker             trips after 3 connectivity failures, 60s cool-down
+│   ├── ErrorHandler               exception → structured response mapper
+│   ├── Logging                    app log + error log + audit log (rotating)
+│   └── OpenAPI Adapter            per-tool POST /api/tools/{name} routes
+├── Tool Registry (42 base + 4 AI = 46)
+│   ├── Email              (10)    send, read, search(3 modes), update, delete, move, copy, reply, forward
+│   ├── Drafts             (3)     create_draft, create_reply_draft, create_forward_draft
+│   ├── Attachments        (7)     list, download, add, delete, read(PDF/DOCX/XLSX), mime, attach_email_to_draft
+│   ├── Calendar           (7)     create, get, update, delete, respond, availability, find_meeting_times
+│   ├── Contacts           (3)     create, update, delete
+│   ├── Contact Intelligence(2)    find_person, analyze_contacts
+│   ├── Tasks              (5)     create, get, update, complete, delete
+│   ├── Search             (1)     search_by_conversation
+│   ├── Folders            (3)     list, find, manage(create/delete/rename/move)
+│   ├── Out-of-Office      (1)     oof_settings(get/set)
+│   └── AI (optional)      (4)     semantic_search, classify, summarize, suggest_replies
+├── Services
+│   ├── PersonService              multi-source contact discovery + relationship scoring
+│   ├── EmailService               message lookups, folder resolution
+│   ├── ThreadService              conversation reconstruction
+│   └── AttachmentService          attachment I/O
+├── Adapters
+│   ├── GALAdapter                 multi-strategy directory search (exact → partial → domain)
+│   └── CacheAdapter               in-memory TTL cache
+├── AI (optional)
+│   ├── Providers                  OpenAI  •  Anthropic  •  OpenAI-compatible local
+│   ├── EmbeddingService           file-backed cache at data/embeddings/embeddings.json
+│   └── ClassificationService      priority / sentiment / summary / reply suggestions
+├── EWS Client (exchangelib)       impersonation & delegation via target_mailbox
+└── Authentication                 OAuth2 (MSAL) • Basic • NTLM
 ```
 
 ---
@@ -465,38 +655,25 @@ EWS MCP Server v3.4
 
 ---
 
+## Known limitations
+
+Items to be aware of when deploying. See [CHANGELOG.md](CHANGELOG.md) for the full history.
+
+- **AI tools do not honor `target_mailbox`.** `semantic_search_emails`, `classify_email`, `summarize_email`, and `suggest_replies` always operate on the primary authenticated mailbox. Use non-AI tools (`read_emails`, `search_emails`, `get_email_details`) with impersonation when you need multi-mailbox behaviour.
+- **`read_attachment` extracts PDF / DOCX / XLSX only.** Other formats fall through to the default "text/plain only" path.
+- **SSE transport is unauthenticated by default.** `MCP_HOST` defaults to `0.0.0.0`. For any deployment that is reachable beyond localhost, put the server behind an auth-enforcing reverse proxy or bind to `127.0.0.1`. See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
+- **Global TLS verification.** The EWS HTTP adapter currently does not verify server certificates. Intended for corporate environments with internal CAs; review before exposing to untrusted networks.
+- **Audit log content.** The audit log currently records tool arguments. Review `logs/` retention and access control if arguments may contain sensitive payloads.
+
 ## Version History
 
-### v3.4 - Reliability & Code Quality
-- **Circuit breaker**: Auto-trips after 3 EWS failures, instant rejection for 60s
-- **Async/await**: `asyncio.to_thread()` for blocking EWS calls, `asyncio.gather()` for concurrent scans
-- **Simplified errors**: 200-char max, human-readable validation messages
-- **Code cleanup**: -70 lines dead code, deduplicated JSON encoder
+See [CHANGELOG.md](CHANGELOG.md) for the full history. Recent highlights:
 
-### v3.3 - Tool Consolidation
-- **10 tools merged into 5**: 46 → 36 tools, ~55% token savings on `list_tools`
-- **Unified search**: `search_emails` with quick/advanced/full_text modes
-- **Unified contacts**: `find_person` with 5 source types, `analyze_contacts` with 6 analysis types
-- **Unified folders**: `manage_folder` with create/delete/rename/move actions
-- **Unified OOF**: `oof_settings` with get/set actions
-- **Server-side filtering**: `analyze_contacts` communication history uses EWS sender filter
-
-### v3.2 - Reply, Forward & Impersonation
-- **Reply & Forward**: Full body preservation, inline images, Outlook-style headers
-- **Impersonation**: All tools support `target_mailbox` parameter
-- **Documentation**: Comprehensive guides for new features
-
-### v3.0 - Person-Centric Architecture
-- Multi-strategy GAL search (eliminates 0-results bug)
-- Person-first data model with relationship scoring
-- Intelligent caching (70% reduction in API calls)
-- Enterprise logging system
-
-### v2.x - Enterprise Features
-- 40+ tools for email, calendar, contacts, tasks
-- Attachment content extraction (PDF, DOCX, XLSX, PPTX)
-- AI-powered meeting time finder
-- Folder management
+- **v3.4.x (Unreleased)** — HTML reply/forward drafts; `find_folder`; folder-ID support on move/parent resolution; Windows MSIX wrapper; availability parsing fix.
+- **v3.4.0** — Circuit breaker; `asyncio.to_thread` / `asyncio.gather`; 200-char error truncation; removed `handle_ews_errors`; deduplicated JSON encoder.
+- **v3.3.0** — Tool consolidation (unified search / find_person / manage_folder / oof_settings / analyze_contacts).
+- **v3.2.0** — Reply, forward, inline base64 attachments; impersonation on every base tool.
+- **v3.0.0** — Person-centric architecture; multi-strategy GAL search; enterprise logging.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,34 @@
 # API Documentation
 
-Complete reference for all EWS MCP Server v3.4 tools (36 base tools + 4 AI tools).
+Complete reference for all EWS MCP Server tools: **42 base tools** (always available, subject to category flags) and **4 optional AI tools** (`semantic_search_emails`, `classify_email`, `summarize_email`, `suggest_replies`). Grand total: **46**.
+
+| Category | Tools |
+|----------|-------|
+| Email | 10 |
+| Email Drafts | 3 |
+| Attachments | 7 |
+| Calendar | 7 |
+| Contacts | 3 |
+| Contact Intelligence | 2 |
+| Tasks | 5 |
+| Search | 1 |
+| Folders | 3 |
+| Out-of-Office | 1 |
+| AI (optional) | 4 |
+
+Every base tool accepts `target_mailbox` (when `EWS_IMPERSONATION_ENABLED=true`). **AI tools do not**, and always act on the primary authenticated mailbox.
+
+All responses follow the same shape:
+
+```json
+{ "success": true, "message": "...", "data": { ... } }
+```
+
+On failure:
+
+```json
+{ "success": false, "error": "short description (max 200 chars)" }
+```
 
 ## Contact Intelligence Tools (v3.3 Consolidated)
 
@@ -823,6 +851,102 @@ Unified folder management with 4 actions: create, delete, rename, move.
 }
 ```
 
+### find_folder
+
+Locate a folder by name or ID anywhere in the mailbox hierarchy. Returns the folder ID, full path, parent, and (when available) item count.
+
+**Input Schema:**
+```json
+{
+  "folder_name": "Archive/Q1 Reports",   // Optional: name or path
+  "folder_id": "AAMkAGF...",             // Optional: resolve by stable ID
+  "target_mailbox": "other@example.com"  // Optional: impersonation
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "folder": {
+    "folder_id": "AAMkAGF...",
+    "name": "Q1 Reports",
+    "path": "Archive/Q1 Reports",
+    "parent_id": "AAMkAGF...",
+    "item_count": 42,
+    "child_count": 0
+  }
+}
+```
+
+Use `folder_id` from this response with `move_email`, `copy_email` (`destination_folder_id`), or `manage_folder` (`parent_folder_id`) for robust folder references.
+
+## Email Drafts
+
+Draft tools let an AI assistant prepare a message in the Drafts folder for the user to review/edit/send. Nothing leaves the mailbox until it is explicitly sent.
+
+### create_draft
+
+Create a new email draft.
+
+**Input Schema:**
+```json
+{
+  "to": ["recipient@example.com"],          // Required
+  "subject": "Draft subject",                // Required (min length 1)
+  "body": "<p>Draft body (HTML supported)</p>", // Required
+  "cc": ["cc@example.com"],
+  "bcc": ["bcc@example.com"],
+  "importance": "Normal",                    // Low / Normal / High
+  "attachments": ["/path/to/file.pdf"],
+  "inline_attachments": [
+    { "file_name": "logo.png", "content_id": "logo1", "file_content": "base64..." }
+  ],
+  "target_mailbox": "shared@example.com"
+}
+```
+
+**Response:**
+```json
+{ "success": true, "draft_id": "AAMkAGF...", "folder": "drafts" }
+```
+
+### create_reply_draft
+
+Build a reply draft for AI preview-before-send. Preserves original conversation threading, quoted headers (From/To/Sent/Subject), inline images, and signature placement.
+
+**Input Schema:**
+```json
+{
+  "message_id": "AAMkAGF...",       // Required: original message
+  "body": "<p>Your draft reply</p>", // Required
+  "to_all": false,                   // Reply-all vs. reply to sender
+  "subject": "Optional override",
+  "attachments": ["/path/to/file.pdf"],
+  "target_mailbox": "shared@example.com"
+}
+```
+
+**Response:** `{ "success": true, "draft_id": "AAMkAGF..." }`
+
+### create_forward_draft
+
+Build a forward draft (full body + inline images + attachments preserved).
+
+**Input Schema:**
+```json
+{
+  "message_id": "AAMkAGF...",      // Required: original message
+  "to": ["recipient@example.com"],  // Required: forward recipients
+  "body": "<p>Forward message</p>", // Required
+  "subject": "Optional override",
+  "attachments": ["/path/to/file.pdf"],
+  "target_mailbox": "shared@example.com"
+}
+```
+
+**Response:** `{ "success": true, "draft_id": "AAMkAGF..." }`
+
 ## Enhanced Attachment Tools
 
 ### add_attachment
@@ -876,6 +1000,50 @@ Remove attachments from emails by attachment ID or name.
   "attachment_id": "AAMkAGA...",
   "attachment_name": "old_file.pdf",
   "message_id": "AAMkAGF..."
+}
+```
+
+### get_email_mime
+
+Return the full RFC-822 MIME content of a message (useful for archival, forensics, and external processors that expect `.eml` input).
+
+**Input Schema:**
+```json
+{
+  "message_id": "AAMkAGF...",
+  "target_mailbox": "shared@example.com"
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message_id": "AAMkAGF...",
+  "mime_content": "Received: from ...\r\nFrom: ...\r\nTo: ...\r\n\r\n<body>",
+  "size_bytes": 12345
+}
+```
+
+### attach_email_to_draft
+
+Attach an existing message (as `.eml`) to a draft. Use in combination with `create_draft` / `create_reply_draft` / `create_forward_draft` when you want to forward/quote a full message as an attachment rather than inline.
+
+**Input Schema:**
+```json
+{
+  "draft_id": "AAMkAGF-draft-id...",
+  "message_id_to_attach": "AAMkAGF-original-msg...",
+  "target_mailbox": "shared@example.com"
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "draft_id": "AAMkAGF-draft-id...",
+  "attachment_name": "Fwd_original_subject.eml"
 }
 ```
 
@@ -1062,6 +1230,113 @@ Copy an email to another folder while preserving the original.
   "source_folder": "inbox",
   "destination_folder": "archive",
   "subject": "Important Document"
+}
+```
+
+## AI Tools (optional)
+
+Disabled by default. Enable via `ENABLE_AI=true` plus the per-feature flag listed below. Requires `AI_PROVIDER`, `AI_API_KEY`, and `AI_MODEL` (and `AI_EMBEDDING_MODEL` for semantic search).
+
+> AI tools do **not** accept `target_mailbox`; they operate on the primary authenticated mailbox.
+
+### semantic_search_emails
+
+Search emails by semantic similarity using embeddings. Enabled by `ENABLE_SEMANTIC_SEARCH=true`.
+
+**Input Schema:**
+```json
+{
+  "query": "invoices about Q1 cloud spend",  // Required: natural-language query
+  "folder": "inbox",                          // Optional: inbox (default) / sent / drafts / all
+  "max_results": 10,                          // 1-100
+  "threshold": 0.7                            // 0.0-1.0 similarity cutoff
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "query": "invoices about Q1 cloud spend",
+  "total_results": 3,
+  "results": [
+    {
+      "message_id": "AAMkAGF...",
+      "subject": "AWS Q1 invoice",
+      "from": "billing@aws.amazon.com",
+      "similarity_score": 0.89,
+      "received_time": "2026-03-05T10:00:00"
+    }
+  ]
+}
+```
+
+### classify_email
+
+Classify an email's priority, sentiment, and (optionally) spam probability. Enabled by `ENABLE_EMAIL_CLASSIFICATION=true`.
+
+**Input Schema:**
+```json
+{
+  "message_id": "AAMkAGF...",
+  "include_spam_detection": true
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "classification": {
+    "priority": "high",
+    "sentiment": "neutral",
+    "category": "customer_support",
+    "spam_probability": 0.03
+  }
+}
+```
+
+### summarize_email
+
+Generate an AI summary of an email. Enabled by `ENABLE_EMAIL_SUMMARIZATION=true`.
+
+**Input Schema:**
+```json
+{
+  "message_id": "AAMkAGF...",
+  "max_length": 200           // 50-500 characters
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "summary": "Customer reports login failure after yesterday's deploy; wants ETA for fix."
+}
+```
+
+### suggest_replies
+
+Generate N draft reply variants. Enabled by `ENABLE_SMART_REPLIES=true`.
+
+**Input Schema:**
+```json
+{
+  "message_id": "AAMkAGF...",
+  "num_suggestions": 3        // 1-5
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "suggestions": [
+    "Thanks for the update — will review and get back by EOD.",
+    "Acknowledged. Can we sync tomorrow at 10 to walk through the details?",
+    "Received; looping in the platform team for a second opinion."
+  ]
 }
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,8 @@
-# Architecture Overview - v3.4
+# Architecture Overview
 
-Technical architecture and design decisions for EWS MCP Server v3.4 (Reliability & Code Quality).
+Technical architecture and design decisions for the EWS MCP Server. Target readers: maintainers and integrators. See [API.md](API.md) for per-tool input/output contracts.
+
+**Current tool inventory:** 42 base tools + 4 optional AI tools = **46 total**, organized into 10 categories (plus AI). See [Tool Registry](#4-tool-registry-srctools) below.
 
 ## System Architecture
 
@@ -19,11 +21,13 @@ Technical architecture and design decisions for EWS MCP Server v3.4 (Reliability
 │               │                                              │
 │  ┌────────────▼───────────────────────────────────────────┐ │
 │  │              Tool Registry & Router                     │ │
-│  │  - Contact Intelligence (2)  - Email (11)              │ │
-│  │  - Calendar (7)              - Contacts (3)            │ │
+│  │  42 base + 4 AI = 46 total                             │ │
+│  │  - Email (10)                - Drafts (3)              │ │
+│  │  - Attachments (7)           - Calendar (7)            │ │
+│  │  - Contacts (3)              - Contact Intel. (2)      │ │
 │  │  - Tasks (5)                 - Search (1)              │ │
-│  │  - Folders (2)               - Out-of-Office (1)       │ │
-│  │  - Attachments (5)                                     │ │
+│  │  - Folders (3)               - Out-of-Office (1)       │ │
+│  │  - AI (4, optional)                                    │ │
 │  └────────────┬───────────────────────────────────────────┘ │
 │               │                                              │
 │  ┌────────────▼───────────────────────────────────────────┐ │

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,8 +1,8 @@
 # Deployment Guide
 
-Complete guide for deploying EWS MCP Server v3.4 in various environments.
+Complete guide for deploying the EWS MCP Server in various environments.
 
-> **v3.4 Features:** Person-centric architecture, multi-strategy GAL search, enterprise logging (console for monitoring, files for troubleshooting), and intelligent caching.
+> **Security note:** the SSE/HTTP transport is currently unauthenticated and binds `0.0.0.0` by default. For any deployment beyond localhost, put the server behind an auth-enforcing reverse proxy (or bind `MCP_HOST=127.0.0.1`) and restrict network exposure. See [README — Known limitations](../README.md#known-limitations).
 
 ## Pre-built Docker Image (Easiest)
 

--- a/docs/IMPERSONATION.md
+++ b/docs/IMPERSONATION.md
@@ -2,6 +2,8 @@
 
 EWS MCP Server supports operating on behalf of other users through Exchange impersonation or delegation. This allows a service account to access multiple mailboxes without requiring separate credentials for each user.
 
+> **Note:** every **base tool (42)** accepts a `target_mailbox` parameter. The **4 optional AI tools** (`semantic_search_emails`, `classify_email`, `summarize_email`, `suggest_replies`) currently ignore `target_mailbox` and always operate on the primary authenticated mailbox.
+
 ## Overview
 
 | Feature | Impersonation | Delegation |
@@ -174,8 +176,9 @@ list_folders(
 )
 
 # Create folder in another user's mailbox
-create_folder(
-    name="Project X",
+manage_folder(
+    action="create",
+    folder_name="Project X",
     parent_folder="inbox",
     target_mailbox="user@domain.com"
 )

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,8 +1,8 @@
 # Setup Guide
 
-Step-by-step guide to set up EWS MCP Server v3.4.
+Step-by-step guide to install and configure the EWS MCP Server.
 
-> **v3.0 Features:** Person-centric architecture, multi-strategy GAL search (fixes 0-results bug), enterprise logging, intelligent caching, and comprehensive attachment support.
+> **What you get:** 42 base tools plus 4 optional AI tools covering email (incl. reply/forward drafts), calendar, contacts, directory (GAL), tasks, folders (incl. ID-based references), attachments, and out-of-office. All base tools support `target_mailbox` via impersonation.
 
 ## Prerequisites
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,8 +1,8 @@
 # Troubleshooting Guide
 
-Common issues and solutions for EWS MCP Server v3.4.
+Common issues and solutions for the EWS MCP Server.
 
-> **Note:** Many issues from v2.x have been resolved in v3.0, particularly the GAL 0-results bug which is now completely fixed with multi-strategy search.
+> **Note:** Many earlier GAL 0-results / recipient-resolution issues are resolved by the multi-strategy `find_person` search. When in doubt, call `find_person` with `source="all"` — it falls back across GAL, contacts, and email history.
 
 ## Authentication Issues
 


### PR DESCRIPTION
Fix tool count drift and document recently added functionality so the docs reflect what the server actually exposes today.

- Correct tool counts everywhere: 42 base + 4 optional AI = 46 total (README, CHANGELOG, API.md, ARCHITECTURE.md, OPENWEBUI_SETUP.md).
- Document 3 draft tools (create_draft, create_reply_draft, create_forward_draft), find_folder, get_email_mime, and attach_email_to_draft in README and API.md.
- Add an "AI Tools" section to API.md with per-tool schemas and make the target_mailbox limitation explicit in README, API.md, and IMPERSONATION.md.
- Add a complete environment-variable reference to the README covering EWS connection, auth, impersonation, transport, OpenAPI, category flags, AI, performance, and logging settings.
- Add draft-workflow and folder-discovery usage examples to README.
- Add an "Unreleased" CHANGELOG section summarising the HTML reply/ forward drafts, folder-ID support, find_folder, availability fixes, Windows MSIX wrapper, and draft-attachment flow.
- Replace create_folder(...) example in IMPERSONATION.md with the unified manage_folder(action="create", ...) call.
- Replace version-specific blurbs with neutral language in SETUP.md, DEPLOYMENT.md, TROUBLESHOOTING.md, and ARCHITECTURE.md.
- Add a "Known limitations" section to the README covering AI-tool target_mailbox, read_attachment format scope, unauthenticated SSE transport default, TLS verification, and audit-log content.