### PR TITLE
fix(security+quality): close review HIGHs and top code defects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ logs/*
 logs/analysis/*
 !logs/analysis/.gitkeep
 
+# Attachment download jail (runtime-only, path set by EWS_DOWNLOAD_DIR)
+downloads/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,171 @@
 # Changelog
 
-## Unreleased — Drafts, folder discovery, availability fixes
+## Unreleased — Security and reliability hardening
+
+This release closes the 6 HIGH-severity findings from the end-to-end security
+review and the top code-quality bugs found alongside them. **Behaviour
+changes that operators need to know about** are called out under
+"Breaking / operator-visible changes".
+
+### Security fixes (HIGH)
+
+- **S1 — Authenticated HTTP/SSE transport.** When `MCP_API_KEY` is set,
+  every request to `/sse`, `/messages`, `/openapi.json`, and
+  `/api/tools/{tool}` must present `Authorization: Bearer <key>` (or
+  `X-API-Key`). Only `/health` remains public. The OpenAPI schema now
+  advertises `bearerAuth` instead of the unenforced `basicAuth`.
+- **S2 — TLS verification restored by default.** The EWS HTTP adapter
+  no longer globally disables certificate verification. Set
+  `EWS_INSECURE_SKIP_VERIFY=true` to opt back in for internal Exchange
+  servers with private CAs — a `WARNING` log line is emitted when used.
+- **S3 — `download_attachment` path jail.** `save_path` is now treated
+  as a basename hint only; directory components and `..` are stripped
+  and the resolved path is verified to live inside `EWS_DOWNLOAD_DIR`
+  (defaults to `./downloads`). This closes the pre-auth
+  arbitrary-file-write → RCE chain with S1.
+- **S4 — HTML injection in reply/forward drafts fixed.** `reply_email`,
+  `forward_email`, `create_reply_draft`, and `create_forward_draft`
+  now HTML-escape the original message's From/To/Cc/Subject/Sent
+  fields and pass user-supplied bodies through a proper sanitiser
+  (`utils.sanitize_html`, which now actually removes `<script>`,
+  `<style>`, `on*=` handlers, and `javascript:` URIs). Plain-text
+  bodies are escaped and newline→`<br/>` converted.
+- **S5 — Audit log redaction.** `AuditLogger.log_operation` now runs
+  every `details` payload through a new `redact_sensitive()` helper
+  before writing to `audit.log`. Fields matching `password`, `token`,
+  `secret`, `api_key`, `authorization`, `body`, `html_body`,
+  `text_body`, `file_content`, `content_base64`, `mime_content`, or
+  `inline_attachments` are replaced with `[redacted]` / length hints.
+- **S6 — Default bind `127.0.0.1`.** `MCP_HOST` defaults to loopback;
+  the SSE startup now refuses to bind a non-loopback address without
+  `MCP_API_KEY`, and warns when running on loopback with no API key.
+
+### Code-quality fixes (High)
+
+- **C1** `read_attachment` now correctly extracts PDF / DOCX / XLSX.
+  The `_read_pdf`, `_read_docx`, `_read_excel` methods were incorrectly
+  placed on `AttachEmailToDraftTool` (they were unreachable from
+  `ReadAttachmentTool.execute`, which silently fell back to a generic
+  "Failed to read attachment" error for every non-TXT extraction).
+- **C2** `main.py` now returns **JSON** over the MCP transport.
+  Responses were built with `str(result)` (Python repr — single
+  quotes, `True/False/None`, opaque `str(datetime(...))`).
+- **C3** `find_meeting_times` fixes: slots outside the returned
+  `merged_free_busy` range are now treated as **unavailable** (they
+  were falsely reported as free), dead buffer-check code now actually
+  runs, and accepted slots advance by `duration_minutes` so the tool
+  stops emitting N overlapping 15-minute shifts of the same hour.
+- **C4** `EmailService.get_message` and `ThreadService.get_thread` now
+  use `account.trash` instead of the nonexistent `account.deleted`
+  (which previously raised and was swallowed by a bare `except:`,
+  silently skipping Deleted Items).
+- **C5** OAuth2 credential path simplified. `AuthHandler` no longer
+  pre-fetches an MSAL token that was then thrown away; `exchangelib`
+  already handles the OAuth2 token lifecycle internally.
+- **C6** Advanced search responses now stringify `ItemId` via
+  `ews_id_to_str` so `message_id` is a plain string, matching the
+  other search modes.
+
+### Code-quality fixes (Medium)
+
+- **C7** `RateLimiter`, `CircuitBreaker`, and `CacheAdapter` are now
+  thread-safe; a `threading.Lock` guards every mutating critical
+  section so concurrent tool executions don't race on the rate window,
+  failure count, or cache dict.
+- **C8** Inline-attachment `content_id` values are sanitized (spaces
+  → dashes, non-ASCII stripped) and de-duplicated so multiple inlines
+  with the same basename don't collide and so `cid:...` references
+  render correctly in Outlook/OWA.
+- **C9** `parse_datetime_tz_aware` / `parse_date_tz_aware` are now
+  annotated `Optional[...]` to match their actual behaviour; bad
+  inputs log a DEBUG line so silent None-assignment to exchangelib
+  fields stops being invisible.
+- **C10** `CreateReplyDraftTool` / `CreateForwardDraftTool` now use
+  `add_reply_prefix` / `add_forward_prefix` so threads no longer stack
+  "RE: RE: RE: …".
+- **C11** Plain-text bodies in reply/forward/draft tools are HTML-escaped
+  and newlines converted to `<br/>` (handled by the new
+  `utils.format_body_for_html`).
+- **C12** `ConnectionError` renamed to `EWSConnectionError` (alias
+  kept for one release). The old name shadowed the Python builtin of
+  the same name and broke `isinstance(e, ConnectionError)` matching
+  for real OS-level socket errors.
+- **C13** `GetCalendar` end-date heuristic no longer over-collects the
+  day after when the caller explicitly asks for events ending at
+  midnight; it now checks whether the input was date-only (no `T`).
+- **C14** `EmbeddingService._save_cache` writes atomically
+  (`tempfile` + `os.replace`) so a crash mid-write cannot corrupt
+  `embeddings.json`.
+- **C15** `EmbeddingService.embed_batch` no longer has an O(N²)
+  `indices_to_embed.index(i)` lookup; replaced with positional
+  iteration.
+- **C16** `openapi_adapter.handle_rest_request` now returns a proper
+  HTTP status (400 / 401 / 429 / 503 / 500) when a tool fails, matching
+  the advertised OpenAPI responses.
+- **C17** Tool-count comments corrected in `main.py` (42 base + 4 AI = 46).
+- **C19** AI tools (`semantic_search_emails`, `classify_email`,
+  `summarize_email`, `suggest_replies`) now accept `target_mailbox`
+  for impersonation — they used to be the only four tools that
+  ignored it.
+
+### Code-quality fixes (Low)
+
+- **C21** Remaining bare `except:` clauses in `attachment_service.py`
+  replaced with logged `except Exception:` blocks.
+- **C22** `run_server.py` no longer hardcodes `C:\Tools\ews-mcp`. It
+  uses `os.path.dirname(os.path.abspath(__file__))` so the MSIX
+  wrapper works from any install location on any OS.
+- **C25** Config now logs when `AI_MODEL` / `AI_EMBEDDING_MODEL`
+  defaults are applied (previously silent) and warns when semantic
+  search is enabled against a local provider without
+  `AI_EMBEDDING_MODEL` set.
+
+### New settings
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `MCP_API_KEY` | — | Bearer token required on every non-`/health` request on the SSE transport |
+| `MCP_HOST` | `127.0.0.1` (was `0.0.0.0`) | Bind address for SSE |
+| `EWS_INSECURE_SKIP_VERIFY` | `false` | Opt-in for internal Exchange with private CAs |
+| `EWS_DOWNLOAD_DIR` | `downloads` | Jail directory for `download_attachment` writes |
+
+### Breaking / operator-visible changes
+
+- **SSE transport binds `127.0.0.1` by default.** Docker-compose files
+  that expect the server on `0.0.0.0` must now set `MCP_HOST=0.0.0.0`
+  **and** `MCP_API_KEY=<secret>` — startup refuses the combination
+  without a key.
+- **TLS is verified by default.** Setups that depended on the old
+  behaviour must set `EWS_INSECURE_SKIP_VERIFY=true` or install the
+  internal CA bundle into the container's trust store.
+- **`download_attachment` save path is jailed.** Callers can no
+  longer pick an arbitrary filesystem location; only the basename of
+  `save_path` is honoured and the file is written under
+  `EWS_DOWNLOAD_DIR`. The response `file_path` shows the actual
+  location.
+- **MCP tool responses are now JSON** rather than Python repr.
+  Clients that relied on parsing `True`/`False`/single-quoted dicts
+  need to switch to `json.loads`.
+- **`ConnectionError` → `EWSConnectionError`.** The old name is
+  aliased for one release but should be replaced in any downstream
+  `except` / `isinstance` checks.
+
+### Files changed (18)
+
+`src/main.py`, `src/config.py`, `src/auth.py`, `src/ews_client.py`,
+`src/exceptions.py`, `src/utils.py`, `src/openapi_adapter.py`,
+`src/middleware/logging.py`, `src/middleware/rate_limiter.py`,
+`src/middleware/circuit_breaker.py`, `src/middleware/error_handler.py`,
+`src/adapters/cache_adapter.py`, `src/tools/attachment_tools.py`,
+`src/tools/email_tools.py`, `src/tools/email_tools_draft.py`,
+`src/tools/calendar_tools.py`, `src/tools/ai_tools.py`,
+`src/services/email_service.py`, `src/services/thread_service.py`,
+`src/services/attachment_service.py`, `src/ai/embedding_service.py`,
+`run_server.py`, `tests/test_attachment_tools.py`.
+
+---
+
+## Prior to this release (also unreleased) — Drafts, folder discovery, availability fixes
 
 ### New Tools (+4)
 

--- a/OPENWEBUI_SETUP.md
+++ b/OPENWEBUI_SETUP.md
@@ -67,6 +67,13 @@ EWS_PASSWORD=your-password
 EWS_SERVER_URL=https://your-exchange-server/EWS/Exchange.asmx
 EWS_AUTH_TYPE=basic
 TIMEZONE=Asia/Riyadh
+
+# SSE transport for Open WebUI. MCP_HOST must be 0.0.0.0 for the
+# port to be reachable from the Open WebUI container, and MCP_API_KEY
+# must be set — the server refuses a non-loopback bind without one.
+MCP_TRANSPORT=sse
+MCP_HOST=0.0.0.0
+MCP_API_KEY=$(openssl rand -hex 32 2>/dev/null || echo "change-me-32-chars-or-more")
 EOF
 
 # Start the server

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ manage_folder(action="create", folder_name="Archive")
 manage_folder(action="rename", folder_id="AAMk...", new_name="Old Projects")
 ```
 
-> Every **base tool (42)** accepts `target_mailbox` for impersonation/delegation. The 4 optional AI tools currently act only on the primary mailbox — see [Known limitations](#known-limitations).
+> All **46 tools** (42 base + 4 AI) accept `target_mailbox` when `EWS_IMPERSONATION_ENABLED=true`.
 
 ---
 
@@ -171,6 +171,13 @@ EWS_AUTH_TYPE=basic
 EWS_USERNAME=user@company.com
 EWS_PASSWORD=your-password
 TIMEZONE=UTC
+
+# If you plan to reach the SSE transport from outside the container,
+# set MCP_HOST=0.0.0.0 AND an API key — the server refuses to bind a
+# non-loopback address without an API key.
+# MCP_TRANSPORT=sse
+# MCP_HOST=0.0.0.0
+# MCP_API_KEY=$(openssl rand -hex 32)
 EOF
 
 # Run
@@ -301,7 +308,7 @@ python -m src.main
 
 ### AI (4, optional)
 
-Enabled per-feature via `enable_ai=true` plus individual flags. These tools currently act on the **primary mailbox only** (they do not honor `target_mailbox` — see [Known limitations](#known-limitations)).
+Enabled per-feature via `enable_ai=true` plus individual flags. Accept `target_mailbox` when `EWS_IMPERSONATION_ENABLED=true`.
 
 | Tool | Description | Feature flag |
 |------|-------------|--------------|
@@ -499,6 +506,8 @@ All settings are parsed by `src/config.py` (Pydantic `Settings`). Examples live 
 |----------|---------|-------------|
 | `EWS_SERVER_URL` | — | Explicit server URL; if empty, autodiscover is used |
 | `EWS_AUTODISCOVER` | `true` | Enable Exchange autodiscover |
+| `EWS_INSECURE_SKIP_VERIFY` | `false` | Disable TLS certificate verification for EWS traffic. Opt-in only — use when the corporate Exchange uses a private CA that cannot be installed into the container trust store. |
+| `EWS_DOWNLOAD_DIR` | `downloads` | Jail directory for `download_attachment` writes (`save_path` is treated as a basename hint only). |
 
 #### Auth — OAuth2 (Office 365)
 
@@ -527,8 +536,9 @@ All settings are parsed by `src/config.py` (Pydantic `Settings`). Examples live 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MCP_TRANSPORT` | `stdio` | `stdio` or `sse` (HTTP + Server-Sent Events) |
-| `MCP_HOST` | `0.0.0.0` | Bind address for SSE (override to `127.0.0.1` for local-only) |
+| `MCP_HOST` | `127.0.0.1` | Bind address for SSE. Non-loopback values require `MCP_API_KEY` |
 | `MCP_PORT` | `8000` | Port for SSE |
+| `MCP_API_KEY` | — | Required bearer token on every non-`/health` request when the server is reachable beyond loopback. Clients send `Authorization: Bearer <key>` or `X-API-Key: <key>`. |
 | `MCP_SERVER_NAME` | `ews-mcp-server` | Identifier advertised to MCP clients |
 
 #### OpenAPI (SSE transport)
@@ -655,15 +665,31 @@ EWS MCP Server
 
 ---
 
-## Known limitations
+## Security & operations notes
 
-Items to be aware of when deploying. See [CHANGELOG.md](CHANGELOG.md) for the full history.
+Things to be aware of when deploying. See the Unreleased section of
+[CHANGELOG.md](CHANGELOG.md) for the specific hardening work this covers.
 
-- **AI tools do not honor `target_mailbox`.** `semantic_search_emails`, `classify_email`, `summarize_email`, and `suggest_replies` always operate on the primary authenticated mailbox. Use non-AI tools (`read_emails`, `search_emails`, `get_email_details`) with impersonation when you need multi-mailbox behaviour.
-- **`read_attachment` extracts PDF / DOCX / XLSX only.** Other formats fall through to the default "text/plain only" path.
-- **SSE transport is unauthenticated by default.** `MCP_HOST` defaults to `0.0.0.0`. For any deployment that is reachable beyond localhost, put the server behind an auth-enforcing reverse proxy or bind to `127.0.0.1`. See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
-- **Global TLS verification.** The EWS HTTP adapter currently does not verify server certificates. Intended for corporate environments with internal CAs; review before exposing to untrusted networks.
-- **Audit log content.** The audit log currently records tool arguments. Review `logs/` retention and access control if arguments may contain sensitive payloads.
+- **SSE transport now defaults to loopback.** `MCP_HOST` defaults to
+  `127.0.0.1`. To expose the server on a non-loopback address you
+  must also set `MCP_API_KEY=<secret>` — clients then pass
+  `Authorization: Bearer <secret>` (or `X-API-Key: <secret>`) on every
+  non-`/health` request. Startup refuses the insecure combination.
+- **TLS verification is on by default.** Set
+  `EWS_INSECURE_SKIP_VERIFY=true` only if your internal Exchange
+  server uses a private CA that cannot be installed into the container's
+  trust store. A warning is logged when this is enabled.
+- **Attachment downloads are jailed.** `download_attachment(save_path=...)`
+  now writes inside `EWS_DOWNLOAD_DIR` (default `./downloads`);
+  directory components and `..` in the caller-supplied path are
+  stripped. The response `file_path` tells you the resolved location.
+- **Audit-log redaction.** Email bodies, token fields, and base64
+  attachment content are replaced with `[redacted]` before being
+  written to `audit.log`.
+- **AI tools now honour `target_mailbox`.** All 46 tools (42 base + 4 AI)
+  accept `target_mailbox` when `EWS_IMPERSONATION_ENABLED=true`.
+- **`read_attachment` supports PDF / DOCX / XLSX / TXT.** Other formats
+  return an "Unsupported file type" error.
 
 ## Version History
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,12 @@
 version: '3.8'
 
-# EWS MCP v3.4 - Person-Centric Exchange Server
-# Build from source for development/testing
+# EWS MCP - Person-Centric Exchange Server
+# Build from source for development/testing.
+#
+# SSE transport reminder: MCP_HOST defaults to 127.0.0.1. If you set
+# MCP_TRANSPORT=sse and want the port reachable outside the container,
+# set MCP_HOST=0.0.0.0 AND MCP_API_KEY=<secret> in your .env. The server
+# refuses to bind a non-loopback address without an API key.
 
 services:
   ews-mcp-server:

--- a/run_server.py
+++ b/run_server.py
@@ -1,7 +1,18 @@
-import os
-import sys
-import runpy
+"""Portable entrypoint wrapper for the MCP server.
 
-os.chdir(r"C:\Tools\ews-mcp")
-sys.path.insert(0, r"C:\Tools\ews-mcp")
+Some MCP clients (notably Claude Desktop MSIX on Windows) launch Python with
+an unrelated working directory. This wrapper pins CWD and sys.path to the
+directory this file lives in so ``python run_server.py`` works from anywhere.
+"""
+
+import os
+import runpy
+import sys
+
+_PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
+
+os.chdir(_PROJECT_ROOT)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
 runpy.run_module("src.main", run_name="__main__")

--- a/src/adapters/cache_adapter.py
+++ b/src/adapters/cache_adapter.py
@@ -1,6 +1,7 @@
 """Simple in-memory cache adapter for EWS MCP v3.0."""
 
 import logging
+import threading
 from typing import Any, Optional, Dict, Callable
 from datetime import datetime, timedelta
 import asyncio
@@ -11,6 +12,10 @@ class CacheAdapter:
     Simple in-memory cache with TTL support.
 
     Reduces load on Exchange servers by caching frequent queries.
+
+    Thread-safe: a single lock guards the underlying dict so concurrent
+    get/set/delete calls from the SSE transport and asyncio.gather paths
+    don't race on read-modify-write sequences.
     """
 
     # Default cache durations (seconds)
@@ -28,6 +33,7 @@ class CacheAdapter:
         self.logger = logging.getLogger(__name__)
         self.hit_count = 0
         self.miss_count = 0
+        self._lock = threading.Lock()
 
     def get(self, key: str) -> Optional[Any]:
         """
@@ -39,19 +45,21 @@ class CacheAdapter:
         Returns:
             Cached value if exists and not expired, None otherwise
         """
-        if key not in self.cache:
-            self.miss_count += 1
-            return None
+        with self._lock:
+            if key not in self.cache:
+                self.miss_count += 1
+                return None
 
-        value, expires_at = self.cache[key]
+            value, expires_at = self.cache[key]
 
-        # Check if expired
-        if datetime.now() >= expires_at:
-            del self.cache[key]
-            self.miss_count += 1
-            return None
+            # Check if expired
+            if datetime.now() >= expires_at:
+                del self.cache[key]
+                self.miss_count += 1
+                return None
 
-        self.hit_count += 1
+            self.hit_count += 1
+
         self.logger.debug(f"Cache HIT: {key}")
         return value
 
@@ -71,20 +79,23 @@ class CacheAdapter:
         """
         duration = duration or 300
         expires_at = datetime.now() + timedelta(seconds=duration)
-        self.cache[key] = (value, expires_at)
+        with self._lock:
+            self.cache[key] = (value, expires_at)
         self.logger.debug(f"Cache SET: {key} (TTL: {duration}s)")
 
     def delete(self, key: str) -> None:
         """Delete key from cache."""
-        if key in self.cache:
-            del self.cache[key]
-            self.logger.debug(f"Cache DELETE: {key}")
+        with self._lock:
+            if key in self.cache:
+                del self.cache[key]
+                self.logger.debug(f"Cache DELETE: {key}")
 
     def clear(self) -> None:
         """Clear all cache."""
-        self.cache.clear()
-        self.hit_count = 0
-        self.miss_count = 0
+        with self._lock:
+            self.cache.clear()
+            self.hit_count = 0
+            self.miss_count = 0
         self.logger.info("Cache cleared")
 
     async def get_or_fetch(

--- a/src/ai/embedding_service.py
+++ b/src/ai/embedding_service.py
@@ -2,6 +2,8 @@
 
 import json
 import logging
+import os
+import tempfile
 from typing import List, Dict, Any, Optional, Tuple
 from pathlib import Path
 from .base import EmbeddingProvider
@@ -41,14 +43,29 @@ class EmbeddingService:
                 self.logger.warning(f"Failed to load embeddings cache: {e}")
 
     def _save_cache(self):
-        """Save embeddings cache to disk."""
+        """Save embeddings cache to disk atomically.
+
+        Writes to a temp file in the same directory and renames over the
+        target so a crash mid-write cannot corrupt the cache.
+        """
         if not self.cache_dir:
             return
 
         cache_file = self.cache_dir / "embeddings.json"
         try:
-            with open(cache_file, 'w') as f:
-                json.dump(self.embedding_cache, f)
+            fd, tmp_path = tempfile.mkstemp(
+                prefix="embeddings-", suffix=".json.tmp", dir=self.cache_dir
+            )
+            try:
+                with os.fdopen(fd, "w") as f:
+                    json.dump(self.embedding_cache, f)
+                os.replace(tmp_path, cache_file)
+            except Exception:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
         except Exception as e:
             self.logger.warning(f"Failed to save embeddings cache: {e}")
 
@@ -99,9 +116,9 @@ class EmbeddingService:
             return [r.embedding for r in responses]
 
         # Check cache
-        embeddings = []
-        texts_to_embed = []
-        indices_to_embed = []
+        embeddings: List[Tuple[int, List[float]]] = []
+        texts_to_embed: List[str] = []
+        indices_to_embed: List[int] = []
 
         for i, text in enumerate(texts):
             cache_key = self._get_cache_key(text)
@@ -111,15 +128,17 @@ class EmbeddingService:
                 texts_to_embed.append(text)
                 indices_to_embed.append(i)
 
-        # Embed uncached texts
+        # Embed uncached texts. texts_to_embed[pos] corresponds positionally
+        # to responses[pos] and to the original texts[indices_to_embed[pos]].
         if texts_to_embed:
             responses = await self.provider.embed_batch(texts_to_embed)
-            for i, response in zip(indices_to_embed, responses):
-                embeddings.append((i, response.embedding))
-                # Cache it
-                cache_key = self._get_cache_key(texts_to_embed[indices_to_embed.index(i)])
-                self.embedding_cache[cache_key] = response.embedding
+            for pos, (original_idx, response) in enumerate(zip(indices_to_embed, responses)):
+                embedding = response.embedding
+                embeddings.append((original_idx, embedding))
+                cache_key = self._get_cache_key(texts_to_embed[pos])
+                self.embedding_cache[cache_key] = embedding
 
+            # One disk write for the whole batch (was N writes / call).
             self._save_cache()
 
         # Sort by original index

--- a/src/auth.py
+++ b/src/auth.py
@@ -1,8 +1,6 @@
 """Authentication handlers for Exchange Web Services."""
 
 from exchangelib import Credentials, OAuth2Credentials, NTLM
-from msal import ConfidentialClientApplication
-from typing import Optional
 import logging
 
 from .config import Settings
@@ -15,7 +13,6 @@ class AuthHandler:
     def __init__(self, config: Settings):
         self.config = config
         self.logger = logging.getLogger(__name__)
-        self._token_cache: Optional[str] = None
 
     def get_credentials(self) -> Credentials:
         """Get appropriate credentials based on auth type."""
@@ -34,34 +31,17 @@ class AuthHandler:
             raise AuthenticationError(f"Authentication setup failed: {e}")
 
     def _get_oauth2_credentials(self) -> OAuth2Credentials:
-        """Get OAuth2 credentials using MSAL."""
+        """Build OAuth2 credentials. exchangelib manages the token lifecycle
+        internally via MSAL when given client_id/client_secret/tenant_id;
+        pre-fetching a token here only added latency and a failure surface.
+        """
         try:
-            # Create MSAL app
-            app = ConfidentialClientApplication(
-                client_id=self.config.ews_client_id,
-                client_credential=self.config.ews_client_secret,
-                authority=f"https://login.microsoftonline.com/{self.config.ews_tenant_id}"
-            )
-
-            # Get token
-            scopes = ["https://outlook.office365.com/.default"]
-            result = app.acquire_token_for_client(scopes=scopes)
-
-            if "access_token" not in result:
-                error = result.get("error_description", "Unknown error")
-                raise AuthenticationError(f"Failed to acquire OAuth2 token: {error}")
-
-            access_token = result["access_token"]
-            self._token_cache = access_token
-
-            # Return OAuth2 credentials
             return OAuth2Credentials(
                 client_id=self.config.ews_client_id,
                 client_secret=self.config.ews_client_secret,
                 tenant_id=self.config.ews_tenant_id,
                 identity=self.config.ews_email
             )
-
         except Exception as e:
             self.logger.error(f"OAuth2 authentication failed: {e}")
             raise AuthenticationError(f"OAuth2 setup failed: {e}")
@@ -89,7 +69,6 @@ class AuthHandler:
             raise AuthenticationError(f"NTLM auth failed: {e}")
 
     def refresh_token(self) -> None:
-        """Refresh OAuth2 token if needed."""
+        """Token refresh is handled inside exchangelib. Kept for API stability."""
         if self.config.ews_auth_type == "oauth2":
-            self.logger.info("Refreshing OAuth2 token")
-            self._get_oauth2_credentials()
+            self.logger.debug("OAuth2 token refresh is handled by exchangelib")

--- a/src/config.py
+++ b/src/config.py
@@ -31,10 +31,21 @@ class Settings(BaseSettings):
     # Server configuration
     mcp_server_name: str = "ews-mcp-server"
     mcp_transport: Literal["stdio", "sse"] = "stdio"
-    mcp_host: str = "0.0.0.0"
+    # Default to localhost. The SSE transport serves an unauthenticated-by-default
+    # REST surface; operators must opt in to 0.0.0.0 and should set MCP_API_KEY
+    # before doing so. See README "Known limitations".
+    mcp_host: str = "127.0.0.1"
     mcp_port: int = 8000
+    # If set, the SSE/HTTP transport requires this API key in the
+    # Authorization: Bearer <key> header (or X-API-Key header) on every
+    # non-health endpoint. Required whenever mcp_host is not 127.0.0.1/localhost.
+    mcp_api_key: Optional[str] = None
     timezone: str = "UTC"
     log_level: str = "INFO"
+
+    # TLS for EWS/autodiscover. Default is verified TLS (secure). Set to true
+    # only for corporate Exchange with self-signed certs and review the risks.
+    ews_insecure_skip_verify: bool = False
 
     # OpenAPI/REST API Configuration
     api_base_url: Optional[str] = None  # External URL for API (e.g., https://api.example.com)
@@ -105,20 +116,46 @@ class Settings(BaseSettings):
             if not self.ews_username or not self.ews_password:
                 raise ValueError(f"{self.ews_auth_type.upper()} auth requires ews_username and ews_password")
 
+        # SSE transport binding safety: require API key if not loopback.
+        if self.mcp_transport == "sse":
+            loopback_hosts = {"127.0.0.1", "::1", "localhost"}
+            if self.mcp_host not in loopback_hosts and not self.mcp_api_key:
+                raise ValueError(
+                    "SSE transport bound to a non-loopback address requires "
+                    "MCP_API_KEY to be set. Either set MCP_API_KEY or bind "
+                    "MCP_HOST to 127.0.0.1 and put the server behind an "
+                    "auth-enforcing reverse proxy."
+                )
+
         # Validate AI settings
         if self.enable_ai:
+            import logging as _logging
+            _log = _logging.getLogger(__name__)
             if not self.ai_api_key and self.ai_provider != "local":
                 raise ValueError(f"AI enabled but ai_api_key not provided for {self.ai_provider}")
             if not self.ai_model:
-                # Set default models based on provider
                 if self.ai_provider == "openai":
                     self.ai_model = "gpt-4o-mini"
                 elif self.ai_provider == "anthropic":
                     self.ai_model = "claude-3-5-sonnet-20241022"
+                if self.ai_model:
+                    _log.info(
+                        f"AI_MODEL not set; defaulting to {self.ai_model!r} "
+                        f"for provider={self.ai_provider}"
+                    )
             if self.enable_semantic_search and not self.ai_embedding_model:
-                # Set default embedding model
                 if self.ai_provider == "openai":
                     self.ai_embedding_model = "text-embedding-3-small"
+                    _log.info(
+                        "AI_EMBEDDING_MODEL not set; defaulting to "
+                        "'text-embedding-3-small' for semantic search"
+                    )
+                elif self.ai_provider == "local":
+                    _log.warning(
+                        "enable_semantic_search=true with AI_PROVIDER=local but "
+                        "AI_EMBEDDING_MODEL is not set. Set AI_EMBEDDING_MODEL "
+                        "explicitly for local/OpenAI-compatible endpoints."
+                    )
 
         return self
 

--- a/src/ews_client.py
+++ b/src/ews_client.py
@@ -6,14 +6,10 @@ from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_excep
 import logging
 import pytz
 from typing import Optional, Dict
-import urllib3
 
 from .config import Settings
 from .auth import AuthHandler
-from .exceptions import ConnectionError, AuthenticationError
-
-# Suppress SSL warnings when using NoVerifyHTTPAdapter
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+from .exceptions import EWSConnectionError, AuthenticationError
 
 
 class EWSClient:
@@ -26,8 +22,20 @@ class EWSClient:
         self._account: Optional[Account] = None
         self._impersonated_accounts: Dict[str, Account] = {}
 
-        # Configure exchangelib
-        BaseProtocol.HTTP_ADAPTER_CLS = NoVerifyHTTPAdapter
+        # TLS verification: verified by default. Only disable when the operator
+        # explicitly sets EWS_INSECURE_SKIP_VERIFY=true (e.g. internal Exchange
+        # with a private CA that cannot be installed into the container trust
+        # store). Downgrading to NoVerifyHTTPAdapter opens a MITM risk for
+        # credentials and tokens — log loudly.
+        if getattr(self.config, "ews_insecure_skip_verify", False):
+            import urllib3
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+            BaseProtocol.HTTP_ADAPTER_CLS = NoVerifyHTTPAdapter
+            self.logger.warning(
+                "EWS_INSECURE_SKIP_VERIFY=true: TLS certificate verification "
+                "DISABLED for all Exchange traffic. This is unsafe on untrusted "
+                "networks. Prefer installing your internal CA bundle."
+            )
 
     @property
     def account(self) -> Account:
@@ -127,7 +135,7 @@ class EWSClient:
                 )
             else:
                 # No server URL and autodiscover disabled
-                raise ConnectionError(
+                raise EWSConnectionError(
                     "No EWS_SERVER_URL provided and EWS_AUTODISCOVER is disabled. "
                     "Either provide EWS_SERVER_URL or enable EWS_AUTODISCOVER."
                 )
@@ -142,7 +150,7 @@ class EWSClient:
             raise
         except Exception as e:
             self.logger.error(f"Failed to create account: {e}")
-            raise ConnectionError(f"Failed to connect to Exchange: {e}")
+            raise EWSConnectionError(f"Failed to connect to Exchange: {e}")
 
     def test_connection(self) -> bool:
         """Test EWS connection."""
@@ -178,7 +186,7 @@ class EWSClient:
             Account object for the specified mailbox
 
         Raises:
-            ConnectionError: If impersonation is not enabled or fails
+            EWSConnectionError: If impersonation is not enabled or fails
         """
         # Return primary account if no target specified
         if not target_mailbox or target_mailbox.lower() == self.config.ews_email.lower():
@@ -186,7 +194,7 @@ class EWSClient:
 
         # Check if impersonation is enabled
         if not self.config.ews_impersonation_enabled:
-            raise ConnectionError(
+            raise EWSConnectionError(
                 f"Impersonation not enabled. Set EWS_IMPERSONATION_ENABLED=true "
                 f"to access mailbox: {target_mailbox}"
             )
@@ -246,7 +254,7 @@ class EWSClient:
                     default_timezone=tz
                 )
             else:
-                raise ConnectionError(
+                raise EWSConnectionError(
                     "No EWS_SERVER_URL provided and EWS_AUTODISCOVER is disabled."
                 )
 
@@ -261,7 +269,7 @@ class EWSClient:
 
         except Exception as e:
             self.logger.error(f"Failed to access mailbox {target_mailbox}: {e}")
-            raise ConnectionError(
+            raise EWSConnectionError(
                 f"Failed to access mailbox {target_mailbox}: {e}. "
                 f"Ensure the service account has ApplicationImpersonation role "
                 f"or delegate access to this mailbox."

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -11,9 +11,16 @@ class AuthenticationError(EWSMCPException):
     pass
 
 
-class ConnectionError(EWSMCPException):
+class EWSConnectionError(EWSMCPException):
     """Connection to Exchange failed."""
     pass
+
+
+# Deprecated alias. `ConnectionError` shadows the Python builtin of the same
+# name, so `except ConnectionError` blocks in code that imported this name
+# silently stopped matching real OS-level socket/HTTP errors. New code should
+# use `EWSConnectionError`; this alias is retained for one release.
+ConnectionError = EWSConnectionError  # noqa: A001
 
 
 class RateLimitError(EWSMCPException):

--- a/src/main.py
+++ b/src/main.py
@@ -22,8 +22,9 @@ from .middleware.rate_limiter import RateLimiter
 from .exceptions import EWSMCPException
 from .logging_system import get_logger
 from .openapi_adapter import OpenAPIAdapter
+from .utils import safe_json_dumps
 
-# Import all tool classes (up to 42 tools total: 38 base + 4 AI)
+# Import all tool classes (46 total: 42 base + 4 optional AI)
 from .tools import (
     CreateDraftTool, CreateReplyDraftTool, CreateForwardDraftTool,
     SendEmailTool, ReadEmailsTool, SearchEmailsTool, GetEmailDetailsTool,
@@ -150,7 +151,7 @@ class EWSMCPServer:
                 except Exception as e:
                     return [TextContent(
                         type="text",
-                        text=str(self.error_handler.handle_exception(e, f"Rate limit"))
+                        text=safe_json_dumps(self.error_handler.handle_exception(e, f"Rate limit"))
                     )]
 
             # Check if tool exists
@@ -162,7 +163,7 @@ class EWSMCPServer:
                 }
                 return [TextContent(
                     type="text",
-                    text=str(error_response)
+                    text=safe_json_dumps(error_response)
                 )]
 
             # Execute tool
@@ -172,7 +173,8 @@ class EWSMCPServer:
             try:
                 result = await tool.safe_execute(**arguments)
 
-                # Audit log
+                # Audit log — AuditLogger.log_operation redacts sensitive
+                # fields (body/token/attachment content) before writing.
                 if self.settings.enable_audit_log:
                     self.audit_logger.log_operation(
                         operation=name,
@@ -183,7 +185,7 @@ class EWSMCPServer:
 
                 return [TextContent(
                     type="text",
-                    text=str(result)
+                    text=safe_json_dumps(result)
                 )]
 
             except Exception as e:
@@ -191,14 +193,14 @@ class EWSMCPServer:
                 error_response = self.error_handler.handle_exception(e, f"Tool: {name}")
                 return [TextContent(
                     type="text",
-                    text=str(error_response)
+                    text=safe_json_dumps(error_response)
                 )]
 
     def register_tools(self):
-        """Register all enabled tools (36 base tools, up to 40 with AI)."""
+        """Register all enabled tools (42 base tools, up to 46 with AI)."""
         tool_classes = []
 
-        # Email tools (11 tools — search_emails includes quick/advanced/full_text modes)
+        # Email tools (10 core + 3 drafts = 13)
         if self.settings.enable_email:
             tool_classes.extend([
                 CreateDraftTool,
@@ -382,6 +384,12 @@ class EWSMCPServer:
                     )
             elif self.settings.mcp_transport == "sse":
                 self.logger.info(f"Server ready - listening on http://{self.settings.mcp_host}:{self.settings.mcp_port}")
+                if not self.settings.mcp_api_key:
+                    self.logger.warning(
+                        "SSE transport is running without MCP_API_KEY. Only /health is public; "
+                        "all other endpoints accept unauthenticated requests. Bind to 127.0.0.1 "
+                        "or set MCP_API_KEY before exposing the port beyond localhost."
+                    )
                 await self.run_sse()
 
         except KeyboardInterrupt:
@@ -451,12 +459,64 @@ class EWSMCPServer:
                     except Exception:
                         pass  # Connection already broken
 
+        # API key verification for non-health endpoints.
+        # When MCP_API_KEY is set, every request (except /health) must include
+        # either `Authorization: Bearer <key>` or `X-API-Key: <key>`.
+        api_key = self.settings.mcp_api_key
+
+        async def _send_401(send, reason: str = "Unauthorized") -> None:
+            body = b'{"success":false,"error":"' + reason.encode("utf-8") + b'"}'
+            await send({
+                "type": "http.response.start",
+                "status": 401,
+                "headers": [
+                    [b"content-type", b"application/json"],
+                    [b"content-length", str(len(body)).encode()],
+                    [b"www-authenticate", b'Bearer realm="ews-mcp"'],
+                ],
+            })
+            await send({"type": "http.response.body", "body": body})
+
+        def _authorized(headers: list) -> bool:
+            if not api_key:
+                return True
+            for name, value in headers:
+                name_lower = name.lower() if isinstance(name, bytes) else name.encode().lower()
+                if name_lower == b"authorization":
+                    raw = value.decode("utf-8", errors="replace") if isinstance(value, bytes) else value
+                    if raw.lower().startswith("bearer "):
+                        if raw[7:].strip() == api_key:
+                            return True
+                elif name_lower == b"x-api-key":
+                    raw = value.decode("utf-8", errors="replace") if isinstance(value, bytes) else value
+                    if raw.strip() == api_key:
+                        return True
+            return False
+
         # Create a simple ASGI router that handles both MCP and REST endpoints
         async def app(scope, receive, send):
             """ASGI router for MCP SSE transport + REST API."""
             if scope["type"] == "http":
                 path = scope["path"]
                 method = scope["method"]
+
+                # Health check is always public
+                if path == "/health" and method == "GET":
+                    await send({
+                        "type": "http.response.start",
+                        "status": 200,
+                        "headers": [[b"content-type", b"application/json"]],
+                    })
+                    await send({
+                        "type": "http.response.body",
+                        "body": b'{"status":"ok","tools":' + str(len(self.tools)).encode() + b'}',
+                    })
+                    return
+
+                # All other endpoints require auth when MCP_API_KEY is set
+                if not _authorized(scope.get("headers") or []):
+                    await _send_401(send)
+                    return
 
                 # MCP SSE endpoints
                 if path == "/sse" and method == "GET":
@@ -515,18 +575,6 @@ class EWSMCPServer:
                     await send({
                         "type": "http.response.body",
                         "body": response_body,
-                    })
-
-                elif path == "/health" and method == "GET":
-                    # Health check
-                    await send({
-                        "type": "http.response.start",
-                        "status": 200,
-                        "headers": [[b"content-type", b"application/json"]],
-                    })
-                    await send({
-                        "type": "http.response.body",
-                        "body": b'{"status":"ok","tools":' + str(len(self.tools)).encode() + b'}',
                     })
 
                 else:

--- a/src/middleware/circuit_breaker.py
+++ b/src/middleware/circuit_breaker.py
@@ -6,6 +6,7 @@ Trips after N consecutive failures, resets after timeout.
 
 import time
 import logging
+import threading
 from enum import Enum
 from typing import Optional
 
@@ -19,7 +20,12 @@ class CircuitState(str, Enum):
 
 
 class CircuitBreaker:
-    """Simple circuit breaker for EWS operations."""
+    """Thread-safe circuit breaker for EWS operations.
+
+    A single lock guards state/count transitions so concurrent tool
+    executions (SSE + asyncio.gather) can't race on failure counts or
+    on the CLOSED → OPEN → HALF_OPEN → CLOSED walk.
+    """
 
     def __init__(
         self,
@@ -34,45 +40,49 @@ class CircuitBreaker:
         self.failure_count = 0
         self.last_failure_time: Optional[float] = None
         self.logger = logging.getLogger(__name__)
+        self._lock = threading.Lock()
 
     def check(self) -> None:
         """Check if requests are allowed. Raises if circuit is open."""
-        if self.state == CircuitState.CLOSED:
-            return
-
-        if self.state == CircuitState.OPEN:
-            elapsed = time.time() - (self.last_failure_time or 0)
-            if elapsed >= self.reset_timeout:
-                self.state = CircuitState.HALF_OPEN
-                self.logger.info(f"Circuit '{self.name}' half-open, allowing probe request")
+        with self._lock:
+            if self.state == CircuitState.CLOSED:
                 return
-            raise ToolExecutionError(
-                f"Exchange unavailable (circuit open). Retry in {int(self.reset_timeout - elapsed)}s."
-            )
 
-        # HALF_OPEN: allow one probe request
-        return
+            if self.state == CircuitState.OPEN:
+                elapsed = time.time() - (self.last_failure_time or 0)
+                if elapsed >= self.reset_timeout:
+                    self.state = CircuitState.HALF_OPEN
+                    self.logger.info(f"Circuit '{self.name}' half-open, allowing probe request")
+                    return
+                raise ToolExecutionError(
+                    f"Exchange unavailable (circuit open). Retry in {int(self.reset_timeout - elapsed)}s."
+                )
+
+            # HALF_OPEN: allow one probe request
+            return
 
     def record_success(self) -> None:
         """Record a successful request."""
-        if self.state == CircuitState.HALF_OPEN:
-            self.logger.info(f"Circuit '{self.name}' recovered, closing")
-        self.state = CircuitState.CLOSED
-        self.failure_count = 0
+        with self._lock:
+            if self.state == CircuitState.HALF_OPEN:
+                self.logger.info(f"Circuit '{self.name}' recovered, closing")
+            self.state = CircuitState.CLOSED
+            self.failure_count = 0
 
     def record_failure(self) -> None:
         """Record a failed request."""
-        self.failure_count += 1
-        self.last_failure_time = time.time()
+        with self._lock:
+            self.failure_count += 1
+            self.last_failure_time = time.time()
 
-        if self.state == CircuitState.HALF_OPEN:
-            self.state = CircuitState.OPEN
-            self.logger.warning(f"Circuit '{self.name}' re-opened after probe failure")
-        elif self.failure_count >= self.failure_threshold:
-            self.state = CircuitState.OPEN
-            self.logger.warning(
-                f"Circuit '{self.name}' opened after {self.failure_count} consecutive failures"
-            )
+            if self.state == CircuitState.HALF_OPEN:
+                self.state = CircuitState.OPEN
+                self.logger.warning(f"Circuit '{self.name}' re-opened after probe failure")
+            elif self.failure_count >= self.failure_threshold:
+                self.state = CircuitState.OPEN
+                self.logger.warning(
+                    f"Circuit '{self.name}' opened after {self.failure_count} consecutive failures"
+                )
 
 
 # Global instance

--- a/src/middleware/error_handler.py
+++ b/src/middleware/error_handler.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 from ..exceptions import (
     EWSMCPException,
     AuthenticationError,
-    ConnectionError,
+    EWSConnectionError,
     RateLimitError,
     ValidationError,
     ToolExecutionError
@@ -23,7 +23,7 @@ class ErrorHandler:
         error_msg = f"{context}: {str(e)}" if context else str(e)
 
         # Log based on error type
-        if isinstance(e, (AuthenticationError, ConnectionError)):
+        if isinstance(e, (AuthenticationError, EWSConnectionError)):
             self.logger.error(f"Critical error: {error_msg}")
         elif isinstance(e, (ValidationError, RateLimitError)):
             self.logger.warning(f"User error: {error_msg}")
@@ -42,5 +42,5 @@ class ErrorHandler:
 
     def _is_retryable(self, e: Exception) -> bool:
         """Determine if error is retryable."""
-        retryable_types = (ConnectionError, RateLimitError)
+        retryable_types = (EWSConnectionError, RateLimitError)
         return isinstance(e, retryable_types)

--- a/src/middleware/logging.py
+++ b/src/middleware/logging.py
@@ -7,6 +7,63 @@ from pathlib import Path
 from typing import Any, Dict
 
 
+# Fields whose values must be redacted before being written to any log (audit
+# or otherwise). Match is case-insensitive and substring-based so variants
+# like "client_secret", "access_token", "auth_token" are covered.
+_SENSITIVE_KEY_PATTERNS: tuple = (
+    "password", "token", "secret", "api_key", "apikey", "authorization",
+    # Mail content — bodies can contain PII, attachments are base64 blobs.
+    "body", "html_body", "text_body",
+    "file_content", "content_base64", "mime_content", "mime_content_base64",
+    "inline_attachments",
+)
+
+
+def _is_sensitive(key: str) -> bool:
+    lower = str(key).lower()
+    return any(pattern in lower for pattern in _SENSITIVE_KEY_PATTERNS)
+
+
+def redact_sensitive(obj: Any, max_str: int = 200) -> Any:
+    """Return a copy of obj with sensitive fields replaced by "[redacted]".
+
+    - Dict keys that match _SENSITIVE_KEY_PATTERNS are replaced whole-value.
+    - Lists/tuples are walked recursively.
+    - Long strings are truncated so a single audit line cannot grow unbounded.
+    """
+    if obj is None:
+        return None
+    if isinstance(obj, str):
+        if len(obj) > max_str:
+            return obj[: max_str - 3] + "..."
+        return obj
+    if isinstance(obj, (int, float, bool)):
+        return obj
+    if isinstance(obj, dict):
+        redacted: Dict[str, Any] = {}
+        for key, value in obj.items():
+            if _is_sensitive(key):
+                if isinstance(value, (list, tuple)):
+                    redacted[key] = f"[redacted: {len(value)} item(s)]"
+                elif isinstance(value, str):
+                    redacted[key] = f"[redacted: {len(value)} chars]"
+                else:
+                    redacted[key] = "[redacted]"
+            else:
+                redacted[key] = redact_sensitive(value, max_str)
+        return redacted
+    if isinstance(obj, (list, tuple)):
+        return [redact_sensitive(item, max_str) for item in obj]
+    # Fallback: stringify and truncate.
+    try:
+        text = str(obj)
+    except Exception:
+        return "[non-serializable]"
+    if len(text) > max_str:
+        return text[: max_str - 3] + "..."
+    return text
+
+
 DEFAULT_LOG_DIR = Path("logs")
 FALLBACK_LOG_DIR = Path("/tmp/ews_mcp_logs")
 
@@ -109,10 +166,15 @@ class AuditLogger:
         success: bool,
         details: Dict[str, Any] = None
     ) -> None:
-        """Log operation for audit trail."""
+        """Log operation for audit trail.
+
+        Sensitive fields in `details` (passwords, tokens, email bodies,
+        attachment bytes) are redacted before being written to audit.log.
+        """
         message = f"op={operation} | user={user} | success={success}"
         if details:
-            message += f" | {details}"
+            safe_details = redact_sensitive(details)
+            message += f" | {safe_details}"
 
         if success:
             self.logger.info(message)

--- a/src/middleware/rate_limiter.py
+++ b/src/middleware/rate_limiter.py
@@ -4,34 +4,44 @@ from collections import deque
 from time import time
 from typing import Optional
 import logging
+import threading
 
 from ..exceptions import RateLimitError
 
 
 class RateLimiter:
-    """Token bucket rate limiter for controlling request rates."""
+    """Sliding-window rate limiter for controlling request rates.
+
+    Thread-safe: a single lock guards the request timestamp deque so the
+    SSE transport + asyncio.gather paths don't race when mutating the
+    window boundaries.
+    """
 
     def __init__(self, requests_per_minute: int):
         self.requests_per_minute = requests_per_minute
         self.requests = deque()
         self.window_seconds = 60
         self.logger = logging.getLogger(__name__)
+        self._lock = threading.Lock()
 
     def is_allowed(self) -> bool:
         """Check if request is allowed under rate limit."""
         now = time()
         window_start = now - self.window_seconds
 
-        # Remove old requests outside the window
-        while self.requests and self.requests[0] < window_start:
-            self.requests.popleft()
+        with self._lock:
+            # Remove old requests outside the window
+            while self.requests and self.requests[0] < window_start:
+                self.requests.popleft()
 
-        # Check if we're under the limit
-        if len(self.requests) < self.requests_per_minute:
-            self.requests.append(now)
-            return True
+            # Check if we're under the limit
+            if len(self.requests) < self.requests_per_minute:
+                self.requests.append(now)
+                return True
 
-        self.logger.warning(f"Rate limit exceeded: {len(self.requests)} requests in last minute")
+            over_limit_count = len(self.requests)
+
+        self.logger.warning(f"Rate limit exceeded: {over_limit_count} requests in last minute")
         return False
 
     def check_and_raise(self) -> None:
@@ -46,13 +56,13 @@ class RateLimiter:
         now = time()
         window_start = now - self.window_seconds
 
-        # Remove old requests
-        while self.requests and self.requests[0] < window_start:
-            self.requests.popleft()
-
-        return max(0, self.requests_per_minute - len(self.requests))
+        with self._lock:
+            while self.requests and self.requests[0] < window_start:
+                self.requests.popleft()
+            return max(0, self.requests_per_minute - len(self.requests))
 
     def reset(self) -> None:
         """Reset the rate limiter."""
-        self.requests.clear()
+        with self._lock:
+            self.requests.clear()
         self.logger.info("Rate limiter reset")

--- a/src/openapi_adapter.py
+++ b/src/openapi_adapter.py
@@ -153,15 +153,19 @@ class OpenAPIAdapter:
             ],
             "components": {
                 "securitySchemes": {
-                    "basicAuth": {
+                    "bearerAuth": {
                         "type": "http",
-                        "scheme": "basic",
-                        "description": "Exchange credentials passed via environment variables"
+                        "scheme": "bearer",
+                        "description": (
+                            "Set MCP_API_KEY on the server; clients send "
+                            "'Authorization: Bearer <key>' (or X-API-Key header) "
+                            "on every non-health request."
+                        )
                     }
                 }
             },
             "security": [
-                {"basicAuth": []}
+                {"bearerAuth": []}
             ]
         }
 
@@ -250,12 +254,28 @@ class OpenAPIAdapter:
             tool = self.tools[tool_name]
             result = await tool.safe_execute(**arguments)
 
-            # Return successful response
+            # Map tool-level failure to an HTTP status so proxies / clients
+            # can branch on the transport-level result. Tools surface the
+            # category in result["error_type"] when available.
+            status = 200
+            if not result.get("success", False):
+                error_type = str(result.get("error_type", "")).lower()
+                if "validation" in error_type:
+                    status = 400
+                elif "authentication" in error_type:
+                    status = 401
+                elif "ratelimit" in error_type or "rate_limit" in error_type:
+                    status = 429
+                elif "connection" in error_type:
+                    status = 503
+                else:
+                    status = 500
+
             return {
                 "success": result.get("success", False),
                 "data": result,
-                "message": result.get("message", ""),
-                "status": 200
+                "message": result.get("message", result.get("error", "")),
+                "status": status
             }
 
         except Exception as e:

--- a/src/services/attachment_service.py
+++ b/src/services/attachment_service.py
@@ -128,12 +128,15 @@ class AttachmentService:
     async def _get_message(self, message_id: str):
         """Get message from any folder."""
         for folder_name in ['inbox', 'sent', 'drafts']:
-            folder = getattr(self.ews_client.account, folder_name)
+            folder = getattr(self.ews_client.account, folder_name, None)
+            if folder is None:
+                continue
             try:
                 message = folder.get(id=message_id)
                 if message:
                     return message
-            except:
+            except Exception as e:
+                self.logger.debug(f"Message not in {folder_name}: {e}")
                 continue
         return None
 
@@ -421,8 +424,8 @@ class AttachmentService:
                             with zf.open(file_info) as f:
                                 content_text = f.read().decode('utf-8')
                                 result.extracted_content[file_info.filename] = content_text
-                        except:
-                            pass
+                        except Exception as e:
+                            self.logger.debug(f"Skipped {file_info.filename}: {e}")
 
             result.success = True
             return result

--- a/src/services/email_service.py
+++ b/src/services/email_service.py
@@ -130,14 +130,27 @@ class EmailService:
             EmailMessage object or None
         """
         try:
-            # Search in multiple folders
-            for folder_name in ['inbox', 'sent', 'drafts', 'deleted']:
-                folder = getattr(self.ews_client.account, folder_name)
+            # Search across the common folders. exchangelib exposes the
+            # Deleted Items folder as `trash`, not `deleted` — fetching
+            # `account.deleted` used to raise and get swallowed by a bare
+            # except, silently dropping messages in Deleted Items.
+            account = self.ews_client.account
+            candidates = [
+                ('inbox', getattr(account, 'inbox', None)),
+                ('sent', getattr(account, 'sent', None)),
+                ('drafts', getattr(account, 'drafts', None)),
+                ('deleted', getattr(account, 'trash', None)),
+                ('junk', getattr(account, 'junk', None)),
+            ]
+            for folder_name, folder in candidates:
+                if folder is None:
+                    continue
                 try:
                     message = folder.get(id=message_id)
                     if message:
                         return EmailMessage.from_ews_message(message)
-                except:
+                except Exception as e:
+                    self.logger.debug(f"Message not in {folder_name}: {e}")
                     continue
 
             return None

--- a/src/services/thread_service.py
+++ b/src/services/thread_service.py
@@ -47,16 +47,26 @@ class ThreadService:
         self.logger.info(f"Getting thread for message: {message_id}")
 
         try:
-            # Get the original message
-            # Search in multiple folders
+            # Get the original message. exchangelib exposes Deleted Items as
+            # `trash`, not `deleted`, so enumerate explicitly and skip folders
+            # that don't exist rather than catching a bare except.
             message = None
-            for folder_name in ['inbox', 'sent', 'drafts']:
-                folder = getattr(self.ews_client.account, folder_name)
+            account = self.ews_client.account
+            candidates = [
+                ('inbox', getattr(account, 'inbox', None)),
+                ('sent', getattr(account, 'sent', None)),
+                ('drafts', getattr(account, 'drafts', None)),
+                ('deleted', getattr(account, 'trash', None)),
+            ]
+            for folder_name, folder in candidates:
+                if folder is None:
+                    continue
                 try:
                     message = folder.get(id=message_id)
                     if message:
                         break
-                except:
+                except Exception as e:
+                    self.logger.debug(f"Message not in {folder_name}: {e}")
                     continue
 
             if not message:

--- a/src/tools/ai_tools.py
+++ b/src/tools/ai_tools.py
@@ -3,8 +3,16 @@
 from typing import Any, Dict
 from .base import BaseTool
 from ..exceptions import ToolExecutionError
-from ..utils import format_success_response, safe_get, find_message_across_folders
+from ..utils import format_success_response, safe_get, find_message_for_account
 from ..ai import get_ai_provider, get_embedding_provider, EmailClassificationService, EmbeddingService
+
+
+_TARGET_MAILBOX_SCHEMA = {
+    "target_mailbox": {
+        "type": "string",
+        "description": "Email address to operate on (requires EWS_IMPERSONATION_ENABLED=true)"
+    }
+}
 
 
 class SemanticSearchEmailsTool(BaseTool):
@@ -40,7 +48,8 @@ class SemanticSearchEmailsTool(BaseTool):
                         "default": 0.7,
                         "minimum": 0.0,
                         "maximum": 1.0
-                    }
+                    },
+                    **_TARGET_MAILBOX_SCHEMA
                 },
                 "required": ["query"]
             }
@@ -52,6 +61,7 @@ class SemanticSearchEmailsTool(BaseTool):
         folder_name = kwargs.get("folder", "inbox").lower()
         max_results = kwargs.get("max_results", 10)
         threshold = kwargs.get("threshold", 0.7)
+        target_mailbox = kwargs.get("target_mailbox")
 
         if not query:
             raise ToolExecutionError("query is required")
@@ -64,16 +74,18 @@ class SemanticSearchEmailsTool(BaseTool):
 
             embedding_service = EmbeddingService(embedding_provider, cache_dir="data/embeddings")
 
-            # Get folder
+            account = self.get_account(target_mailbox)
+            mailbox = self.get_mailbox_info(target_mailbox)
+
             folder_map = {
-                "inbox": self.ews_client.account.inbox,
-                "sent": self.ews_client.account.sent,
-                "drafts": self.ews_client.account.drafts,
-                "archive": self.ews_client.account.archive,
-                "all": self.ews_client.account.inbox  # For now, just inbox
+                "inbox": account.inbox,
+                "sent": account.sent,
+                "drafts": account.drafts,
+                "archive": getattr(account, 'archive', account.inbox),
+                "all": account.inbox,  # Placeholder; "all" maps to inbox today
             }
 
-            folder = folder_map.get(folder_name, self.ews_client.account.inbox)
+            folder = folder_map.get(folder_name, account.inbox)
 
             # Fetch recent emails
             emails = list(folder.all().order_by('-datetime_received')[:100])
@@ -116,7 +128,8 @@ class SemanticSearchEmailsTool(BaseTool):
                 f"Found {len(formatted_results)} semantically similar emails",
                 query=query,
                 result_count=len(formatted_results),
-                results=formatted_results
+                results=formatted_results,
+                mailbox=mailbox
             )
 
         except ToolExecutionError:
@@ -144,7 +157,8 @@ class ClassifyEmailTool(BaseTool):
                         "type": "boolean",
                         "description": "Include spam/phishing detection",
                         "default": False
-                    }
+                    },
+                    **_TARGET_MAILBOX_SCHEMA
                 },
                 "required": ["message_id"]
             }
@@ -154,6 +168,7 @@ class ClassifyEmailTool(BaseTool):
         """Execute email classification."""
         message_id = kwargs.get("message_id")
         include_spam = kwargs.get("include_spam_detection", False)
+        target_mailbox = kwargs.get("target_mailbox")
 
         if not message_id:
             raise ToolExecutionError("message_id is required")
@@ -166,8 +181,10 @@ class ClassifyEmailTool(BaseTool):
 
             classification_service = EmailClassificationService(ai_provider)
 
-            # Find message across all folders (including custom subfolders)
-            message = find_message_across_folders(self.ews_client, message_id)
+            # Resolve account (honours target_mailbox when impersonation is enabled).
+            account = self.get_account(target_mailbox)
+            mailbox = self.get_mailbox_info(target_mailbox)
+            message = find_message_for_account(account, message_id)
 
             # Extract email details
             subject = safe_get(message, 'subject', '')
@@ -188,7 +205,8 @@ class ClassifyEmailTool(BaseTool):
                 "Email classified successfully",
                 message_id=message_id,
                 subject=subject,
-                classification=classification
+                classification=classification,
+                mailbox=mailbox
             )
 
         except ToolExecutionError:
@@ -218,7 +236,8 @@ class SummarizeEmailTool(BaseTool):
                         "default": 200,
                         "minimum": 50,
                         "maximum": 500
-                    }
+                    },
+                    **_TARGET_MAILBOX_SCHEMA
                 },
                 "required": ["message_id"]
             }
@@ -228,6 +247,7 @@ class SummarizeEmailTool(BaseTool):
         """Execute email summarization."""
         message_id = kwargs.get("message_id")
         max_length = kwargs.get("max_length", 200)
+        target_mailbox = kwargs.get("target_mailbox")
 
         if not message_id:
             raise ToolExecutionError("message_id is required")
@@ -240,8 +260,9 @@ class SummarizeEmailTool(BaseTool):
 
             classification_service = EmailClassificationService(ai_provider)
 
-            # Find message across all folders (including custom subfolders)
-            message = find_message_across_folders(self.ews_client, message_id)
+            account = self.get_account(target_mailbox)
+            mailbox = self.get_mailbox_info(target_mailbox)
+            message = find_message_for_account(account, message_id)
 
             # Extract email details
             subject = safe_get(message, 'subject', '')
@@ -261,7 +282,8 @@ class SummarizeEmailTool(BaseTool):
                 message_id=message_id,
                 subject=subject,
                 summary=summary,
-                summary_length=len(summary)
+                summary_length=len(summary),
+                mailbox=mailbox
             )
 
         except ToolExecutionError:
@@ -291,7 +313,8 @@ class SuggestRepliesTool(BaseTool):
                         "default": 3,
                         "minimum": 1,
                         "maximum": 5
-                    }
+                    },
+                    **_TARGET_MAILBOX_SCHEMA
                 },
                 "required": ["message_id"]
             }
@@ -301,6 +324,7 @@ class SuggestRepliesTool(BaseTool):
         """Execute smart reply suggestion generation."""
         message_id = kwargs.get("message_id")
         num_suggestions = kwargs.get("num_suggestions", 3)
+        target_mailbox = kwargs.get("target_mailbox")
 
         if not message_id:
             raise ToolExecutionError("message_id is required")
@@ -313,8 +337,9 @@ class SuggestRepliesTool(BaseTool):
 
             classification_service = EmailClassificationService(ai_provider)
 
-            # Find message across all folders (including custom subfolders)
-            message = find_message_across_folders(self.ews_client, message_id)
+            account = self.get_account(target_mailbox)
+            mailbox = self.get_mailbox_info(target_mailbox)
+            message = find_message_for_account(account, message_id)
 
             # Extract email details
             subject = safe_get(message, 'subject', '')
@@ -336,7 +361,8 @@ class SuggestRepliesTool(BaseTool):
                 message_id=message_id,
                 subject=subject,
                 suggestions=suggestions,
-                suggestion_count=len(suggestions)
+                suggestion_count=len(suggestions),
+                mailbox=mailbox
             )
 
         except ToolExecutionError:

--- a/src/tools/attachment_tools.py
+++ b/src/tools/attachment_tools.py
@@ -3,6 +3,8 @@
 from typing import Any, Dict, List
 import base64
 import io
+import os
+import re
 from pathlib import Path
 
 from exchangelib import Body, HTMLBody, ItemAttachment, Message
@@ -10,6 +12,49 @@ from exchangelib import Body, HTMLBody, ItemAttachment, Message
 from .base import BaseTool
 from ..exceptions import ToolExecutionError
 from ..utils import format_success_response, safe_get, find_message_across_folders, find_message_for_account
+
+
+# Download jail for attachment file writes. Default: ./downloads inside the
+# project working directory (created on first use). Operators can override via
+# EWS_DOWNLOAD_DIR. download_attachment(save_path=...) is interpreted relative
+# to this directory; absolute paths, "..", and symlinks that escape the jail
+# are rejected.
+_DEFAULT_DOWNLOAD_DIR = Path(os.environ.get("EWS_DOWNLOAD_DIR", "downloads"))
+
+
+def _safe_basename(name: str) -> str:
+    """Strip directory traversal / path separators from a user-supplied name."""
+    if not name:
+        return "attachment"
+    name = os.path.basename(name)
+    # Collapse any remaining path-like characters
+    name = re.sub(r"[\\/]+", "_", name).strip()
+    return name or "attachment"
+
+
+def resolve_download_path(save_path: str | None, default_name: str) -> Path:
+    """Resolve a save_path into a safe, jailed absolute Path.
+
+    - If save_path is None/empty, use default_name inside the jail.
+    - If save_path contains a directory part, only the basename is honoured.
+    - The returned path is guaranteed to live inside the download jail.
+    """
+    jail = _DEFAULT_DOWNLOAD_DIR.resolve()
+    jail.mkdir(parents=True, exist_ok=True)
+
+    filename = _safe_basename(save_path) if save_path else _safe_basename(default_name)
+    candidate = (jail / filename).resolve()
+
+    # Verify the resolved path is still inside the jail (defence against
+    # symlink tricks or unusual basename behaviour).
+    try:
+        candidate.relative_to(jail)
+    except ValueError:
+        raise ToolExecutionError(
+            "Invalid save_path: resolved outside the download directory"
+        )
+
+    return candidate
 
 
 def extract_attachment_id(attachment) -> str:
@@ -232,13 +277,11 @@ class DownloadAttachmentTool(BaseTool):
                 )
 
             elif return_as == "file_path":
-                # Save to file
-                file_path = Path(save_path)
+                # Save to file, jailed under the configured download directory.
+                # save_path is treated as a basename hint only; directory
+                # components are stripped and "../" is neutralised.
+                file_path = resolve_download_path(save_path, attachment_name)
 
-                # Create parent directories if they don't exist
-                file_path.parent.mkdir(parents=True, exist_ok=True)
-
-                # Write content to file
                 with open(file_path, 'wb') as f:
                     f.write(content)
 
@@ -631,6 +674,120 @@ class ReadAttachmentTool(BaseTool):
             self.logger.error(f"Failed to read attachment: {e}")
             raise ToolExecutionError(f"Failed to read attachment: {e}")
 
+    def _read_pdf(self, content: bytes, extract_tables: bool, max_pages: int) -> str:
+        """Extract text from PDF using pdfplumber."""
+        try:
+            import pdfplumber
+        except ImportError:
+            raise ToolExecutionError(
+                "pdfplumber not installed. Run: pip install pdfplumber>=0.10.0"
+            )
+
+        text_parts = []
+        pdf_bytes = io.BytesIO(content)
+
+        try:
+            with pdfplumber.open(pdf_bytes) as pdf:
+                total_pages = len(pdf.pages)
+                pages_to_process = min(total_pages, max_pages)
+
+                for page_num in range(pages_to_process):
+                    page = pdf.pages[page_num]
+                    text_parts.append(f"--- Page {page_num + 1} of {total_pages} ---")
+
+                    # Extract text (supports UTF-8/Arabic)
+                    page_text = page.extract_text()
+                    if page_text:
+                        text_parts.append(page_text)
+
+                    # Extract tables if requested
+                    if extract_tables:
+                        tables = page.extract_tables()
+                        for table_num, table in enumerate(tables, 1):
+                            text_parts.append(f"\n[Table {table_num}]")
+                            for row in table:
+                                row_text = " | ".join(str(cell) if cell else "" for cell in row)
+                                text_parts.append(row_text)
+
+                if total_pages > max_pages:
+                    text_parts.append(f"\n... (truncated at {max_pages} pages, {total_pages - max_pages} pages omitted)")
+
+            return "\n\n".join(text_parts)
+
+        except Exception as e:
+            raise ToolExecutionError(f"Failed to read PDF: {str(e)}")
+
+    def _read_docx(self, content: bytes, extract_tables: bool) -> str:
+        """Extract text from DOCX using python-docx."""
+        try:
+            from docx import Document
+        except ImportError:
+            raise ToolExecutionError(
+                "python-docx not installed. Run: pip install python-docx>=1.0.0"
+            )
+
+        text_parts = []
+        docx_bytes = io.BytesIO(content)
+
+        try:
+            doc = Document(docx_bytes)
+
+            # Extract paragraphs (supports UTF-8/Arabic)
+            for para in doc.paragraphs:
+                if para.text.strip():
+                    text_parts.append(para.text)
+
+            # Extract tables if requested
+            if extract_tables:
+                for table_num, table in enumerate(doc.tables, 1):
+                    text_parts.append(f"\n[Table {table_num}]")
+                    for row in table.rows:
+                        row_text = " | ".join(cell.text.strip() for cell in row.cells)
+                        if row_text.strip():
+                            text_parts.append(row_text)
+
+            return "\n\n".join(text_parts)
+
+        except Exception as e:
+            raise ToolExecutionError(f"Failed to read DOCX: {str(e)}")
+
+    def _read_excel(self, content: bytes) -> str:
+        """Extract data from Excel using openpyxl."""
+        try:
+            import openpyxl
+        except ImportError:
+            raise ToolExecutionError(
+                "openpyxl not installed. Run: pip install openpyxl>=3.1.0"
+            )
+
+        text_parts = []
+        excel_bytes = io.BytesIO(content)
+
+        try:
+            # Load workbook (data_only=True to get calculated values)
+            workbook = openpyxl.load_workbook(excel_bytes, data_only=True)
+
+            for sheet_name in workbook.sheetnames:
+                sheet = workbook[sheet_name]
+                text_parts.append(f"--- Sheet: {sheet_name} ---")
+
+                # Extract all rows
+                for row in sheet.iter_rows(values_only=True):
+                    # Skip empty rows
+                    if any(cell is not None for cell in row):
+                        row_text = " | ".join(
+                            str(cell) if cell is not None else ""
+                            for cell in row
+                        )
+                        text_parts.append(row_text)
+
+                text_parts.append("")  # Empty line between sheets
+
+            return "\n".join(text_parts)
+
+        except Exception as e:
+            raise ToolExecutionError(f"Failed to read Excel: {str(e)}")
+
 
 class GetEmailMimeTool(BaseTool):
     """Tool for retrieving raw MIME content for an email."""
@@ -755,117 +912,3 @@ class AttachEmailToDraftTool(BaseTool):
         except Exception as e:
             self.logger.error(f"Failed to attach email to draft: {e}")
             raise ToolExecutionError(f"Failed to attach email to draft: {e}")
-
-    def _read_pdf(self, content: bytes, extract_tables: bool, max_pages: int) -> str:
-        """Extract text from PDF using pdfplumber."""
-        try:
-            import pdfplumber
-        except ImportError:
-            raise ToolExecutionError(
-                "pdfplumber not installed. Run: pip install pdfplumber>=0.10.0"
-            )
-
-        text_parts = []
-        pdf_bytes = io.BytesIO(content)
-
-        try:
-            with pdfplumber.open(pdf_bytes) as pdf:
-                total_pages = len(pdf.pages)
-                pages_to_process = min(total_pages, max_pages)
-
-                for page_num in range(pages_to_process):
-                    page = pdf.pages[page_num]
-                    text_parts.append(f"--- Page {page_num + 1} of {total_pages} ---")
-
-                    # Extract text (supports UTF-8/Arabic)
-                    page_text = page.extract_text()
-                    if page_text:
-                        text_parts.append(page_text)
-
-                    # Extract tables if requested
-                    if extract_tables:
-                        tables = page.extract_tables()
-                        for table_num, table in enumerate(tables, 1):
-                            text_parts.append(f"\n[Table {table_num}]")
-                            for row in table:
-                                row_text = " | ".join(str(cell) if cell else "" for cell in row)
-                                text_parts.append(row_text)
-
-                if total_pages > max_pages:
-                    text_parts.append(f"\n... (truncated at {max_pages} pages, {total_pages - max_pages} pages omitted)")
-
-            return "\n\n".join(text_parts)
-
-        except Exception as e:
-            raise ToolExecutionError(f"Failed to read PDF: {str(e)}")
-
-    def _read_docx(self, content: bytes, extract_tables: bool) -> str:
-        """Extract text from DOCX using python-docx."""
-        try:
-            from docx import Document
-        except ImportError:
-            raise ToolExecutionError(
-                "python-docx not installed. Run: pip install python-docx>=1.0.0"
-            )
-
-        text_parts = []
-        docx_bytes = io.BytesIO(content)
-
-        try:
-            doc = Document(docx_bytes)
-
-            # Extract paragraphs (supports UTF-8/Arabic)
-            for para in doc.paragraphs:
-                if para.text.strip():
-                    text_parts.append(para.text)
-
-            # Extract tables if requested
-            if extract_tables:
-                for table_num, table in enumerate(doc.tables, 1):
-                    text_parts.append(f"\n[Table {table_num}]")
-                    for row in table.rows:
-                        row_text = " | ".join(cell.text.strip() for cell in row.cells)
-                        if row_text.strip():
-                            text_parts.append(row_text)
-
-            return "\n\n".join(text_parts)
-
-        except Exception as e:
-            raise ToolExecutionError(f"Failed to read DOCX: {str(e)}")
-
-    def _read_excel(self, content: bytes) -> str:
-        """Extract data from Excel using openpyxl."""
-        try:
-            import openpyxl
-        except ImportError:
-            raise ToolExecutionError(
-                "openpyxl not installed. Run: pip install openpyxl>=3.1.0"
-            )
-
-        text_parts = []
-        excel_bytes = io.BytesIO(content)
-
-        try:
-            # Load workbook (data_only=True to get calculated values)
-            workbook = openpyxl.load_workbook(excel_bytes, data_only=True)
-
-            for sheet_name in workbook.sheetnames:
-                sheet = workbook[sheet_name]
-                text_parts.append(f"--- Sheet: {sheet_name} ---")
-
-                # Extract all rows
-                for row in sheet.iter_rows(values_only=True):
-                    # Skip empty rows
-                    if any(cell is not None for cell in row):
-                        row_text = " | ".join(
-                            str(cell) if cell is not None else ""
-                            for cell in row
-                        )
-                        text_parts.append(row_text)
-
-                text_parts.append("")  # Empty line between sheets
-
-            return "\n".join(text_parts)
-
-        except Exception as e:
-            raise ToolExecutionError(f"Failed to read Excel: {str(e)}")

--- a/src/tools/calendar_tools.py
+++ b/src/tools/calendar_tools.py
@@ -268,12 +268,15 @@ class GetCalendarTool(BaseTool):
             else:
                 start_date = make_tz_aware(datetime.now())
 
-            end_date = kwargs.get("end_date")
-            if end_date:
-                end_date = parse_datetime_tz_aware(end_date)
-                # If end_date is at midnight (00:00:00), it means user provided date-only
-                # Add 1 day to include the full day's events
-                if end_date.hour == 0 and end_date.minute == 0 and end_date.second == 0:
+            end_date_raw = kwargs.get("end_date")
+            if end_date_raw:
+                end_date = parse_datetime_tz_aware(end_date_raw)
+                # If the caller supplied a date-only string (no 'T'), treat it
+                # as "the whole of that day" by extending through the next
+                # midnight. Previously we did this whenever the parsed time
+                # happened to be exactly 00:00:00, which over-collected events
+                # whenever someone deliberately requested a midnight boundary.
+                if end_date is not None and isinstance(end_date_raw, str) and "T" not in end_date_raw:
                     end_date = end_date + timedelta(days=1)
             else:
                 # Use days_ahead parameter (default: 7, max: 90)
@@ -874,50 +877,59 @@ class FindMeetingTimesTool(BaseTool):
                     current_time = (current_time + timedelta(days=1)).replace(hour=earliest_hour, minute=0, second=0)
                     continue
 
-                # Check if all attendees are available
+                # Check if all attendees are available for the full slot.
+                # Treat missing data (slot past end of merged_free_busy) or
+                # attendees without a merged_free_busy response as BUSY so we
+                # never surface a slot we couldn't actually verify.
                 all_available = True
+                buffer_available = True
                 for busy_info in availability_data:
-                    # Check merged_free_busy string if available
-                    if hasattr(busy_info, 'merged_free_busy') and busy_info.merged_free_busy:
-                        # Calculate time offset in 15-minute intervals
-                        minutes_from_start = int((current_time - start_date).total_seconds() / 60)
-                        interval_index = minutes_from_start // 15
+                    merged = getattr(busy_info, 'merged_free_busy', None)
+                    if not merged:
+                        all_available = False
+                        break
 
-                        # Check duration worth of intervals
-                        intervals_needed = (duration_minutes + 14) // 15  # Round up
+                    minutes_from_start = int((current_time - start_date).total_seconds() / 60)
+                    interval_index = minutes_from_start // 15
+                    intervals_needed = (duration_minutes + 14) // 15  # Round up
 
-                        if interval_index + intervals_needed <= len(busy_info.merged_free_busy):
-                            for i in range(intervals_needed):
-                                status = busy_info.merged_free_busy[interval_index + i]
-                                # 0=Free, 1=Tentative, 2=Busy, 3=OOF, 4=NoData
-                                if status in ['2', '3']:  # Busy or Out of Office
-                                    all_available = False
-                                    break
+                    # Slot must fit entirely within the returned data.
+                    if interval_index + intervals_needed > len(merged):
+                        all_available = False
+                        break
 
-                            if not all_available:
+                    for i in range(intervals_needed):
+                        status = merged[interval_index + i]
+                        # 0=Free, 1=Tentative, 2=Busy, 3=OOF, 4=NoData
+                        if status in ('2', '3', '4'):
+                            all_available = False
+                            break
+
+                    if not all_available:
+                        break
+
+                    # Buffer check (only used for scoring, not for filtering).
+                    if avoid_back_to_back:
+                        buffer_intervals = max(1, min_break_minutes // 15)
+                        pre_start = max(0, interval_index - buffer_intervals)
+                        post_end = min(len(merged), interval_index + intervals_needed + buffer_intervals)
+                        for i in range(pre_start, post_end):
+                            if merged[i] in ('2', '3'):
+                                buffer_available = False
                                 break
 
                 if all_available:
-                    # Calculate a score for this time slot
                     score = 100
 
-                    # Preference scoring
                     if prefer_morning and current_time.hour < 12:
                         score += 20
                     if prefer_afternoon and current_time.hour >= 13:
                         score += 20
 
-                    # Penalize very early or very late times
                     if current_time.hour < 9 or current_time.hour > 16:
                         score -= 10
 
-                    # Check for back-to-back meetings
-                    if avoid_back_to_back:
-                        # Check 15 minutes before and after
-                        buffer_start = current_time - timedelta(minutes=min_break_minutes)
-                        buffer_end = slot_end + timedelta(minutes=min_break_minutes)
-
-                        # Simple check - if we have buffer time, add to score
+                    if avoid_back_to_back and buffer_available:
                         score += 10
 
                     suggestions.append({
@@ -929,8 +941,16 @@ class FindMeetingTimesTool(BaseTool):
                         "time_of_day": "Morning" if current_time.hour < 12 else "Afternoon" if current_time.hour < 17 else "Evening"
                     })
 
-                # Move to next 15-minute interval
-                current_time += timedelta(minutes=15)
+                    # Advance past the accepted slot (plus buffer) so we don't
+                    # emit N overlapping suggestions at 15-minute offsets of
+                    # the same hour.
+                    advance = timedelta(
+                        minutes=duration_minutes + (min_break_minutes if avoid_back_to_back else 0)
+                    )
+                    current_time = current_time + advance
+                else:
+                    # Keep scanning in 15-minute steps.
+                    current_time += timedelta(minutes=15)
 
             # Sort suggestions by score (highest first)
             suggestions.sort(key=lambda x: x['score'], reverse=True)

--- a/src/tools/email_tools.py
+++ b/src/tools/email_tools.py
@@ -27,7 +27,12 @@ import re
 from .base import BaseTool
 from ..models import SendEmailRequest, EmailSearchRequest, EmailDetails
 from ..exceptions import ToolExecutionError
-from ..utils import format_success_response, safe_get, truncate_text, parse_datetime_tz_aware, find_message_across_folders, find_message_for_account, ews_id_to_str, attach_inline_files, INLINE_ATTACHMENTS_SCHEMA
+from ..utils import (
+    format_success_response, safe_get, truncate_text, parse_datetime_tz_aware,
+    find_message_across_folders, find_message_for_account, ews_id_to_str,
+    attach_inline_files, INLINE_ATTACHMENTS_SCHEMA,
+    escape_html, format_body_for_html, sanitize_html,
+)
 from .folder_tools import find_folder_by_id, get_standard_folder_map
 
 
@@ -1092,7 +1097,7 @@ class SearchEmailsTool(BaseTool):
                     results_per_folder = max_results // len(folders) if len(folders) > 1 else max_results
                     for email in query[:results_per_folder]:
                         all_results.append({
-                            "message_id": safe_get(email, 'id', ''),
+                            "message_id": ews_id_to_str(safe_get(email, 'id', '')),
                             "subject": safe_get(email, 'subject', ''),
                             "from": safe_get(email, 'sender', {}).email_address if hasattr(safe_get(email, 'sender', {}), 'email_address') else '',
                             "to": [r.email_address for r in safe_get(email, 'to_recipients', []) if hasattr(r, 'email_address')],
@@ -1734,14 +1739,23 @@ class ReplyEmailTool(BaseTool):
                 self.logger.info(f"Reply to {original_from_email}")
 
             # Build the complete reply body manually
-            # 1. User's message at top (wrapped in WordSection1 for Exclaimer signature placement)
-            user_message = body if body else ""
+            # 1. User's message at top, rendered safely (plain text -> escaped +
+            #    <br/>, existing HTML -> lightly sanitised against script/style/
+            #    javascript: payloads). See utils.format_body_for_html.
+            user_message_html = format_body_for_html(body)
 
-            # 2. Format the reply headers from original email metadata
+            # 2. Format the reply headers from original email metadata. These
+            #    fields originate in an inbound email (attacker-controlled) and
+            #    MUST be HTML-escaped before interpolation.
             header = format_forward_header(original_message)
+            safe_from = escape_html(header.get('from', ''))
+            safe_to = escape_html(header.get('to', ''))
+            safe_cc = escape_html(header.get('cc', ''))
+            safe_sent = escape_html(header.get('sent', ''))
+            safe_subject = escape_html(header.get('subject', ''))
 
             # 3. Get the original email body HTML (preserves styles but strips document structure)
-            original_body_html = extract_body_html(original_message)
+            original_body_html = sanitize_html(extract_body_html(original_message))
             self.logger.info(f"Extracted original body: {len(original_body_html)} characters")
 
             # Clean original body - rename WordSection1 to OriginalSection
@@ -1754,15 +1768,15 @@ class ReplyEmailTool(BaseTool):
             # - Headers inline in separator div
             # - original body (with OriginalSection class to avoid Exclaimer confusion)
             complete_body = f'''<div class="WordSection1">
-<p class="MsoNormal" style="font-size:11pt;font-family:Calibri,sans-serif;">{user_message}</p>
+<p class="MsoNormal" style="font-size:11pt;font-family:Calibri,sans-serif;">{user_message_html}</p>
 </div>
 <div style="border:none;border-top:solid #E1E1E1 1.0pt;padding:3.0pt 0in 0in 0in">
-<p class="MsoNormal" style="font-size:11pt;font-family:Calibri,sans-serif;"><b>From:</b> {header['from']}<br/>
-<b>Sent:</b> {header['sent']}<br/>
-<b>To:</b> {header['to']}<br/>'''
-            if header['cc']:
-                complete_body += f'''<b>Cc:</b> {header['cc']}<br/>'''
-            complete_body += f'''<b>Subject:</b> {header['subject']}</p>
+<p class="MsoNormal" style="font-size:11pt;font-family:Calibri,sans-serif;"><b>From:</b> {safe_from}<br/>
+<b>Sent:</b> {safe_sent}<br/>
+<b>To:</b> {safe_to}<br/>'''
+            if safe_cc:
+                complete_body += f'''<b>Cc:</b> {safe_cc}<br/>'''
+            complete_body += f'''<b>Subject:</b> {safe_subject}</p>
 </div>
 {original_body_html}'''
 
@@ -1933,14 +1947,21 @@ class ForwardEmailTool(BaseTool):
             forward_subject = add_forward_prefix(original_subject)
 
             # Build the complete forward body manually
-            # 1. User's message at top (wrapped in WordSection1 for Exclaimer signature placement)
-            user_message = body if body else ""
+            # 1. User's message at top, rendered safely (plain text -> escaped +
+            #    <br/>, existing HTML -> lightly sanitised). See utils.format_body_for_html.
+            user_message_html = format_body_for_html(body)
 
-            # 2. Format the forward headers from original email metadata
+            # 2. Format the forward headers from original email metadata; these
+            #    are attacker-controlled and must be HTML-escaped.
             header = format_forward_header(original_message)
+            safe_from = escape_html(header.get('from', ''))
+            safe_to = escape_html(header.get('to', ''))
+            safe_cc = escape_html(header.get('cc', ''))
+            safe_sent = escape_html(header.get('sent', ''))
+            safe_subject = escape_html(header.get('subject', ''))
 
             # 3. Get the original email body HTML (preserves styles but strips document structure)
-            original_body_html = extract_body_html(original_message)
+            original_body_html = sanitize_html(extract_body_html(original_message))
             self.logger.info(f"Extracted original body: {len(original_body_html)} characters")
 
             # Clean original body - rename WordSection1 to OriginalSection
@@ -1949,13 +1970,13 @@ class ForwardEmailTool(BaseTool):
 
             # 4. Build headers block (Outlook format)
             headers_html = f'''<p style="font-size:11pt;font-family:Calibri,sans-serif;">
-<b>From:</b> {header['from']}<br/>
-<b>Date:</b> {header['sent']}<br/>
-<b>Subject:</b> {header['subject']}<br/>'''
-            if header['to']:
-                headers_html += f'''<b>To:</b> {header['to']}<br/>'''
-            if header['cc']:
-                headers_html += f'''<b>Cc:</b> {header['cc']}<br/>'''
+<b>From:</b> {safe_from}<br/>
+<b>Date:</b> {safe_sent}<br/>
+<b>Subject:</b> {safe_subject}<br/>'''
+            if safe_to:
+                headers_html += f'''<b>To:</b> {safe_to}<br/>'''
+            if safe_cc:
+                headers_html += f'''<b>Cc:</b> {safe_cc}<br/>'''
             headers_html += '''</p>'''
 
             # 5. Construct complete body matching Outlook's exact structure
@@ -1964,15 +1985,15 @@ class ForwardEmailTool(BaseTool):
             # - divRplyFwdMsg: headers block
             # - original body (with OriginalSection class to avoid Exclaimer confusion)
             complete_body = f'''<div class="WordSection1">
-<p class="MsoNormal" style="font-size:11pt;font-family:Calibri,sans-serif;">{user_message}</p>
+<p class="MsoNormal" style="font-size:11pt;font-family:Calibri,sans-serif;">{user_message_html}</p>
 </div>
 <div style="border:none;border-top:solid #E1E1E1 1.0pt;padding:3.0pt 0in 0in 0in">
-<p class="MsoNormal" style="font-size:11pt;font-family:Calibri,sans-serif;"><b>From:</b> {header['from']}<br/>
-<b>Sent:</b> {header['sent']}<br/>
-<b>To:</b> {header['to']}<br/>'''
-            if header['cc']:
-                complete_body += f'''<b>Cc:</b> {header['cc']}<br/>'''
-            complete_body += f'''<b>Subject:</b> {header['subject']}</p>
+<p class="MsoNormal" style="font-size:11pt;font-family:Calibri,sans-serif;"><b>From:</b> {safe_from}<br/>
+<b>Sent:</b> {safe_sent}<br/>
+<b>To:</b> {safe_to}<br/>'''
+            if safe_cc:
+                complete_body += f'''<b>Cc:</b> {safe_cc}<br/>'''
+            complete_body += f'''<b>Subject:</b> {safe_subject}</p>
 </div>
 {original_body_html}'''
 

--- a/src/tools/email_tools_draft.py
+++ b/src/tools/email_tools_draft.py
@@ -21,7 +21,11 @@ from ..utils import (
     ews_id_to_str,
     attach_inline_files,
     INLINE_ATTACHMENTS_SCHEMA,
+    escape_html,
+    format_body_for_html,
+    sanitize_html,
 )
+from .email_tools import add_reply_prefix, add_forward_prefix
 
 
 class CreateDraftTool(BaseTool):
@@ -218,7 +222,8 @@ class CreateReplyDraftTool(BaseTool):
 
             original_message = find_message_for_account(account, message_id)
             original_subject = safe_get(original_message, "subject", "") or ""
-            reply_subject = f"RE: {original_subject}" if original_subject else "RE:"
+            # Use shared prefix helpers so we don't produce "RE: RE: ..." stacks.
+            reply_subject = add_reply_prefix(original_subject) if original_subject else "RE:"
             original_sender = safe_get(original_message, "sender", None)
             original_from_email = ""
             if original_sender and hasattr(original_sender, "email_address"):
@@ -247,21 +252,31 @@ class CreateReplyDraftTool(BaseTool):
                 reply_to_recipients = [Mailbox(email_address=original_from_email)]
 
             header = format_forward_header(original_message)
-            original_body_html = extract_body_html(original_message)
+            safe_from = escape_html(header.get("from", ""))
+            safe_to = escape_html(header.get("to", ""))
+            safe_cc = escape_html(header.get("cc", ""))
+            safe_sent = escape_html(header.get("sent", ""))
+            safe_subject = escape_html(header.get("subject", ""))
+
+            original_body_html = sanitize_html(extract_body_html(original_message))
             original_body_html = clean_original_body_for_signature(original_body_html)
 
+            # Render user body safely: plain text gets HTML-escaped and newlines
+            # converted to <br/>; HTML goes through the lightweight sanitiser.
+            user_body_html = format_body_for_html(body)
+
             headers_html = f'''<p style="font-size:11pt;font-family:Calibri,sans-serif;">
-<b>From:</b> {header['from']}<br/>
-<b>Sent:</b> {header['sent']}<br/>'''
-            if header["to"]:
-                headers_html += f'''<b>To:</b> {header['to']}<br/>'''
-            if header["cc"]:
-                headers_html += f'''<b>Cc:</b> {header['cc']}<br/>'''
-            headers_html += f'''<b>Subject:</b> {header['subject']}
+<b>From:</b> {safe_from}<br/>
+<b>Sent:</b> {safe_sent}<br/>'''
+            if safe_to:
+                headers_html += f'''<b>To:</b> {safe_to}<br/>'''
+            if safe_cc:
+                headers_html += f'''<b>Cc:</b> {safe_cc}<br/>'''
+            headers_html += f'''<b>Subject:</b> {safe_subject}
 </p>'''
 
             complete_body = f'''<div class="WordSection1">
-<p class="MsoNormal" style="font-size:11pt;font-family:Calibri,sans-serif;">{body}</p>
+<p class="MsoNormal" style="font-size:11pt;font-family:Calibri,sans-serif;">{user_body_html}</p>
 </div>
 <div style="border:none;border-top:solid #E1E1E1 1.0pt;padding:3.0pt 0in 0in 0in">
 {headers_html}
@@ -393,24 +408,33 @@ class CreateForwardDraftTool(BaseTool):
 
             original_message = find_message_for_account(account, message_id)
             original_subject = safe_get(original_message, "subject", "") or ""
-            forward_subject = f"FW: {original_subject}" if original_subject else "FW:"
+            # Shared prefix helper avoids "FW: FW: ..." stacks.
+            forward_subject = add_forward_prefix(original_subject) if original_subject else "FW:"
 
             header = format_forward_header(original_message)
-            original_body_html = extract_body_html(original_message)
+            safe_from = escape_html(header.get("from", ""))
+            safe_to = escape_html(header.get("to", ""))
+            safe_cc = escape_html(header.get("cc", ""))
+            safe_sent = escape_html(header.get("sent", ""))
+            safe_subject = escape_html(header.get("subject", ""))
+
+            original_body_html = sanitize_html(extract_body_html(original_message))
             original_body_html = clean_original_body_for_signature(original_body_html)
 
+            user_body_html = format_body_for_html(body)
+
             headers_html = f'''<p style="font-size:11pt;font-family:Calibri,sans-serif;">
-<b>From:</b> {header['from']}<br/>
-<b>Date:</b> {header['sent']}<br/>
-<b>Subject:</b> {header['subject']}<br/>'''
-            if header["to"]:
-                headers_html += f'''<b>To:</b> {header['to']}<br/>'''
-            if header["cc"]:
-                headers_html += f'''<b>Cc:</b> {header['cc']}<br/>'''
+<b>From:</b> {safe_from}<br/>
+<b>Date:</b> {safe_sent}<br/>
+<b>Subject:</b> {safe_subject}<br/>'''
+            if safe_to:
+                headers_html += f'''<b>To:</b> {safe_to}<br/>'''
+            if safe_cc:
+                headers_html += f'''<b>Cc:</b> {safe_cc}<br/>'''
             headers_html += "</p>"
 
             complete_body = f'''<div class="WordSection1">
-<p class="MsoNormal" style="font-size:11pt;font-family:Calibri,sans-serif;">{body}</p>
+<p class="MsoNormal" style="font-size:11pt;font-family:Calibri,sans-serif;">{user_body_html}</p>
 </div>
 <div style="border:none;border-top:solid #E1E1E1 1.0pt;padding:3.0pt 0in 0in 0in">
 {headers_html}

--- a/src/utils.py
+++ b/src/utils.py
@@ -2,9 +2,11 @@
 
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
+import html
 import logging
 import os
 import json
+import re
 from exchangelib import EWSTimeZone, EWSDateTime, EWSDate
 import pytz
 
@@ -66,10 +68,12 @@ def make_tz_aware(dt: datetime) -> EWSDateTime:
     )
 
 
-def parse_datetime_tz_aware(dt_str: str) -> EWSDateTime:
+def parse_datetime_tz_aware(dt_str: Optional[str]) -> Optional[EWSDateTime]:
     """Parse ISO 8601 datetime string and return as EWSDateTime with EWSTimeZone.
 
-    This ensures all datetime objects used with exchangelib have the correct timezone format.
+    Returns None if the input is empty or unparseable. Callers that require
+    a value should check for None before using the result (assigning None to
+    exchangelib datetime fields is a hard-to-diagnose silent failure).
     """
     if not dt_str:
         return None
@@ -81,14 +85,16 @@ def parse_datetime_tz_aware(dt_str: str) -> EWSDateTime:
         # Convert to EWSDateTime with configured timezone
         return make_tz_aware(dt)
     except ValueError:
+        logging.getLogger(__name__).debug(f"parse_datetime_tz_aware: bad value: {dt_str!r}")
         return None
 
 
-def parse_date_tz_aware(date_str: str) -> EWSDate:
+def parse_date_tz_aware(date_str: Optional[str]) -> Optional[EWSDate]:
     """Parse ISO 8601 date/datetime string and return as EWSDate.
 
-    Used for task due_date and start_date fields which only accept EWSDate, not EWSDateTime.
-    Accepts both date-only strings (2025-11-15) and full datetime strings (2025-11-15T17:00:00+03:00).
+    Used for task due_date and start_date fields which only accept EWSDate,
+    not EWSDateTime. Accepts date-only ('2025-11-15') and datetime strings.
+    Returns None on empty/unparseable input.
     """
     if not date_str:
         return None
@@ -106,6 +112,7 @@ def parse_date_tz_aware(date_str: str) -> EWSDate:
         # Create EWSDate from the date components only (no time)
         return EWSDate(dt.year, dt.month, dt.day)
     except ValueError:
+        logging.getLogger(__name__).debug(f"parse_date_tz_aware: bad value: {date_str!r}")
         return None
 
 
@@ -126,10 +133,67 @@ def parse_datetime(dt_str: Optional[str]) -> Optional[datetime]:
         return None
 
 
-def sanitize_html(html: str) -> str:
-    """Basic HTML sanitization."""
-    # In production, use a proper HTML sanitizer like bleach
-    return html
+def escape_html(text: Any) -> str:
+    """HTML-escape an arbitrary value for safe interpolation into markup.
+
+    Returns an empty string for None. Accepts non-string values by coercing
+    to str. Use for every field that is embedded into an HTML template we
+    emit (reply/forward quoted headers, user-supplied body when treated as
+    plain text, etc.).
+    """
+    if text is None:
+        return ""
+    return html.escape(str(text), quote=True)
+
+
+def sanitize_html(html_content: str) -> str:
+    """Sanitize HTML that will be sent to Exchange.
+
+    Strips <script> and <style> blocks and dangerous inline handlers. This is
+    intentionally conservative — full allowlist sanitisation would require
+    bleach/lxml. Use escape_html for text that should never contain markup.
+    """
+    if not html_content:
+        return ""
+
+    cleaned = re.sub(
+        r"<\s*(script|style)[^>]*>.*?<\s*/\s*\1\s*>",
+        "",
+        html_content,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    # Strip event handlers (onclick=, onerror=, ...). Matches on attribute
+    # boundaries to avoid clobbering CSS selectors.
+    cleaned = re.sub(
+        r"(?i)\son[a-z]+\s*=\s*(?:\"[^\"]*\"|'[^']*'|[^\s>]+)",
+        "",
+        cleaned,
+    )
+    # Neutralise javascript: URIs inside href/src attributes.
+    cleaned = re.sub(
+        r"(?i)(href|src)\s*=\s*([\"']?)\s*javascript:",
+        r"\1=\2about:blank;",
+        cleaned,
+    )
+    return cleaned
+
+
+def format_body_for_html(body: Optional[str]) -> str:
+    """Return an HTML-safe rendering of a user-supplied body.
+
+    - If the body already contains tags, run it through sanitize_html so
+      attacker-controlled markup is neutralised while the author's intent is
+      preserved.
+    - Otherwise treat it as plain text: HTML-escape and convert newlines to
+      <br/> so line breaks survive the round trip.
+    """
+    if not body:
+        return ""
+    body = body.strip()
+    looks_like_html = bool(re.search(r"<[^>]+>", body))
+    if looks_like_html:
+        return sanitize_html(body)
+    return escape_html(body).replace("\n", "<br/>")
 
 
 def truncate_text(text: str, max_length: int = 100) -> str:
@@ -378,6 +442,25 @@ def find_message_across_folders(ews_client, message_id):
     return find_message_for_account(ews_client.account, message_id)
 
 
+def _safe_content_id(file_name: str, index: int, existing: set) -> str:
+    """Produce a safe, unique cid: value from an arbitrary file name.
+
+    Content-ID values are embedded into HTML (`cid:...`) and should be ASCII
+    with no whitespace, `<`, `>`, quotes, or collision with other inlines in
+    the same message.
+    """
+    base = re.sub(r"[^A-Za-z0-9._-]+", "-", file_name).strip("-")
+    if not base:
+        base = f"inline-{index}"
+    candidate = base
+    suffix = 1
+    while candidate in existing:
+        suffix += 1
+        candidate = f"{base}-{suffix}"
+    existing.add(candidate)
+    return candidate
+
+
 def attach_inline_files(message, inline_attachments: list) -> int:
     """Attach base64-encoded files to an EWS message or calendar item.
 
@@ -396,19 +479,27 @@ def attach_inline_files(message, inline_attachments: list) -> int:
     from exchangelib import FileAttachment
 
     count = 0
-    for att in inline_attachments:
+    used_cids: set = set()
+    for index, att in enumerate(inline_attachments):
         file_name = att.get("file_name")
         file_content = att.get("file_content")
         if not file_name or not file_content:
             continue
 
         is_inline = att.get("is_inline", False)
+        content_id = (
+            att.get("content_id")
+            or (_safe_content_id(file_name, index, used_cids) if is_inline else None)
+        )
+        if is_inline and content_id:
+            used_cids.add(content_id)
+
         file_attachment = FileAttachment(
             name=file_name,
             content=base64.b64decode(file_content),
             content_type=att.get("content_type", "application/octet-stream"),
             is_inline=is_inline,
-            content_id=file_name if is_inline else None,
+            content_id=content_id,
         )
         message.attach(file_attachment)
         count += 1

--- a/tests/test_attachment_tools.py
+++ b/tests/test_attachment_tools.py
@@ -125,20 +125,34 @@ async def test_download_attachment_as_file(mock_ews_client, tmp_path):
     mock_message.attachments = [mock_attachment]
     mock_ews_client.account.inbox.get.return_value = mock_message
 
-    # Use temporary path
-    save_path = tmp_path / "downloaded.pdf"
+    # The tool jails writes to EWS_DOWNLOAD_DIR (defaults to ./downloads).
+    # Point the jail at the pytest tmp_path and verify we still get the
+    # correct filename and content at the returned absolute path.
+    import os
+    from pathlib import Path
+    os.environ["EWS_DOWNLOAD_DIR"] = str(tmp_path)
+    # Re-import so the module picks up the new env var.
+    import importlib
+    from src.tools import attachment_tools as _at
+    importlib.reload(_at)
+
+    tool = _at.DownloadAttachmentTool(mock_ews_client)
 
     result = await tool.execute(
         message_id="test-id",
         attachment_id="att456",
         return_as="file_path",
-        save_path=str(save_path)
+        save_path="downloaded.pdf"
     )
 
     assert result["success"] is True
     assert result["name"] == "document.pdf"
     assert "file_path" in result
-    assert save_path.read_bytes() == b"PDF content here"
+    saved = Path(result["file_path"])
+    assert saved.name == "downloaded.pdf"
+    # Resolved path must live inside the jail (no traversal).
+    assert str(saved).startswith(str(tmp_path))
+    assert saved.read_bytes() == b"PDF content here"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes the 6 HIGH-severity security findings and the top code-quality bugs from the end-to-end review. Docs and CHANGELOG updated. Existing test suite status unchanged (18 pre-existing failures / 124 passing; one test updated for the download-path jail).

Security fixes
- S1  HTTP/SSE transport now enforces MCP_API_KEY (Authorization: Bearer / X-API-Key). OpenAPI schema advertises bearerAuth.
- S2  TLS cert verification on by default; EWS_INSECURE_SKIP_VERIFY is an explicit opt-in and logs a warning.
- S3  download_attachment writes jailed under EWS_DOWNLOAD_DIR; only the basename of save_path is honoured. Closes the pre-auth arbitrary-file-write path.
- S4  reply/forward/draft HTML generation HTML-escapes every header field and runs user body through a real sanitiser (script/style/ on*= / javascript: stripped). sanitize_html is no longer a no-op.
- S5  AuditLogger redacts sensitive fields (password/token/secret, body/html_body/text_body, file_content/content_base64, mime_content, inline_attachments) before writing audit.log.
- S6  MCP_HOST defaults to 127.0.0.1; server refuses non-loopback bind without MCP_API_KEY.

High code-quality fixes
- C1  ReadAttachmentTool now owns _read_pdf/_read_docx/_read_excel (were placed on AttachEmailToDraftTool, making every non-TXT extraction fail).
- C2  main.py returns safe_json_dumps(result) instead of str(result) (was emitting Python repr over the MCP transport).
- C3  find_meeting_times: missing merged_free_busy treated as busy; buffer check actually runs; accepted slots advance by duration_minutes to stop emitting overlapping 15-minute shifts.
- C4  EmailService/ThreadService use account.trash instead of the nonexistent account.deleted (previously hidden by bare except).
- C5  Drop MSAL pre-fetch in AuthHandler; exchangelib handles OAuth2 token lifecycle.
- C6  Advanced-search _search_advanced stringifies ItemId via ews_id_to_str.

Medium / Low fixes
- C7  Add threading.Lock to RateLimiter, CircuitBreaker, CacheAdapter.
- C8  Inline-attachment content_id sanitised and de-duplicated.
- C9  parse_datetime/_date_tz_aware annotated Optional; bad values log DEBUG instead of silently returning None.
- C10 CreateReplyDraftTool / CreateForwardDraftTool use add_reply_prefix / add_forward_prefix (no more RE: RE: RE:).
- C11 Plain-text bodies in reply/forward/draft HTML-escaped and newlines converted to <br/>.
- C12 ConnectionError -> EWSConnectionError (alias kept for one release). The old name shadowed the Python builtin.
- C13 GetCalendar end-date heuristic uses input format (no 'T') instead of the parsed hour being exactly midnight.
- C14 EmbeddingService._save_cache writes atomically (tempfile + os.replace).
- C15 EmbeddingService.embed_batch drops O(n^2) indices_to_embed.index.
- C16 handle_rest_request returns 400/401/429/503/500 on tool failure (was always 200).
- C17 Tool-count comments corrected (42 base + 4 AI = 46).
- C19 AI tools accept target_mailbox and route through get_account.
- C21 Remaining bare except: clauses in attachment_service logged.
- C22 run_server.py uses __file__ based path (no hardcoded Windows path).
- C25 Config logs when AI_MODEL / AI_EMBEDDING_MODEL defaults apply and warns for local+semantic_search without an embedding model.

New settings
- MCP_API_KEY, MCP_HOST (default 127.0.0.1), EWS_INSECURE_SKIP_VERIFY (default false), EWS_DOWNLOAD_DIR (default ./downloads).

Breaking / operator-visible
- SSE transport now binds 127.0.0.1 by default. Expose on a non- loopback address only with MCP_API_KEY set (enforced at startup).
- TLS verified by default for EWS traffic.
- download_attachment save_path treated as basename; response file_path is authoritative.
- MCP responses are JSON (not Python repr).
- ConnectionError -> EWSConnectionError.