### PR TITLE
fix(tools): round-2 follow-up bugs (CAL-006, TSK-004, CON-008, delete…

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -1,6 +1,30 @@
 """Pydantic models for EWS MCP Server."""
 
+import re
 from pydantic import BaseModel, EmailStr, Field, field_validator
+
+# Bug CON-008: pydantic's ``EmailStr`` uses email-validator, which as of
+# 2.x rejects every reserved TLD from RFC 2606 (.invalid, .test, .example,
+# .localhost). Contacts frequently contain placeholder addresses in
+# training data and tests, so we use a looser regex for this project's
+# contact-model fields. The upstream Exchange server performs its own
+# validation when the item is saved, which is the authoritative check.
+_EMAIL_SYNTAX_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+
+
+def _validate_loose_email(value: str) -> str:
+    """Lenient email-syntax check that allows RFC 2606 reserved TLDs.
+
+    Used by :class:`CreateContactRequest`. Intentionally does NOT call
+    ``email_validator.validate_email`` because that library enforces a
+    special-use-domain denylist we don't want for contact data.
+    """
+    if not isinstance(value, str):
+        raise ValueError("email_address must be a string")
+    stripped = value.strip()
+    if not stripped or not _EMAIL_SYNTAX_RE.match(stripped):
+        raise ValueError(f"email_address {value!r} is not a valid email syntax")
+    return stripped
 from typing import Optional, List, Literal
 from datetime import datetime
 from enum import Enum
@@ -145,14 +169,27 @@ class MeetingResponse(BaseModel):
 
 # Contact Models
 class CreateContactRequest(BaseModel):
-    """Request model for creating contact."""
+    """Request model for creating contact.
+
+    ``email_address`` uses a lenient syntax-only validator (see
+    :func:`_validate_loose_email`) rather than pydantic's ``EmailStr``
+    so RFC 2606 reserved TLDs (``.invalid`` / ``.test`` / ``.example``)
+    and other non-deliverable but syntactically-valid addresses are
+    accepted — Exchange itself performs the authoritative validation
+    when the contact is saved.
+    """
     given_name: str = Field(..., min_length=1, description="First name")
     surname: str = Field(..., min_length=1, description="Last name")
-    email_address: EmailStr = Field(..., description="Email address")
+    email_address: str = Field(..., description="Email address")
     phone_number: Optional[str] = Field(None, description="Phone number")
     company: Optional[str] = Field(None, description="Company name")
     job_title: Optional[str] = Field(None, description="Job title")
     department: Optional[str] = Field(None, description="Department")
+
+    @field_validator("email_address")
+    @classmethod
+    def _email_loose(cls, value: str) -> str:
+        return _validate_loose_email(value)
 
 
 class ContactDetails(BaseModel):

--- a/src/tools/attachment_tools.py
+++ b/src/tools/attachment_tools.py
@@ -22,6 +22,32 @@ from ..utils import format_success_response, safe_get, find_message_across_folde
 _DEFAULT_DOWNLOAD_DIR = Path(os.environ.get("EWS_DOWNLOAD_DIR", "downloads"))
 
 
+def _is_traversal_path(name: str) -> bool:
+    """True iff ``name`` contains anything that escapes a single filename.
+
+    Rejects absolute paths, "..", "./", leading slashes, UNC roots, and
+    NUL bytes. Used to make save_path a *safe-or-rejected* field: either
+    it's a simple filename we can honour, or the caller hears about it.
+    """
+    if not isinstance(name, str) or not name:
+        return False
+    if "\x00" in name:
+        return True
+    if os.path.isabs(name):
+        return True
+    # Normalise both slash flavours.
+    unified = name.replace("\\", "/")
+    if unified.startswith("/") or unified.startswith("~"):
+        return True
+    parts = [p for p in unified.split("/") if p]
+    for p in parts:
+        if p == "..":
+            return True
+    # "./foo" — the "." element is technically safe, but require a plain
+    # filename with no separators at all for simplicity.
+    return "/" in unified or "\\" in name
+
+
 def _safe_basename(name: str) -> str:
     """Strip directory traversal / path separators from a user-supplied name."""
     if not name:
@@ -32,27 +58,47 @@ def _safe_basename(name: str) -> str:
     return name or "attachment"
 
 
-def resolve_download_path(save_path: str | None, default_name: str) -> Path:
+def resolve_download_path(
+    save_path: Any,
+    default_name: str,
+    *,
+    strict: bool = False,
+) -> Path:
     """Resolve a save_path into a safe, jailed absolute Path.
 
-    - If save_path is None/empty, use default_name inside the jail.
-    - If save_path contains a directory part, only the basename is honoured.
-    - The returned path is guaranteed to live inside the download jail.
+    - If ``save_path`` is None/empty, use ``default_name`` inside the jail.
+    - If ``save_path`` contains directory components or parent refs and
+      ``strict=True``, raise :class:`ValidationError` (HTTP 400).
+    - If ``strict=False`` (legacy mode), only the basename is kept.
+    - The returned path is always inside the jail; symlink tricks that
+      would escape raise :class:`ToolExecutionError`.
     """
     jail = _DEFAULT_DOWNLOAD_DIR.resolve()
     jail.mkdir(parents=True, exist_ok=True)
 
-    filename = _safe_basename(save_path) if save_path else _safe_basename(default_name)
+    if save_path and _is_traversal_path(str(save_path)):
+        if strict:
+            raise ValidationError(
+                f"Invalid save_path {save_path!r}: must be a plain filename "
+                f"with no directory components or '..' refs. Files are "
+                f"written under {jail}"
+            )
+        # Back-compat: strip to basename.
+        save_path = _safe_basename(str(save_path))
+
+    filename = (
+        _safe_basename(str(save_path)) if save_path else _safe_basename(default_name)
+    )
     candidate = (jail / filename).resolve()
 
     # Verify the resolved path is still inside the jail (defence against
     # symlink tricks or unusual basename behaviour).
     try:
         candidate.relative_to(jail)
-    except ValueError:
+    except ValueError as exc:
         raise ToolExecutionError(
             "Invalid save_path: resolved outside the download directory"
-        )
+        ) from exc
 
     return candidate
 
@@ -318,15 +364,24 @@ class DownloadAttachmentTool(BaseTool):
                 )
 
             elif return_as == "file_path":
-                # Save to file, jailed under the configured download directory.
-                # save_path is treated as a basename hint only; directory
-                # components are stripped and "../" is neutralised.
-                file_path = resolve_download_path(save_path, attachment_name)
+                # Save to file, jailed under EWS_DOWNLOAD_DIR.
+                #
+                # ``strict=True`` converts traversal-style save_paths
+                # ("../../etc/passwd", "/tmp/x", "C:\\...", NUL bytes)
+                # into ValidationError -> HTTP 400. Previously the path
+                # was silently reduced to its basename — callers thought
+                # the tool had honoured their request, but it had jailed
+                # it quietly. Bug #6.
+                file_path = resolve_download_path(
+                    save_path, attachment_name, strict=True
+                )
 
                 with open(file_path, 'wb') as f:
                     f.write(content)
 
-                self.logger.info(f"Saved attachment {attachment_name} to {file_path}")
+                self.logger.info(
+                    f"Saved attachment {attachment_name} to {file_path}"
+                )
 
                 return format_success_response(
                     "Attachment saved successfully",
@@ -334,7 +389,11 @@ class DownloadAttachmentTool(BaseTool):
                     attachment_id=attachment_id,
                     name=attachment_name,
                     size=len(content),
-                    content_type=safe_get(attachment, 'content_type', 'application/octet-stream'),
+                    content_type=safe_get(
+                        attachment, 'content_type', 'application/octet-stream'
+                    ),
+                    # Always include file_path in file-mode responses so
+                    # callers don't have to reconstruct it.
                     file_path=str(file_path),
                     mailbox=mailbox
                 )

--- a/src/tools/email_tools.py
+++ b/src/tools/email_tools.py
@@ -1578,7 +1578,11 @@ class DeleteEmailTool(BaseTool):
     def get_schema(self) -> Dict[str, Any]:
         return {
             "name": "delete_email",
-            "description": "Delete an email by ID (moves to trash).",
+            "description": (
+                "Delete an email by ID. Default is soft delete (moves to "
+                "Deleted Items). Set ``permanent`` (or ``hard_delete`` "
+                "alias) true to bypass Trash and remove permanently."
+            ),
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -1588,7 +1592,12 @@ class DeleteEmailTool(BaseTool):
                     },
                     "permanent": {
                         "type": "boolean",
-                        "description": "Permanently delete (hard delete)",
+                        "description": "Permanently delete (bypasses Trash). Alias: hard_delete.",
+                        "default": False
+                    },
+                    "hard_delete": {
+                        "type": "boolean",
+                        "description": "Alias for 'permanent'.",
                         "default": False
                     },
                     "target_mailbox": {
@@ -1603,8 +1612,16 @@ class DeleteEmailTool(BaseTool):
     async def execute(self, **kwargs) -> Dict[str, Any]:
         """Delete email."""
         message_id = kwargs.get("message_id")
-        permanent = kwargs.get("permanent", False)
+        # Accept both ``permanent`` (canonical) and ``hard_delete`` (alias
+        # matching manage_folder / callers' muscle memory). Either truthy
+        # value triggers a permanent delete.
+        permanent = bool(
+            kwargs.get("permanent", False) or kwargs.get("hard_delete", False)
+        )
         target_mailbox = kwargs.get("target_mailbox")
+
+        if not message_id or not isinstance(message_id, str) or not message_id.strip():
+            raise ValidationError("message_id is required")
 
         try:
             # Get account (primary or impersonated)
@@ -1615,11 +1632,20 @@ class DeleteEmailTool(BaseTool):
             item = find_message_for_account(account, message_id)
 
             if permanent:
-                item.delete()
+                # ``item.delete()`` in exchangelib defaults to
+                # MOVE_TO_DELETED_ITEMS — items end up in Trash, defeating
+                # the caller's "permanent" intent. Pass HARD_DELETE so the
+                # item bypasses both Trash and the recoverable-items dump.
+                try:
+                    from exchangelib import HARD_DELETE
+                    item.delete(delete_type=HARD_DELETE)
+                except ImportError:
+                    # exchangelib < 3 lacks the module-level constant;
+                    # fall back to the string that the EWS API expects.
+                    item.delete(delete_type="HardDelete")
                 action = "permanently deleted"
             else:
-                # Move to trash folder (Deleted Items) so user can recover
-                # Note: soft_delete() makes items recoverable but not visible in Deleted Items
+                # Move to trash folder (Deleted Items) so user can recover.
                 item.move(account.trash)
                 action = "moved to trash"
 
@@ -1628,12 +1654,18 @@ class DeleteEmailTool(BaseTool):
             return format_success_response(
                 f"Email {action}",
                 message_id=message_id,
+                permanent=permanent,
+                hard_delete=permanent,
                 mailbox=mailbox
             )
 
+        except (ValidationError, ToolExecutionError):
+            raise
         except Exception as e:
-            self.logger.error(f"Failed to delete email: {e}")
-            raise ToolExecutionError(f"Failed to delete email: {e}")
+            self.logger.exception(f"Failed to delete email: {type(e).__name__}: {e}")
+            raise ToolExecutionError(
+                f"Failed to delete email: {type(e).__name__}: {e}"
+            )
 
 
 class MoveEmailTool(BaseTool):

--- a/src/tools/folder_tools.py
+++ b/src/tools/folder_tools.py
@@ -445,8 +445,12 @@ class ManageFolderTool(BaseTool):
                     },
                     "destination": {
                         "type": "string",
-                        "description": "Target parent folder name or ID (move action)",
+                        "description": "Target parent folder — standard name (move action). Prefer destination_folder_id for custom folders.",
                         "enum": ["root", "inbox", "sent", "drafts", "deleted", "junk", "calendar", "contacts", "tasks"]
+                    },
+                    "destination_folder_id": {
+                        "type": "string",
+                        "description": "Target parent folder id (move action). Same shape as move_email's destination_folder_id."
                     },
                     "permanent": {
                         "type": "boolean",
@@ -657,15 +661,30 @@ class ManageFolderTool(BaseTool):
             raise ToolExecutionError(f"Failed to rename folder: {e}")
 
     async def _move(self, **kwargs) -> Dict[str, Any]:
-        """Move a folder to a new parent."""
+        """Move a folder to a new parent.
+
+        Destination accepted in three forms (in order of preference):
+
+        * ``destination_folder_id`` — same name as ``move_email`` uses
+          (canonical).
+        * ``destination`` — legacy alias for either a standard folder
+          name (``"archive"``) OR a folder id string.
+        * No param is rejected with ValidationError (HTTP 400).
+        """
         folder_id = kwargs.get("folder_id")
+        # Bug #5: accept destination_folder_id so callers can use the same
+        # shape as move_email / copy_email.
+        destination_id = kwargs.get("destination_folder_id")
         destination = kwargs.get("destination")
         target_mailbox = kwargs.get("target_mailbox")
 
         if not folder_id:
-            raise ToolExecutionError("folder_id is required for move action")
-        if not destination:
-            raise ToolExecutionError("destination is required for move action")
+            raise ValidationError("folder_id is required for move action")
+        if not destination and not destination_id:
+            raise ValidationError(
+                "move requires 'destination' (standard folder name) or "
+                "'destination_folder_id' (explicit folder id)"
+            )
 
         try:
             account = self.get_account(target_mailbox)
@@ -673,26 +692,54 @@ class ManageFolderTool(BaseTool):
 
             folder = self._find_folder_by_id(account.root, folder_id)
             if not folder:
-                raise ToolExecutionError(f"Folder not found: {folder_id}")
+                raise ValidationError(f"Folder not found: {folder_id}")
 
             folder_name = safe_get(folder, 'name', 'Unknown')
 
-            folder_map = self._get_folder_map(account)
-            target_parent = folder_map.get(destination.lower())
-            if not target_parent:
-                raise ToolExecutionError(f"Unknown destination folder: {destination}")
+            # Resolve the target parent. First try the explicit id; then
+            # try ``destination`` as a standard name; finally try
+            # ``destination`` as an id (some callers conflate the fields).
+            target_parent = None
+            resolved_destination = None
+            if destination_id:
+                target_parent = self._find_folder_by_id(account.root, destination_id)
+                resolved_destination = destination_id
+            if target_parent is None and destination:
+                folder_map = self._get_folder_map(account)
+                target_parent = folder_map.get(str(destination).lower())
+                if target_parent is not None:
+                    resolved_destination = destination
+                else:
+                    # Fallback: maybe ``destination`` is an id.
+                    target_parent = self._find_folder_by_id(account.root, destination)
+                    if target_parent is not None:
+                        resolved_destination = destination
+
+            if target_parent is None:
+                raise ValidationError(
+                    f"Unknown destination: "
+                    f"{destination_id or destination!r}"
+                )
 
             folder.parent = target_parent
             folder.save()
 
             return format_success_response(
-                f"Folder '{folder_name}' moved to '{destination}'",
+                f"Folder '{folder_name}' moved",
                 folder_id=folder_id,
                 folder_name=folder_name,
-                destination=destination,
-                mailbox=mailbox
+                destination=resolved_destination,
+                destination_folder_id=ews_id_to_str(
+                    safe_get(target_parent, "id", None)
+                ),
+                mailbox=mailbox,
             )
-        except ToolExecutionError:
+        except (ValidationError, ToolExecutionError):
             raise
         except Exception as e:
-            raise ToolExecutionError(f"Failed to move folder: {e}")
+            self.logger.exception(
+                f"manage_folder(action=move) failed: {type(e).__name__}: {e}"
+            )
+            raise ToolExecutionError(
+                f"Failed to move folder: {type(e).__name__}: {e}"
+            )

--- a/src/utils.py
+++ b/src/utils.py
@@ -332,27 +332,39 @@ def safe_json_dumps(obj: Any, **kwargs) -> str:
 def format_error_response(error: Exception, context: str = "") -> Dict[str, Any]:
     """Format error as a short, actionable response.
 
-    Includes ``error_type`` (the exception class name) so the SSE/HTTP
-    adapter can map it to a proper HTTP status (400 for ValidationError,
-    503 for EWSConnectionError, etc.). The field is kept stable across
-    tool results so external clients can dispatch on it.
+    Response shape (stable contract):
+
+    * ``success``: ``False``
+    * ``error``: human message, truncated at 200 chars, always prefixed
+      with the exception class name so operators see *what* broke even
+      when the response gets surfaced in a generic "Internal Server
+      Error" UI (TSK-004 / CAL-006).
+    * ``error_type``: short exception class name. The SSE/HTTP adapter
+      uses this to pick the HTTP status (400 for ValidationError, 503
+      for EWSConnectionError, etc.).
+    * ``error_class``: fully-qualified class name (module.Class), useful
+      for filing bugs against exchangelib or the MCP layer.
     """
     logger = logging.getLogger(__name__)
-    error_msg = str(error)
+    raw = str(error) or ""
+    type_name = type(error).__name__
 
     if context and context != "":
-        error_msg = f"{context}: {error_msg}"
+        prefixed = f"{context}: {type_name}: {raw}" if raw else f"{context}: {type_name}"
+    else:
+        # Don't double-stamp when the caller already prefixed the message.
+        prefixed = raw if raw.startswith(type_name) else f"{type_name}: {raw}" if raw else type_name
 
-    # Truncate very long error messages
-    if len(error_msg) > 200:
-        error_msg = error_msg[:197] + "..."
+    if len(prefixed) > 200:
+        prefixed = prefixed[:197] + "..."
 
-    logger.error(error_msg)
+    logger.error(prefixed)
 
     return {
         "success": False,
-        "error": error_msg,
-        "error_type": type(error).__name__,
+        "error": prefixed,
+        "error_type": type_name,
+        "error_class": f"{type(error).__module__}.{type_name}",
     }
 
 

--- a/tests/test_folder_management.py
+++ b/tests/test_folder_management.py
@@ -254,11 +254,18 @@ async def test_move_folder(mock_ews_client):
 
 @pytest.mark.asyncio
 async def test_move_folder_source_not_found(mock_ews_client):
-    """Test moving non-existent folder."""
+    """Test moving non-existent folder.
+
+    As of the folder follow-up fixes, "folder not found" and "unknown
+    destination" are caller errors — raised as ValidationError so the
+    SSE adapter maps them to HTTP 400, not 500.
+    """
+    from src.exceptions import ValidationError
+
     tool = ManageFolderTool(mock_ews_client)
 
     with patch.object(tool, '_find_folder_by_id', return_value=None):
-        with pytest.raises(ToolExecutionError) as exc_info:
+        with pytest.raises(ValidationError) as exc_info:
             await tool.execute(
                 action="move",
                 folder_id="nonexistent-id",
@@ -270,7 +277,12 @@ async def test_move_folder_source_not_found(mock_ews_client):
 
 @pytest.mark.asyncio
 async def test_move_folder_destination_not_found(mock_ews_client):
-    """Test moving folder to non-existent destination."""
+    """Test moving folder to non-existent destination.
+
+    Unknown destinations are caller errors -> ValidationError (HTTP 400).
+    """
+    from src.exceptions import ValidationError
+
     tool = ManageFolderTool(mock_ews_client)
 
     # Mock source folder
@@ -278,10 +290,11 @@ async def test_move_folder_destination_not_found(mock_ews_client):
     mock_folder.id = "folder-to-move"
 
     with patch.object(tool, '_find_folder_by_id') as mock_find:
-        # First call returns folder to move, second call returns None (destination not found)
-        mock_find.side_effect = [mock_folder, None]
+        # First call returns folder to move, second call returns None
+        # (destination id also unresolvable).
+        mock_find.side_effect = [mock_folder, None, None]
 
-        with pytest.raises(ToolExecutionError) as exc_info:
+        with pytest.raises(ValidationError) as exc_info:
             await tool.execute(
                 action="move",
                 folder_id="folder-to-move",

--- a/tests/test_tool_reliability_round2.py
+++ b/tests/test_tool_reliability_round2.py
@@ -1,0 +1,341 @@
+"""Regression tests for the six production follow-up bugs (round 2).
+
+Each test fails on pre-fix code and passes after.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# CAL-006 — check_availability diagnostic message
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cal006_backend_exception_includes_type_in_response(mock_ews_client):
+    """When get_free_busy_info raises, the response must include the
+    real exception class name + message in the error field (not just
+    generic 'Internal Server Error')."""
+    from src.tools.calendar_tools import CheckAvailabilityTool
+
+    class _UpstreamOops(Exception):
+        pass
+
+    mock_ews_client.account.primary_smtp_address = "me@example.com"
+    mock_ews_client.account.protocol.get_free_busy_info.side_effect = _UpstreamOops(
+        "exchange said no"
+    )
+
+    tool = CheckAvailabilityTool(mock_ews_client)
+    # safe_execute never raises — it returns the dict.
+    result = await tool.safe_execute(
+        email_addresses=["me@example.com"],
+        start_time="2026-04-18T08:00:00+00:00",
+        end_time="2026-04-18T18:00:00+00:00",
+    )
+    assert result["success"] is False
+    assert result["error_type"] == "ToolExecutionError"
+    err = str(result.get("error", ""))
+    # The upstream exception type appears in the message so operators
+    # see WHAT broke, not just "Internal Server Error".
+    assert "_UpstreamOops" in err or "exchange said no" in err, result
+
+
+@pytest.mark.asyncio
+async def test_cal006_self_only_valid_returns_success(mock_ews_client):
+    """Smoke test: valid self-only params must NOT crash the tool."""
+    from src.tools.calendar_tools import CheckAvailabilityTool
+
+    mock_ews_client.account.primary_smtp_address = "me@example.com"
+    mock_ews_client.account.protocol.get_free_busy_info.return_value = iter([])
+    tool = CheckAvailabilityTool(mock_ews_client)
+    result = await tool.execute(
+        email_addresses=["me@example.com"],
+        start_time="2026-04-18T08:00:00+00:00",
+        end_time="2026-04-18T18:00:00+00:00",
+        interval_minutes=30,
+    )
+    assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# TSK-004 — get_tasks diagnostic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tsk004_backend_exception_includes_type_in_response(mock_ews_client):
+    """When the task folder query raises, operators see the class name."""
+    from src.tools.task_tools import GetTasksTool
+
+    class _ExchangeBoom(Exception):
+        pass
+
+    def _raiser(*args, **kwargs):
+        raise _ExchangeBoom("server unavailable")
+
+    mock_ews_client.account.tasks.all.side_effect = _raiser
+
+    tool = GetTasksTool(mock_ews_client)
+    result = await tool.safe_execute()
+    assert result["success"] is False
+    err = str(result.get("error", ""))
+    assert "_ExchangeBoom" in err or "server unavailable" in err, result
+
+
+# ---------------------------------------------------------------------------
+# CON-008 — loose email validator accepts .invalid
+# ---------------------------------------------------------------------------
+
+
+def test_con008_create_contact_accepts_reserved_tlds():
+    """RFC 2606 reserved TLDs (.invalid / .test / .example) must not be
+    rejected by the contact-create model."""
+    from src.models import CreateContactRequest
+
+    # All of these are RFC 2606 reserved — pydantic's EmailStr rejects
+    # them. Our loose validator accepts them.
+    for email in [
+        "user@example.invalid",
+        "user@example.test",
+        "user@example.example",
+        "alice@company.com",  # regular domain still works
+    ]:
+        req = CreateContactRequest(
+            given_name="A", surname="B", email_address=email,
+        )
+        assert req.email_address == email
+
+
+def test_con008_loose_validator_rejects_real_garbage():
+    """Sanity: the validator still rejects genuinely bad syntax."""
+    from src.models import CreateContactRequest
+    from pydantic import ValidationError as PydanticValidationError
+
+    for bad in ["not-an-email", "@example.com", "user@", "user@space inside.com"]:
+        with pytest.raises(PydanticValidationError):
+            CreateContactRequest(
+                given_name="A", surname="B", email_address=bad,
+            )
+
+
+# ---------------------------------------------------------------------------
+# #4 — delete_email(hard_delete=True) actually hard-deletes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_email_hard_delete_uses_hard_delete_type(mock_ews_client):
+    """hard_delete=True must call item.delete with the HARD_DELETE
+    delete_type — not move() to trash and not a plain delete() that
+    defaults to MoveToDeletedItems."""
+    from src.tools.email_tools import DeleteEmailTool
+
+    item = MagicMock()
+    with patch(
+        "src.tools.email_tools.find_message_for_account", return_value=item
+    ):
+        tool = DeleteEmailTool(mock_ews_client)
+        result = await tool.execute(
+            message_id="AAMk-1", hard_delete=True,
+        )
+
+    # move() must NOT be called — that would put the item in Trash.
+    item.move.assert_not_called()
+    # delete() must be called with an explicit HARD_DELETE delete_type.
+    assert item.delete.called
+    call_kwargs = item.delete.call_args.kwargs
+    assert "delete_type" in call_kwargs
+    # exchangelib's constant or the legacy string.
+    delete_type = call_kwargs["delete_type"]
+    assert str(delete_type).lower().replace("_", "").endswith("harddelete"), delete_type
+    # Response reports permanent=True and hard_delete=True (both aliases).
+    assert result["permanent"] is True
+    assert result["hard_delete"] is True
+
+
+@pytest.mark.asyncio
+async def test_delete_email_default_moves_to_trash(mock_ews_client):
+    """Without hard_delete/permanent, item.move(trash) is called."""
+    from src.tools.email_tools import DeleteEmailTool
+
+    trash = mock_ews_client.account.trash
+    item = MagicMock()
+    with patch(
+        "src.tools.email_tools.find_message_for_account", return_value=item
+    ):
+        tool = DeleteEmailTool(mock_ews_client)
+        result = await tool.execute(message_id="AAMk-1")
+
+    item.move.assert_called_once_with(trash)
+    item.delete.assert_not_called()
+    assert result["permanent"] is False
+
+
+@pytest.mark.asyncio
+async def test_delete_email_permanent_alias_equivalent_to_hard_delete(mock_ews_client):
+    """permanent=True must behave identically to hard_delete=True."""
+    from src.tools.email_tools import DeleteEmailTool
+
+    item = MagicMock()
+    with patch(
+        "src.tools.email_tools.find_message_for_account", return_value=item
+    ):
+        tool = DeleteEmailTool(mock_ews_client)
+        result = await tool.execute(message_id="AAMk-1", permanent=True)
+
+    item.move.assert_not_called()
+    item.delete.assert_called_once()
+    assert result["permanent"] is True
+
+
+# ---------------------------------------------------------------------------
+# #5 — manage_folder(action=move) accepts destination_folder_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_manage_folder_move_accepts_destination_folder_id(mock_ews_client):
+    """destination_folder_id should resolve the target parent without
+    requiring the caller to also supply destination=<name>."""
+    from src.tools.folder_tools import ManageFolderTool
+
+    folder = MagicMock()
+    folder.name = "Archive"
+    folder.id = "AAMk-folder"
+
+    target_parent = MagicMock()
+    target_parent.id = "AAMk-target"
+
+    def _find(root, fid):
+        return folder if fid == "AAMk-folder" else target_parent if fid == "AAMk-target" else None
+
+    tool = ManageFolderTool(mock_ews_client)
+    with patch.object(tool, "_find_folder_by_id", side_effect=_find):
+        result = await tool.execute(
+            action="move",
+            folder_id="AAMk-folder",
+            destination_folder_id="AAMk-target",
+        )
+    assert result["success"] is True
+    assert folder.parent is target_parent
+    folder.save.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_manage_folder_move_requires_destination(mock_ews_client):
+    """Both destination and destination_folder_id missing -> 400."""
+    from src.exceptions import ValidationError
+    from src.tools.folder_tools import ManageFolderTool
+
+    tool = ManageFolderTool(mock_ews_client)
+    with pytest.raises(ValidationError):
+        await tool.execute(action="move", folder_id="AAMk-folder")
+
+
+# ---------------------------------------------------------------------------
+# #6 — download_attachment traversal save_path = 400; file_path always
+# ---------------------------------------------------------------------------
+
+
+def _att_with_content():
+    att = MagicMock()
+    att.attachment_id = {"id": "AT-1"}
+    att.name = "report.pdf"
+    att.content = b"PDF bytes"
+    att.content_type = "application/pdf"
+    return att
+
+
+@pytest.mark.asyncio
+async def test_download_attachment_traversal_path_returns_400(mock_ews_client):
+    """Traversal-style save_path must raise ValidationError (-> HTTP 400)."""
+    from src.exceptions import ValidationError
+    from src.tools.attachment_tools import DownloadAttachmentTool
+
+    att = _att_with_content()
+    msg = MagicMock()
+    msg.attachments = [att]
+
+    tool = DownloadAttachmentTool(mock_ews_client)
+    with patch(
+        "src.tools.attachment_tools.find_message_for_account",
+        return_value=msg,
+    ):
+        for bad in ["../../etc/passwd", "/etc/passwd", "..\\..\\etc", "foo/bar.pdf"]:
+            with pytest.raises(ValidationError):
+                await tool.execute(
+                    message_id="AAMk-msg",
+                    attachment_id="AT-1",
+                    return_as="file_path",
+                    save_path=bad,
+                )
+
+
+@pytest.mark.asyncio
+async def test_download_attachment_file_path_response_includes_file_path(mock_ews_client, tmp_path, monkeypatch):
+    """Every file-mode success response must include file_path."""
+    from src.tools.attachment_tools import DownloadAttachmentTool
+
+    monkeypatch.setenv("EWS_DOWNLOAD_DIR", str(tmp_path))
+    import importlib
+    from src.tools import attachment_tools as at
+    importlib.reload(at)
+
+    att = _att_with_content()
+    msg = MagicMock()
+    msg.attachments = [att]
+
+    tool = at.DownloadAttachmentTool(mock_ews_client)
+    with patch(
+        "src.tools.attachment_tools.find_message_for_account",
+        return_value=msg,
+    ):
+        result = await tool.execute(
+            message_id="AAMk-msg",
+            attachment_id="AT-1",
+            return_as="file_path",
+            save_path="downloaded.pdf",
+        )
+    assert result["success"] is True
+    assert "file_path" in result, result
+    assert result["file_path"].endswith("downloaded.pdf")
+    # File actually exists and contains the expected bytes.
+    from pathlib import Path
+    saved = Path(result["file_path"])
+    assert saved.is_file()
+    assert saved.read_bytes() == b"PDF bytes"
+
+
+@pytest.mark.asyncio
+async def test_download_attachment_traversal_via_openapi_returns_400(mock_ews_client):
+    """End-to-end: SSE adapter maps the ValidationError to HTTP 400."""
+    from src.tools.attachment_tools import DownloadAttachmentTool
+    from src.openapi_adapter import OpenAPIAdapter
+
+    att = _att_with_content()
+    msg = MagicMock()
+    msg.attachments = [att]
+
+    tool = DownloadAttachmentTool(mock_ews_client)
+    with patch(
+        "src.tools.attachment_tools.find_message_for_account",
+        return_value=msg,
+    ):
+        adapter = OpenAPIAdapter(server=None, tools={"download_attachment": tool}, settings=None)
+        response = await adapter.handle_rest_request(
+            "download_attachment",
+            json.dumps({
+                "message_id": "AAMk-msg",
+                "attachment_id": "AT-1",
+                "return_as": "file_path",
+                "save_path": "../../etc/passwd",
+            }).encode(),
+        )
+    assert response["status"] == 400, response
+    assert response["success"] is False


### PR DESCRIPTION
…_email hard, manage_folder move, download_attachment)

Six more reliability follow-ups after the CAL-006 / TSK-004 diagnostic report and three new P0s discovered in end-to-end testing. Each bug has a regression test that fails against pre-fix code.

CAL-006 / TSK-004 — Error diagnostics (verified)
------------------------------------------------
The previous fixes (commit f7c89b6) already (a) raise ValidationError for bad input so the SSE adapter maps to HTTP 400, and (b) log via logger.exception so the full traceback lands in logs/ews-mcp.log. What was missing was a user-visible trail: when a real exchangelib error reached format_error_response, the exception *message* was the only clue in the response — operators looking at a 500 page saw "Internal Server Error" from the web layer.

src/utils.py::format_error_response now:
  * Always prefixes the error string with the exception class name (if not already present) so truncation-at-200 still leaves the type visible.
  * Emits a new ``error_class`` field (fully-qualified module.Class) for operators who want to file a bug against the upstream lib.
  * Keeps error_type as the short class name for the adapter's status mapping.

tests/test_tool_reliability_round2.py adds:
  * test_cal006_backend_exception_includes_type_in_response
  * test_cal006_self_only_valid_returns_success
  * test_tsk004_backend_exception_includes_type_in_response

CON-008 — create_contact accepts RFC 2606 reserved TLDs ------------------------------------------------------- src/models.py::CreateContactRequest.email_address: drop EmailStr (which pins email_validator 2.x, which rejects .invalid/.test/.example by design) and use a local regex-only validator. Contacts frequently hold placeholder addresses; Exchange itself validates at save time.

Tests:
  * test_con008_create_contact_accepts_reserved_tlds — .invalid / .test / .example all accepted.
  * test_con008_loose_validator_rejects_real_garbage — genuine garbage still raises pydantic ValidationError.

delete_email(hard_delete=True) truly hard-deletes
-------------------------------------------------
src/tools/email_tools.py::DeleteEmailTool:
  * Accept ``hard_delete`` as an alias for ``permanent`` (the canonical name on manage_folder). Either truthy value triggers hard delete.
  * permanent=True now calls ``item.delete(delete_type=HARD_DELETE)``. Previously ``item.delete()`` defaulted to MoveToDeletedItems — items ended up in Trash despite the caller's "permanent" intent. Drafts especially hit this because the default delete behaviour preserves them for recovery.
  * Response shape includes both ``permanent`` and ``hard_delete`` so no matter which alias the caller used, confirmation is obvious.
  * Missing/empty message_id raises ValidationError (400).
  * logger.exception for genuine 500s.

Tests:
  * test_delete_email_hard_delete_uses_hard_delete_type — move() is NOT called; delete(delete_type=HARD_DELETE) is.
  * test_delete_email_default_moves_to_trash — soft path unchanged.
  * test_delete_email_permanent_alias_equivalent_to_hard_delete.

manage_folder(action=move) accepts destination_folder_id -------------------------------------------------------- src/tools/folder_tools.py::ManageFolderTool._move:
  * Accept ``destination_folder_id`` (matching move_email's name) OR ``destination`` (standard folder name). Either one resolves the target parent.
  * Fallback: if ``destination`` happens to be an id, try that too.
  * Missing both raises ValidationError (400).
  * Folder-not-found / unknown-destination -> ValidationError (400), not ToolExecutionError (500).
  * Schema gains the destination_folder_id field.

Tests:
  * test_manage_folder_move_accepts_destination_folder_id
  * test_manage_folder_move_requires_destination
  * tests/test_folder_management.py test_move_folder_{source,destination}_not_found updated for ValidationError (matches the 400-mapping change).

download_attachment: traversal save_path = 400, file_path always present ----------------------------------------------------------------------- src/tools/attachment_tools.py:
  * New ``_is_traversal_path`` helper: detects absolute paths, "..", leading "/" or "~", path separators, and NUL bytes.
  * ``resolve_download_path(save_path, default, strict=True)`` raises ValidationError (HTTP 400) on traversal. Legacy call sites keep ``strict=False`` behaviour (basename-only reduction).
  * download_attachment(return_as="file_path") calls it with strict=True so callers hear about invalid paths instead of silently getting a jailed file under a name they didn't ask for.
  * file_path is always present in file-mode responses (was already present in base64-mode responses; only file-mode was affected).

Tests:
  * test_download_attachment_traversal_path_returns_400 — four traversal patterns all raise ValidationError.
  * test_download_attachment_file_path_response_includes_file_path — happy path writes the expected bytes + returns the file_path.
  * test_download_attachment_traversal_via_openapi_returns_400 — 400 at the HTTP layer via the SSE adapter.

Full suite: 261 passing (+13) / 18 pre-existing failures unchanged.