### PR TITLE
fix(tools): round-3 follow-ups — JSON encoder + delete API + response…

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -74,6 +74,41 @@ from .tools import (
     GenerateBriefingTool, PrepareMeetingTool,
 )
 
+
+# Errors that indicate the Exchange connection pool simply wasn't
+# ready yet. Used by the embedding warmup's retry loop to distinguish
+# "Exchange not ready" (retry) from "schema problem" (give up).
+_TRANSIENT_ERROR_NAMES = (
+    "ConnectionError",
+    "RemoteDisconnected",
+    "ProtocolError",
+    "ReadTimeout",
+    "ConnectTimeout",
+    "TimeoutError",
+    "SSLError",
+    "MaxRetryError",
+    "ChunkedEncodingError",
+)
+
+
+def _is_transient_error(errors) -> bool:
+    """Heuristic: any of the per-folder errors look retryable?"""
+    for _name, exc in errors:
+        exc_type = type(exc).__name__
+        if exc_type in _TRANSIENT_ERROR_NAMES:
+            return True
+        # Some exchangelib errors wrap the real exception — check the
+        # message too.
+        msg = str(exc)
+        if any(tok in msg for tok in (
+            "Connection aborted", "RemoteDisconnected",
+            "Max retries exceeded", "Connection refused",
+            "timed out",
+        )):
+            return True
+    return False
+
+
 class EWSMCPServer:
     """MCP Server for Exchange Web Services with comprehensive logging."""
 
@@ -500,10 +535,13 @@ class EWSMCPServer:
             return
 
         # Collect texts in a thread so the blocking iteration doesn't
-        # stall the event loop.
-        def _collect() -> list:
+        # stall the event loop. Returns (texts, per_folder_errors)
+        # so the retry loop below can tell "transient connection broke
+        # on all folders" from "some folders are legitimately empty".
+        def _collect() -> tuple[list, list]:
             from .utils import safe_get
             texts: list = []
+            errors: list = []
             account = self.ews_client.account
             folder_map = {
                 "inbox": getattr(account, "inbox", None),
@@ -520,7 +558,7 @@ class EWSMCPServer:
                         folder.all().order_by("-datetime_received")[:per_folder]
                     )
                 except Exception as exc:
-                    self.logger.warning(f"warmup: failed to list {name}: {exc}")
+                    errors.append((name, exc))
                     continue
                 for item in items:
                     subject = safe_get(item, "subject", "") or ""
@@ -529,16 +567,58 @@ class EWSMCPServer:
                     # the cache key is identical and the at-query-time
                     # lookup hits.
                     texts.append(f"{subject} {body[:500]}")
-            return texts
+            return texts, errors
 
-        try:
-            texts = await asyncio.to_thread(_collect)
-        except Exception as exc:
-            self.logger.warning(f"warmup: collection failed: {exc}")
-            return
+        # Retry collection with exponential backoff. The warmup races
+        # container startup against the Exchange connection pool; early
+        # attempts can hit ``RemoteDisconnected`` / ``ConnectionError``
+        # before the pool is ready.
+        attempts = [5, 15, 45]  # seconds between retries (3 tries total)
+        texts: list = []
+        last_errors: list = []
+        for attempt_idx in range(len(attempts) + 1):
+            try:
+                texts, errors = await asyncio.to_thread(_collect)
+            except Exception as exc:
+                texts, errors = [], [("<top-level>", exc)]
+
+            if texts:
+                if errors:
+                    self.logger.info(
+                        "warmup: collected %d texts with %d folder errors: %s",
+                        len(texts), len(errors),
+                        [(n, type(e).__name__) for n, e in errors],
+                    )
+                break
+
+            # Nothing collected — decide whether to retry.
+            last_errors = errors
+            if attempt_idx >= len(attempts):
+                break
+            if errors and _is_transient_error(errors):
+                delay = attempts[attempt_idx]
+                self.logger.info(
+                    "warmup: collection hit transient errors "
+                    "(%s); retrying in %ds (attempt %d/%d)",
+                    [(n, type(e).__name__) for n, e in errors],
+                    delay, attempt_idx + 2, len(attempts) + 1,
+                )
+                try:
+                    await asyncio.sleep(delay)
+                except Exception:
+                    break
+                continue
+            # Non-transient error or truly empty — don't retry.
+            break
 
         if not texts:
-            self.logger.info("warmup: nothing to embed")
+            if last_errors:
+                self.logger.warning(
+                    "warmup: collection failed after retries: %s",
+                    [(n, f"{type(e).__name__}: {e}") for n, e in last_errors],
+                )
+            else:
+                self.logger.info("warmup: nothing to embed")
             return
 
         self.logger.info(
@@ -685,9 +765,8 @@ class EWSMCPServer:
                 # OpenAPI/REST endpoints
                 elif path == "/openapi.json" and method == "GET":
                     # Return OpenAPI schema
-                    import json
                     schema = self.openapi_adapter.generate_openapi_schema()
-                    body = json.dumps(schema, indent=2).encode('utf-8')
+                    body = safe_json_dumps(schema, indent=2).encode('utf-8')
                     await send({
                         "type": "http.response.start",
                         "status": 200,
@@ -719,9 +798,11 @@ class EWSMCPServer:
                     result = await self.openapi_adapter.handle_rest_request(tool_name, body)
                     status = result.pop("status", 200)
 
-                    # Send response
-                    import json
-                    response_body = json.dumps(result).encode('utf-8')
+                    # Send response. Use safe_json_dumps so exchangelib
+                    # types (CalendarEventDetails, Decimal, ItemId, naive
+                    # datetimes) don't crash the serialiser (CAL-006 /
+                    # TSK-004 root cause).
+                    response_body = safe_json_dumps(result).encode('utf-8')
                     await send({
                         "type": "http.response.start",
                         "status": status,

--- a/src/tools/attachment_tools.py
+++ b/src/tools/attachment_tools.py
@@ -352,6 +352,9 @@ class DownloadAttachmentTool(BaseTool):
 
                 self.logger.info(f"Downloaded attachment {attachment_name} ({len(content)} bytes)")
 
+                # file_path is always present in the response so callers
+                # can key off a stable field regardless of return_as (null
+                # when no file was written). Bug ATT-010.
                 return format_success_response(
                     "Attachment downloaded successfully",
                     message_id=message_id,
@@ -360,6 +363,8 @@ class DownloadAttachmentTool(BaseTool):
                     size=len(content),
                     content_type=safe_get(attachment, 'content_type', 'application/octet-stream'),
                     content_base64=content_b64,
+                    file_path=None,
+                    saved_path=None,
                     mailbox=mailbox
                 )
 
@@ -392,9 +397,11 @@ class DownloadAttachmentTool(BaseTool):
                     content_type=safe_get(
                         attachment, 'content_type', 'application/octet-stream'
                     ),
-                    # Always include file_path in file-mode responses so
-                    # callers don't have to reconstruct it.
+                    # ``file_path`` is the historical field name; ``saved_path``
+                    # is a more descriptive alias. Both present = no caller
+                    # surprises regardless of which they read (Bug ATT-010).
                     file_path=str(file_path),
+                    saved_path=str(file_path),
                     mailbox=mailbox
                 )
 

--- a/src/tools/email_tools.py
+++ b/src/tools/email_tools.py
@@ -1632,17 +1632,22 @@ class DeleteEmailTool(BaseTool):
             item = find_message_for_account(account, message_id)
 
             if permanent:
-                # ``item.delete()`` in exchangelib defaults to
-                # MOVE_TO_DELETED_ITEMS — items end up in Trash, defeating
-                # the caller's "permanent" intent. Pass HARD_DELETE so the
-                # item bypasses both Trash and the recoverable-items dump.
+                # ``item.delete()`` in exchangelib defaults to a
+                # MoveToDeletedItems disposal — the item ends up in
+                # Trash, defeating "permanent". The correct API is
+                # ``item.delete(disposal_type=HARD_DELETE)``; the
+                # constant lives in ``exchangelib.items``, not at the
+                # top-level ``exchangelib`` package (the previous fix
+                # imported from the wrong place and also used the
+                # wrong keyword ``delete_type=`` — both produced 500s).
                 try:
-                    from exchangelib import HARD_DELETE
-                    item.delete(delete_type=HARD_DELETE)
+                    from exchangelib.items import HARD_DELETE
+                    item.delete(disposal_type=HARD_DELETE)
                 except ImportError:
-                    # exchangelib < 3 lacks the module-level constant;
-                    # fall back to the string that the EWS API expects.
-                    item.delete(delete_type="HardDelete")
+                    # Fall back to the wire string if the constant
+                    # ever moves again. ``disposal_type="HardDelete"``
+                    # is accepted by exchangelib in all recent versions.
+                    item.delete(disposal_type="HardDelete")
                 action = "permanently deleted"
             else:
                 # Move to trash folder (Deleted Items) so user can recover.

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,7 @@
 """Utility functions for EWS MCP Server."""
 
 from datetime import datetime
+from decimal import Decimal as _Decimal
 from typing import Any, Dict, List, Optional, Union
 import html
 import logging
@@ -9,6 +10,67 @@ import json
 import re
 from exchangelib import EWSTimeZone, EWSDateTime, EWSDate
 import pytz
+
+# Cached reference to exchangelib's CalendarEventDetails (used by the
+# JSON encoder). Imported lazily + guarded so the module still works if
+# exchangelib's internal layout shifts.
+try:
+    from exchangelib.properties import CalendarEventDetails as _CalendarEventDetails
+except Exception:  # pragma: no cover - import guard
+    _CalendarEventDetails = None  # type: ignore[assignment]
+
+
+def _calendar_event_details_to_json(obj: Any) -> Optional[Dict[str, Any]]:
+    """Convert an exchangelib ``CalendarEventDetails`` to a plain dict.
+
+    Returns None if ``obj`` is not a CalendarEventDetails (so the caller
+    can fall through to its normal dispatch chain). Kept defensive
+    because some exchangelib versions expose different attribute sets.
+    """
+    if _CalendarEventDetails is None or not isinstance(obj, _CalendarEventDetails):
+        return None
+    # Each field is best-effort — exchangelib populates a subset depending
+    # on the Exchange server's response. ``getattr`` with a default keeps
+    # us resilient across versions.
+    return {
+        "id": getattr(obj, "id", None),
+        "subject": getattr(obj, "subject", None),
+        "location": getattr(obj, "location", None),
+        "is_meeting": bool(getattr(obj, "is_meeting", False)),
+        "is_recurring": bool(getattr(obj, "is_recurring", False)),
+        "is_exception": bool(getattr(obj, "is_exception", False)),
+        "is_reminder_set": bool(getattr(obj, "is_reminder_set", False)),
+        "is_private": bool(getattr(obj, "is_private", False)),
+    }
+
+
+def _ensure_aware_iso(dt: datetime) -> str:
+    """Serialise a datetime to ISO, stamping a tz if it's naive.
+
+    exchangelib sometimes emits naive datetimes for calendar events
+    (the user-side warning ``Returning naive datetime ... on field
+    start``). Without a tz these serialise to strings like
+    ``"2026-04-19T10:00:00"`` which downstream consumers treat as local
+    or UTC arbitrarily. Stamp naive ones with the configured TIMEZONE
+    so the ISO string is unambiguous.
+    """
+    if dt.tzinfo is None:
+        try:
+            tz = pytz.timezone(
+                os.environ.get("TIMEZONE", os.environ.get("TZ", "UTC"))
+            )
+        except Exception:
+            tz = pytz.UTC
+        try:
+            dt = tz.localize(dt)
+        except Exception:
+            # Fallback: attach as UTC if localize fails (e.g. DST
+            # ambiguity). Prefer "stamped with SOMETHING" over naive.
+            dt = dt.replace(tzinfo=pytz.UTC)
+    try:
+        return dt.isoformat()
+    except Exception:
+        return str(dt)
 
 
 def get_timezone():
@@ -246,7 +308,8 @@ def ews_id_to_str(ews_id: Any) -> Optional[str]:
 def make_json_serializable(obj: Any) -> Any:
     """Recursively convert an object to be JSON serializable.
 
-    Handles EWS objects, datetime objects, and nested structures.
+    Handles EWS objects, datetime objects, Decimals, exchangelib
+    CalendarEventDetails, and nested structures.
 
     Args:
         obj: Any object that needs to be JSON serializable
@@ -261,13 +324,30 @@ def make_json_serializable(obj: Any) -> Any:
     if isinstance(obj, (str, int, float, bool)):
         return obj
 
-    # Handle datetime objects
+    # Decimal — exchangelib stores task percent_complete and some other
+    # numeric fields as Decimal. json.dumps doesn't know how to serialise
+    # it, so coerce to float at the boundary. Bug TSK-004.
+    if isinstance(obj, _Decimal):
+        return float(obj)
+
+    # Handle datetime objects. Naive datetimes from Exchange are
+    # stamped with the configured TIMEZONE so downstream ISO-string
+    # comparisons remain consistent ("Z" vs. bare "...+03:00"), not
+    # silently interpreted as UTC by the receiver.
     if isinstance(obj, datetime):
-        return obj.isoformat()
+        return _ensure_aware_iso(obj)
 
     # Handle EWSDateTime and EWSDate
     if isinstance(obj, (EWSDateTime, EWSDate)):
         return obj.isoformat() if hasattr(obj, 'isoformat') else str(obj)
+
+    # exchangelib's FreeBusyView calendar_events list contains
+    # ``CalendarEventDetails`` objects — structured but not a dict, not
+    # a primitive, and without a single ``id`` scalar. Pull out the
+    # concrete fields we know about. (Bug CAL-006 JSON-serialisation.)
+    event_json = _calendar_event_details_to_json(obj)
+    if event_json is not None:
+        return event_json
 
     # Handle lists/tuples
     if isinstance(obj, (list, tuple)):
@@ -309,9 +389,10 @@ class EWSJSONEncoder(json.JSONEncoder):
     def default(self, obj: Any) -> Any:
         """Convert non-serializable objects."""
         result = make_json_serializable(obj)
-        if isinstance(result, (dict, list)):
-            return result
-        if isinstance(result, str):
+        # Pass through any JSON-native primitive so Decimal -> float
+        # doesn't get stringified back to "0.25". dict / list already
+        # go through the normal encoder recursion.
+        if isinstance(result, (dict, list, str, int, float, bool)) or result is None:
             return result
         return str(result)
 

--- a/tests/test_tool_reliability_round2.py
+++ b/tests/test_tool_reliability_round2.py
@@ -147,13 +147,17 @@ async def test_delete_email_hard_delete_uses_hard_delete_type(mock_ews_client):
 
     # move() must NOT be called — that would put the item in Trash.
     item.move.assert_not_called()
-    # delete() must be called with an explicit HARD_DELETE delete_type.
+    # delete() must be called with an explicit HARD_DELETE via the
+    # correct ``disposal_type`` kwarg (the exchangelib API; the
+    # previous round used the wrong kwarg ``delete_type``).
     assert item.delete.called
     call_kwargs = item.delete.call_args.kwargs
-    assert "delete_type" in call_kwargs
-    # exchangelib's constant or the legacy string.
-    delete_type = call_kwargs["delete_type"]
-    assert str(delete_type).lower().replace("_", "").endswith("harddelete"), delete_type
+    assert "disposal_type" in call_kwargs, (
+        f"expected disposal_type kwarg; got {call_kwargs!r}"
+    )
+    assert "delete_type" not in call_kwargs
+    disposal = call_kwargs["disposal_type"]
+    assert str(disposal).replace("_", "").lower().endswith("harddelete"), disposal
     # Response reports permanent=True and hard_delete=True (both aliases).
     assert result["permanent"] is True
     assert result["hard_delete"] is True

--- a/tests/test_tool_reliability_round3.py
+++ b/tests/test_tool_reliability_round3.py
@@ -1,0 +1,267 @@
+"""Regression tests for round-3 follow-ups (CAL-006 JSON, TSK-004 Decimal,
+EDS-006 delete API, ATT-010 response field, warmup retry, naive datetime
+stamping)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# CAL-006 — CalendarEventDetails serialises cleanly
+# ---------------------------------------------------------------------------
+
+
+def test_calendar_event_details_serialises():
+    """CalendarEventDetails must pass through safe_json_dumps without
+    TypeError. Previously the plain json.dumps in main.py crashed."""
+    from exchangelib.properties import CalendarEventDetails
+    from src.utils import safe_json_dumps, make_json_serializable
+
+    details = CalendarEventDetails(
+        id="AAMk-event",
+        subject="Budget review",
+        location="Room A",
+        is_meeting=True,
+        is_recurring=False,
+        is_exception=False,
+        is_reminder_set=True,
+        is_private=False,
+    )
+
+    payload = {"event": details}
+    serialised = safe_json_dumps(payload)
+    parsed = json.loads(serialised)
+    assert parsed["event"]["subject"] == "Budget review"
+    assert parsed["event"]["location"] == "Room A"
+    assert parsed["event"]["is_meeting"] is True
+
+    # make_json_serializable handles it directly too.
+    as_dict = make_json_serializable(details)
+    assert as_dict["subject"] == "Budget review"
+
+
+def test_calendar_event_details_in_nested_list():
+    """Lists of events inside availability results must serialise."""
+    from exchangelib.properties import CalendarEventDetails
+    from src.utils import safe_json_dumps
+
+    events = [
+        CalendarEventDetails(id=None, subject="A", location=None,
+                             is_meeting=False, is_recurring=False,
+                             is_exception=False, is_reminder_set=False,
+                             is_private=False),
+        CalendarEventDetails(id="AAMk-2", subject="B", location="X",
+                             is_meeting=True, is_recurring=False,
+                             is_exception=False, is_reminder_set=False,
+                             is_private=False),
+    ]
+    out = safe_json_dumps({"events": events})
+    parsed = json.loads(out)
+    assert [e["subject"] for e in parsed["events"]] == ["A", "B"]
+
+
+# ---------------------------------------------------------------------------
+# TSK-004 — Decimal serialises cleanly
+# ---------------------------------------------------------------------------
+
+
+def test_decimal_serialises_as_float():
+    from src.utils import safe_json_dumps, make_json_serializable
+
+    assert make_json_serializable(Decimal("0.25")) == 0.25
+    parsed = json.loads(safe_json_dumps({"percent_complete": Decimal("0.75")}))
+    assert parsed["percent_complete"] == 0.75
+
+
+def test_decimal_in_tasks_response_survives_round_trip():
+    from src.utils import safe_json_dumps
+
+    task = {
+        "item_id": "AAMk-1",
+        "subject": "Write tests",
+        "percent_complete": Decimal("25.5"),
+        "status": "InProgress",
+    }
+    out = safe_json_dumps({"tasks": [task], "count": 1})
+    parsed = json.loads(out)
+    assert parsed["tasks"][0]["percent_complete"] == 25.5
+
+
+# ---------------------------------------------------------------------------
+# Naive datetime serialisation stamps configured TZ
+# ---------------------------------------------------------------------------
+
+
+def test_naive_datetime_stamped_with_configured_tz(monkeypatch):
+    """Naive datetimes emitted by exchangelib get a tz stamp so the ISO
+    string isn't ambiguous."""
+    from src.utils import make_json_serializable
+
+    monkeypatch.setenv("TIMEZONE", "Asia/Riyadh")
+    naive = datetime(2026, 4, 19, 10, 0, 0)
+    out = make_json_serializable(naive)
+    # Asia/Riyadh is UTC+3 year-round.
+    assert out.endswith("+03:00"), out
+    assert out.startswith("2026-04-19T10:00:00")
+
+
+def test_aware_datetime_passes_through_unchanged():
+    """An already-aware datetime is serialised as-is."""
+    from datetime import timezone, timedelta
+    from src.utils import make_json_serializable
+
+    aware = datetime(2026, 4, 19, 10, 0, 0, tzinfo=timezone(timedelta(hours=5)))
+    out = make_json_serializable(aware)
+    assert out == "2026-04-19T10:00:00+05:00"
+
+
+# ---------------------------------------------------------------------------
+# EDS-006 — delete_email hard_delete uses correct exchangelib API
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_eds006_hard_delete_uses_disposal_type_kwarg(mock_ews_client):
+    """The exchangelib API is ``item.delete(disposal_type=...)`` (not
+    ``delete_type=``) and the HARD_DELETE constant lives in
+    ``exchangelib.items`` (not the top-level ``exchangelib`` package).
+    Previous fix used the wrong keyword AND the wrong import path — both
+    produced 500s."""
+    from src.tools.email_tools import DeleteEmailTool
+
+    item = MagicMock()
+    with patch(
+        "src.tools.email_tools.find_message_for_account", return_value=item
+    ):
+        tool = DeleteEmailTool(mock_ews_client)
+        await tool.execute(message_id="AAMk-1", hard_delete=True)
+
+    # item.delete() called with disposal_type=..., NOT delete_type=...
+    assert item.delete.called
+    call_kwargs = item.delete.call_args.kwargs
+    assert "disposal_type" in call_kwargs, (
+        f"expected disposal_type kwarg; got {call_kwargs!r}"
+    )
+    assert "delete_type" not in call_kwargs
+    # Value is either the exchangelib.items.HARD_DELETE constant or the
+    # literal "HardDelete" fallback — both are valid.
+    value = call_kwargs["disposal_type"]
+    assert str(value).replace("_", "").lower().endswith("harddelete")
+
+
+def test_eds006_hard_delete_constant_import_path():
+    """``HARD_DELETE`` lives in ``exchangelib.items``, not the package root."""
+    # Must import without error from the documented location.
+    from exchangelib.items import HARD_DELETE
+    assert HARD_DELETE is not None
+    # The top-level package no longer re-exports it.
+    import exchangelib
+    assert not hasattr(exchangelib, "HARD_DELETE"), (
+        "If exchangelib starts re-exporting HARD_DELETE, that's fine; the "
+        "important thing is that src/tools/email_tools.py works with BOTH."
+    )
+
+
+# ---------------------------------------------------------------------------
+# ATT-010 — file_path always present in download_attachment response
+# ---------------------------------------------------------------------------
+
+
+def _att():
+    att = MagicMock()
+    att.attachment_id = {"id": "AT-1"}
+    att.name = "report.pdf"
+    att.content = b"PDF bytes"
+    att.content_type = "application/pdf"
+    return att
+
+
+@pytest.mark.asyncio
+async def test_att010_base64_response_has_file_path_key(mock_ews_client):
+    """Even in base64 mode, file_path is present (as null) so callers
+    don't have to branch on return_as."""
+    from src.tools.attachment_tools import DownloadAttachmentTool
+
+    msg = MagicMock()
+    msg.attachments = [_att()]
+
+    tool = DownloadAttachmentTool(mock_ews_client)
+    with patch(
+        "src.tools.attachment_tools.find_message_for_account",
+        return_value=msg,
+    ):
+        result = await tool.execute(
+            message_id="AAMk-msg", attachment_id="AT-1"
+        )
+    assert result["success"] is True
+    # file_path is present (null because no file was written).
+    assert "file_path" in result
+    assert result["file_path"] is None
+    # saved_path alias present too.
+    assert "saved_path" in result
+
+
+@pytest.mark.asyncio
+async def test_att010_file_mode_response_has_both_keys(mock_ews_client, tmp_path, monkeypatch):
+    """File-path mode: both file_path and saved_path point at the resolved
+    location."""
+    from src.tools.attachment_tools import DownloadAttachmentTool
+
+    monkeypatch.setenv("EWS_DOWNLOAD_DIR", str(tmp_path))
+    import importlib
+    from src.tools import attachment_tools as at
+    importlib.reload(at)
+
+    msg = MagicMock()
+    msg.attachments = [_att()]
+
+    tool = at.DownloadAttachmentTool(mock_ews_client)
+    with patch(
+        "src.tools.attachment_tools.find_message_for_account",
+        return_value=msg,
+    ):
+        result = await tool.execute(
+            message_id="AAMk-msg",
+            attachment_id="AT-1",
+            return_as="file_path",
+            save_path="report.pdf",
+        )
+    assert result["success"] is True
+    assert result["file_path"]
+    assert result["saved_path"]
+    assert result["file_path"] == result["saved_path"]
+
+
+# ---------------------------------------------------------------------------
+# Warmup retry-with-backoff
+# ---------------------------------------------------------------------------
+
+
+def test_is_transient_error_detects_connection_issues():
+    from src.main import _is_transient_error
+
+    class RemoteDisconnected(Exception):
+        pass
+
+    assert _is_transient_error([("inbox", RemoteDisconnected("x"))]) is True
+    # Message-only match (wrapped exchangelib errors).
+    assert _is_transient_error([("inbox", RuntimeError("Connection aborted"))]) is True
+    assert _is_transient_error([("inbox", RuntimeError("timed out"))]) is True
+
+
+def test_is_transient_error_skips_non_retryable():
+    from src.main import _is_transient_error
+
+    class SchemaError(Exception):
+        pass
+
+    assert _is_transient_error([("inbox", SchemaError("attribute missing"))]) is False
+    assert _is_transient_error([("inbox", ValueError("bad input"))]) is False
+    assert _is_transient_error([]) is False


### PR DESCRIPTION
… field

Four concrete fixes from the latest end-to-end testing report, plus the two side-findings.

CAL-006: check_availability 500 — CalendarEventDetails JSON-unserializable ------------------------------------------------------------------------- src/utils.py::make_json_serializable now has an explicit handler for ``exchangelib.properties.CalendarEventDetails``. The check_availability tool upgraded to surface event details inside busy slots, but the JSON encoder didn't get the corresponding branch. Fields exposed: id, subject, location, is_meeting, is_recurring, is_exception, is_reminder_set, is_private.

src/main.py: the REST /api/tools/{tool} handler and /openapi.json now use ``safe_json_dumps`` (which goes through EWSJSONEncoder) instead of the raw ``json.dumps`` that was crashing on line 724 per the server traceback.

TSK-004: get_tasks 500 — Decimal JSON-unserializable ---------------------------------------------------- src/utils.py::make_json_serializable now converts ``Decimal`` to float at the boundary. EWSJSONEncoder.default also passes through native JSON primitives (int/float/bool/None) instead of stringifying them, so Decimal("0.75") -> 0.75 (not "0.75").

EDS-006: delete_email(hard_delete=True) 500 — wrong exchangelib API ------------------------------------------------------------------- The previous fix tried both ``from exchangelib import HARD_DELETE`` (wrong — it's in ``exchangelib.items``) and ``item.delete(delete_type=...)`` (wrong — the kwarg is ``disposal_type``). Corrected:

    from exchangelib.items import HARD_DELETE
    item.delete(disposal_type=HARD_DELETE)
    # Fallback (no import):
    item.delete(disposal_type="HardDelete")

Drafts no longer end up in Trash when hard_delete=True is requested.

ATT-010: schema drift on download_attachment response ----------------------------------------------------- src/tools/attachment_tools.py::DownloadAttachmentTool now emits ``file_path`` in EVERY success response:
  * base64 mode: file_path=None (explicit), so callers don't have to branch on return_as.
  * file_path mode: file_path=<resolved> plus a ``saved_path`` alias for newer callers.

Side-finding #1: warmup silent-abort on cold start -------------------------------------------------- src/main.py::_run_embedding_warmup now retries collection up to 3 more times with 5s / 15s / 45s backoff when the failure looks transient (ConnectionError / RemoteDisconnected / ProtocolError / ReadTimeout / SSLError / MaxRetryError / ChunkedEncodingError, or a message containing "Connection aborted" / "Max retries exceeded" / "timed out" / "Connection refused").

Non-retryable errors (schema problems, missing folders) are still logged once and the warmup exits.

New module-level helper: ``_is_transient_error``.

Side-finding #2: naive datetimes leaking from exchangelib --------------------------------------------------------- src/utils.py::make_json_serializable pipes naive datetimes through a new ``_ensure_aware_iso`` helper that stamps them with the configured ``TIMEZONE`` (or UTC fallback) before ``.isoformat()``. Downstream callers no longer see ambiguous "2026-04-19T10:00:00" strings whose timezone interpretation depends on the reader.

Tests (tests/test_tool_reliability_round3.py, 12 new) -----------------------------------------------------
* CalendarEventDetails serialises directly + inside nested lists.
* Decimal round-trips through safe_json_dumps as a float.
* Naive datetime stamped with TIMEZONE=Asia/Riyadh; aware datetime passes through.
* delete_email uses ``disposal_type=`` (not ``delete_type=``); HARD_DELETE importable from ``exchangelib.items``.
* download_attachment response always has ``file_path`` + ``saved_path``.
* _is_transient_error classifies common transient vs. non-transient.

Also updates tests/test_tool_reliability_round2.py:: test_delete_email_hard_delete_uses_hard_delete_type to match the corrected API (``disposal_type`` kwarg).

Full suite: 273 passing (+12 new) / 18 pre-existing failures unchanged.