### PR TITLE
feat(transport): SSE keepalive + long-running-tool resilience

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -2,7 +2,47 @@
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field, model_validator
-from typing import Literal, Optional
+from typing import Callable, Literal, Optional
+
+
+def _make_int_clamp(logger) -> Callable[..., int]:
+    """Factory for an int clamp-with-warn helper.
+
+    Returns a function ``(env_name, value, low, high, default)`` that:
+
+    * Returns ``value`` unchanged when it's inside ``[low, high]``.
+    * Returns the clamped bound (and logs a WARNING) when it's outside.
+    * Returns ``default`` (with a WARNING) when ``value`` is non-numeric
+      (zero, negative, or a type that would spin-loop a background task).
+
+    Used by :meth:`Settings.validate_auth_credentials` to tame the
+    transport-resilience knobs.
+    """
+
+    def _clamp(env_name: str, value: int, low: int, high: int, default: int) -> int:
+        try:
+            ival = int(value)
+        except (TypeError, ValueError):
+            logger.warning(
+                "%s=%r is not an integer; using default %d", env_name, value, default,
+            )
+            return default
+        if ival < low:
+            logger.warning(
+                "%s=%d is below minimum %d; clamping up. Very small intervals "
+                "risk spinning the event loop.",
+                env_name, ival, low,
+            )
+            return low
+        if ival > high:
+            logger.warning(
+                "%s=%d exceeds maximum %d; clamping down.",
+                env_name, ival, high,
+            )
+            return high
+        return ival
+
+    return _clamp
 
 
 class Settings(BaseSettings):
@@ -96,6 +136,45 @@ class Settings(BaseSettings):
     ai_model: Optional[str] = None  # e.g., "gpt-4", "claude-3-5-sonnet-20241022"
     ai_embedding_model: Optional[str] = None  # e.g., "text-embedding-3-small"
     ai_base_url: Optional[str] = None  # For local models or custom endpoints
+
+    # --- Long-lived SSE / transport resilience ---------------------------
+    # Keep the SSE byte stream alive across long tool executions so upstream
+    # proxies (nginx, HAProxy, cloud LBs) don't reap it as idle. Values are
+    # clamped in a validator below; out-of-range settings log a warning but
+    # do not crash startup.
+    sse_keepalive_enabled: bool = Field(
+        default=True,
+        description="Emit SSE comment frames to keep the stream alive through proxies.",
+    )
+    sse_keepalive_interval_seconds: int = Field(
+        default=15,
+        description="Seconds between SSE comment frames (clamped to [5, 60]).",
+    )
+    http_keep_alive_timeout_seconds: int = Field(
+        default=300,
+        description="Uvicorn HTTP keep-alive timeout in seconds (clamped to [30, 900]).",
+    )
+    tcp_keepalive_enabled: bool = Field(
+        default=True,
+        description="Set SO_KEEPALIVE (and TCP_KEEPIDLE on Linux) on accepted sockets.",
+    )
+    tcp_keepalive_idle_seconds: int = Field(
+        default=60,
+        description="Linux TCP_KEEPIDLE (time before first keepalive probe). Clamped to [30, 600].",
+    )
+
+    # Optional MCP progress notifications for long-running tool calls.
+    # Distinct from SSE keepalive: those keep the byte stream alive for
+    # the proxy; these keep the MCP *session* alive for client-side
+    # session watchdogs. Both can run at once.
+    progress_notification_enabled: bool = Field(
+        default=True,
+        description="Periodically send notifications/progress while a tool call is in flight.",
+    )
+    progress_notification_interval_seconds: int = Field(
+        default=10,
+        description="Seconds between progress notifications (clamped to [5, 60]).",
+    )
     ai_max_tokens: int = 4096
     ai_temperature: float = 0.7
     enable_semantic_search: bool = False
@@ -135,10 +214,12 @@ class Settings(BaseSettings):
                     "auth-enforcing reverse proxy."
                 )
 
+        # Shared logger for both AI validation + transport clamping.
+        import logging as _logging
+        _log = _logging.getLogger(__name__)
+
         # Validate AI settings
         if self.enable_ai:
-            import logging as _logging
-            _log = _logging.getLogger(__name__)
             if not self.ai_api_key and self.ai_provider != "local":
                 raise ValueError(f"AI enabled but ai_api_key not provided for {self.ai_provider}")
             if not self.ai_model:
@@ -182,6 +263,33 @@ class Settings(BaseSettings):
                     "'model not found' — update AI_EMBEDDING_MODEL.",
                     self.ai_embedding_model,
                 )
+
+        # Clamp the transport-resilience knobs. Out-of-range values are
+        # accepted with a warning (never a crash) because the dev's typo
+        # shouldn't take the server offline — the clamped value is still
+        # safe. Zero or negative intervals would spin-loop the keepalive
+        # task and DoS the event loop, so we clamp them firmly.
+        _clamp_int = _make_int_clamp(_log)
+        self.sse_keepalive_interval_seconds = _clamp_int(
+            "SSE_KEEPALIVE_INTERVAL",
+            self.sse_keepalive_interval_seconds,
+            low=5, high=60, default=15,
+        )
+        self.http_keep_alive_timeout_seconds = _clamp_int(
+            "HTTP_KEEP_ALIVE_TIMEOUT",
+            self.http_keep_alive_timeout_seconds,
+            low=30, high=900, default=300,
+        )
+        self.tcp_keepalive_idle_seconds = _clamp_int(
+            "TCP_KEEPALIVE_IDLE",
+            self.tcp_keepalive_idle_seconds,
+            low=30, high=600, default=60,
+        )
+        self.progress_notification_interval_seconds = _clamp_int(
+            "PROGRESS_NOTIFICATION_INTERVAL",
+            self.progress_notification_interval_seconds,
+            low=5, high=60, default=10,
+        )
 
         return self
 
@@ -231,7 +339,9 @@ def get_settings() -> Settings:
     """Get or create settings instance (lazy loading)."""
     global _settings
     if _settings is None:
-        _settings = Settings()
+        # Pydantic reads required fields from env vars at runtime; mypy
+        # can't model that, so silence the "missing argument" error.
+        _settings = Settings()  # type: ignore[call-arg]
     return _settings
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,14 @@
 """Main MCP Server implementation for Exchange Web Services."""
 
 import asyncio
+import hmac
 import logging
 import os
+import socket
 import sys
-from typing import Any
+import threading
+import time
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional, Tuple
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
@@ -106,6 +110,300 @@ def _is_transient_error(errors) -> bool:
             "timed out",
         )):
             return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# SSE transport resilience helpers
+# ---------------------------------------------------------------------------
+#
+# Background. The MCP SDK's ``SseServerTransport`` writes Server-Sent-Events
+# directly on the ASGI send callable. Long tool executions can sit idle for
+# 60-240s without emitting events, which triggers proxy idle timeouts and
+# closes the stream. The client's POST to /messages then fires against a
+# dead session and we see ``ClosedResourceError``.
+#
+# Fix: emit SSE *comment* frames (``: keepalive <epoch>\n\n``) on a fixed
+# interval. Comment frames are ignored by spec-compliant clients but keep
+# proxies and load balancers from reaping the stream. To avoid interleaving
+# with the SDK's own event writes (which would corrupt HTTP/1.1 chunked
+# encoding), every send call goes through a per-connection ``asyncio.Lock``.
+#
+# The helpers below are module-level so they can be unit-tested without
+# spinning up the server. Each is narrowly typed; the ASGI ``send`` callable
+# is typed as ``Callable[[Dict[str, Any]], Awaitable[None]]``.
+# ---------------------------------------------------------------------------
+
+
+# ASGI send signature. The ASGI spec types the message as a
+# ``MutableMapping[str, Any]`` (not a concrete ``dict``) — using
+# ``MutableMapping`` here so mypy is happy when we pass our wrapped
+# callable into ``sse.connect_sse``.
+from collections.abc import MutableMapping
+ASGISend = Callable[[MutableMapping[str, Any]], Awaitable[None]]
+
+# Errors that mean "peer has gone away". Module-level so both the SSE
+# keepalive loop and the progress loop can reference the same set.
+# ``anyio.ClosedResourceError`` is imported lazily to avoid a hard import
+# dependency when anyio isn't present (it ships with the MCP SDK, so in
+# practice it always is).
+_PEER_GONE_ERROR_NAMES = frozenset({
+    "BrokenResourceError",
+    "ClosedResourceError",
+    "ConnectionResetError",
+    "BrokenPipeError",
+    "EndOfStream",
+})
+
+
+def _peer_gone(exc: BaseException) -> bool:
+    """True if ``exc`` looks like a client-disconnect, not a server bug.
+
+    Comparison is by class name + a few strings so we don't have to pin
+    anyio import order.
+    """
+    name = type(exc).__name__
+    if name in _PEER_GONE_ERROR_NAMES:
+        return True
+    msg = str(exc)
+    return any(tok in msg for tok in (
+        "Broken pipe", "Connection reset", "Connection aborted",
+        "closed resource",
+    ))
+
+
+# Module-level counter of active SSE connections. Used for /health and as
+# a cheap leak detector in tests. Protected by a threading.Lock because
+# ASGI apps can run under multi-threaded workers in other deployments;
+# even though uvicorn here is single-threaded-asyncio, the lock is cheap
+# and keeps the read/increment atomic.
+_ACTIVE_SSE: Dict[str, int] = {"count": 0}
+_ACTIVE_SSE_LOCK = threading.Lock()
+
+
+def _sse_active_count() -> int:
+    """Return the current number of live SSE connections."""
+    with _ACTIVE_SSE_LOCK:
+        return _ACTIVE_SSE["count"]
+
+
+def _sse_active_inc() -> None:
+    with _ACTIVE_SSE_LOCK:
+        _ACTIVE_SSE["count"] += 1
+
+
+def _sse_active_dec() -> None:
+    with _ACTIVE_SSE_LOCK:
+        if _ACTIVE_SSE["count"] > 0:
+            _ACTIVE_SSE["count"] -= 1
+
+
+# SSE proxy-buster headers. Some reverse proxies (nginx in particular)
+# buffer responses until EOF unless explicitly told otherwise — that
+# buffering defeats the whole point of SSE. ``X-Accel-Buffering: no`` is
+# the nginx-specific opt-out. ``Cache-Control: no-transform`` prevents
+# gzip'ing the stream (a chunked gzip response waits for EOF too).
+_SSE_PROXY_HEADERS: Tuple[Tuple[bytes, bytes], ...] = (
+    (b"cache-control", b"no-cache, no-transform"),
+    (b"x-accel-buffering", b"no"),
+    (b"connection", b"keep-alive"),
+)
+
+
+def _merge_sse_headers(existing: Iterable[Tuple[bytes, bytes]]) -> List[List[bytes]]:
+    """Return the SDK-provided headers plus our proxy-buster set.
+
+    Does not overwrite a header the SDK already supplied (case-insensitive
+    match). Always returns mutable list-of-lists so it can be fed back to
+    ``send``.
+    """
+    # Normalize to list so ASGI accepts it.
+    out: List[List[bytes]] = []
+    seen: set = set()
+    for name, value in existing:
+        nlower = name.lower() if isinstance(name, bytes) else str(name).encode().lower()
+        seen.add(nlower)
+        out.append([name if isinstance(name, bytes) else str(name).encode(),
+                    value if isinstance(value, bytes) else str(value).encode()])
+    for name, value in _SSE_PROXY_HEADERS:
+        if name not in seen:
+            out.append([name, value])
+    return out
+
+
+def _wrap_send_with_sse_headers(send: ASGISend) -> Tuple[ASGISend, asyncio.Event, asyncio.Lock]:
+    """Wrap ``send`` so the first http.response.start gets the SSE
+    proxy-buster headers, and so every write is serialised through a
+    per-connection ``asyncio.Lock``.
+
+    Returns:
+        wrapped_send: drop-in replacement for the ASGI send callable.
+        headers_sent: event set once the first ``http.response.start``
+            has been flushed — the keepalive loop waits on it before
+            sending its first comment frame (sending a comment before
+            headers would 500 the request).
+        send_lock: the lock shared by wrapped_send and the keepalive
+            loop. Two writers on raw ``send`` would corrupt the
+            HTTP/1.1 chunked body.
+    """
+    headers_sent = asyncio.Event()
+    send_lock = asyncio.Lock()
+
+    async def _wrapped(message: MutableMapping[str, Any]) -> None:
+        if message.get("type") == "http.response.start":
+            # Clone the message so we don't mutate the SDK's dict.
+            merged: Dict[str, Any] = dict(message)
+            merged["headers"] = _merge_sse_headers(message.get("headers") or [])
+            async with send_lock:
+                await send(merged)
+            headers_sent.set()
+            return
+        async with send_lock:
+            await send(message)
+
+    return _wrapped, headers_sent, send_lock
+
+
+async def _keepalive_loop(
+    send: ASGISend,
+    send_lock: asyncio.Lock,
+    headers_sent: asyncio.Event,
+    interval_seconds: int,
+    logger: logging.Logger,
+) -> None:
+    """Emit SSE comment frames every ``interval_seconds`` until cancelled.
+
+    * Waits for ``headers_sent`` before the first write — sending a
+      comment before the response headers would 500 the request.
+    * Every frame is a plain ASCII ``: keepalive <epoch>\\n\\n``. No
+      user-controlled content reaches this function (defence against
+      header injection).
+    * On peer-disconnect errors, exits cleanly at DEBUG so log level
+      INFO stays quiet in normal operation.
+    * If the send_lock is held (the SDK is mid-write), skip this tick
+      rather than queue — a slow client must not be able to pin server
+      memory by backlogging keepalives.
+
+    ``send`` here is the *wrapped* callable returned by
+    :func:`_wrap_send_with_sse_headers`; it takes the ``send_lock``
+    internally. We therefore read ``send_lock.locked()`` only to decide
+    whether to skip this tick, and never acquire the lock ourselves
+    (that would deadlock against the wrapper).
+    """
+    try:
+        await headers_sent.wait()
+    except asyncio.CancelledError:
+        raise
+
+    # Hard-cap the interval locally too — the Settings validator clamps,
+    # but a direct caller (tests, future refactor) shouldn't be able to
+    # pass 0 and spin-loop the event loop.
+    interval = max(1, int(interval_seconds))
+
+    while True:
+        try:
+            await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            raise
+
+        # Opportunistic: if the SDK is writing, skip this tick. This keeps
+        # us from queuing up backlog during a burst.
+        if send_lock.locked():
+            continue
+
+        frame = f": keepalive {int(time.time())}\n\n".encode("ascii")
+        try:
+            await send({
+                "type": "http.response.body",
+                "body": frame,
+                "more_body": True,
+            })
+        except asyncio.CancelledError:
+            raise
+        except BaseException as exc:
+            if _peer_gone(exc):
+                logger.debug("sse keepalive: peer closed (%s); exiting loop",
+                             type(exc).__name__)
+                return
+            logger.warning("sse keepalive: unexpected %s: %s",
+                           type(exc).__name__, exc)
+            return
+
+
+def _enable_tcp_keepalive(
+    sock: socket.socket, idle_seconds: int, logger: logging.Logger,
+) -> None:
+    """Turn on OS-level TCP keepalive for an accepted socket.
+
+    * ``SO_KEEPALIVE`` is always set when supported.
+    * On Linux, also set ``TCP_KEEPIDLE`` / ``TCP_KEEPINTVL`` /
+      ``TCP_KEEPCNT`` so the first probe fires at ``idle_seconds`` and
+      we give up after ~3 lost probes (default 9). This matches proxy
+      idle timeouts in the 30-120s range.
+    * On Windows, use ``SIO_KEEPALIVE_VALS``.
+    * On anything else, the ``SO_KEEPALIVE`` call is still made; the
+      platform-specific tuning is skipped silently.
+
+    All ``setsockopt`` calls are guarded with ``hasattr`` so this
+    function never crashes on a platform that lacks a constant.
+    """
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+    except OSError as exc:
+        logger.debug("SO_KEEPALIVE failed: %s", exc)
+        return
+
+    if sys.platform.startswith("linux"):
+        for attr, value in (
+            ("TCP_KEEPIDLE", max(1, int(idle_seconds))),
+            ("TCP_KEEPINTVL", 15),
+            ("TCP_KEEPCNT", 3),
+        ):
+            opt = getattr(socket, attr, None)
+            if opt is None:
+                continue
+            try:
+                sock.setsockopt(socket.IPPROTO_TCP, opt, value)
+            except OSError as exc:
+                logger.debug("setsockopt %s=%d failed: %s", attr, value, exc)
+    elif sys.platform == "win32" and hasattr(socket, "SIO_KEEPALIVE_VALS"):
+        try:
+            # (onoff, keepalivetime_ms, keepaliveinterval_ms)
+            sock.ioctl(
+                socket.SIO_KEEPALIVE_VALS,
+                (1, max(1, int(idle_seconds)) * 1000, 15 * 1000),
+            )
+        except OSError as exc:
+            logger.debug("SIO_KEEPALIVE_VALS failed: %s", exc)
+
+
+def _authorized_request(
+    headers: Iterable[Tuple[bytes, bytes]], api_key: Optional[str],
+) -> bool:
+    """Constant-time auth check for the Bearer / X-API-Key headers.
+
+    ``hmac.compare_digest`` is used so a wrong key of the correct length
+    doesn't leak prefix information via string-comparison timing.
+
+    Returns True if ``api_key`` is unset (no auth configured) or any
+    supported header contains the configured key. Never logs the
+    presented value; callers get False and a generic 401.
+    """
+    if not api_key:
+        return True
+    expected = api_key.encode("utf-8")
+    for name, value in headers or []:
+        name_lower = name.lower() if isinstance(name, bytes) else str(name).encode().lower()
+        raw = value.decode("utf-8", errors="replace") if isinstance(value, bytes) else str(value)
+        if name_lower == b"authorization":
+            if raw.lower().startswith("bearer "):
+                candidate = raw[7:].strip().encode("utf-8")
+                if hmac.compare_digest(candidate, expected):
+                    return True
+        elif name_lower == b"x-api-key":
+            candidate = raw.strip().encode("utf-8")
+            if hmac.compare_digest(candidate, expected):
+                return True
     return False
 
 
@@ -223,6 +521,24 @@ class EWSMCPServer:
             tool = self.tools[name]
             self.logger.info(f"Executing tool: {name}")
 
+            # Optional MCP ``notifications/progress`` stream. Keeps
+            # client-side session watchdogs happy during long tool
+            # executions (distinct from the SSE byte-stream keepalive).
+            # Only runs when the client supplied ``_meta.progressToken``
+            # — we never synthesise a token.
+            progress_task: Optional[asyncio.Task[None]] = None
+            if getattr(self.settings, "progress_notification_enabled", True):
+                progress_task = self._maybe_start_progress_ticker(
+                    tool_name=name,
+                    interval_seconds=int(
+                        getattr(
+                            self.settings,
+                            "progress_notification_interval_seconds",
+                            10,
+                        )
+                    ),
+                )
+
             try:
                 result = await tool.safe_execute(**arguments)
 
@@ -248,6 +564,97 @@ class EWSMCPServer:
                     type="text",
                     text=safe_json_dumps(error_response)
                 )]
+            finally:
+                if progress_task is not None and not progress_task.done():
+                    progress_task.cancel()
+                    try:
+                        await progress_task
+                    except (asyncio.CancelledError, Exception):
+                        pass
+
+    def _maybe_start_progress_ticker(
+        self, *, tool_name: str, interval_seconds: int,
+    ) -> Optional[asyncio.Task[None]]:
+        """Start a background progress-notification ticker for this call.
+
+        Returns None when:
+          * the client didn't include ``_meta.progressToken`` on the request
+          * the MCP SDK doesn't expose the request context in this
+            version (attribute missing)
+          * the session object doesn't have ``send_progress_notification``
+
+        Never raises — worst case we fall back to SSE keepalive only.
+        Never logs the progress token (security rule 2).
+        """
+        # The MCP SDK exposes the active request via a contextvar
+        # attribute on the server. The exact name has varied between
+        # releases, so probe defensively.
+        request_ctx = getattr(self.server, "request_context", None)
+        if request_ctx is None:
+            return None
+
+        session = getattr(request_ctx, "session", None)
+        send_progress = getattr(session, "send_progress_notification", None)
+        if send_progress is None:
+            return None
+
+        # The progress token lives under request.params._meta.progressToken.
+        progress_token = None
+        try:
+            meta = getattr(getattr(request_ctx, "meta", None), "progressToken", None)
+            if meta is not None:
+                progress_token = meta
+            else:
+                req = getattr(request_ctx, "request", None)
+                params = getattr(req, "params", None) if req is not None else None
+                meta = getattr(params, "meta", None) if params is not None else None
+                progress_token = getattr(meta, "progressToken", None) if meta is not None else None
+        except Exception:
+            progress_token = None
+
+        if progress_token is None:
+            return None
+
+        # Bound the interval here too, independent of the Settings
+        # validator. Zero/negative would spin-loop the event loop.
+        interval = max(5, min(60, int(interval_seconds)))
+        logger = self.logger
+
+        async def _ticker() -> None:
+            progress = 0
+            try:
+                while True:
+                    try:
+                        await asyncio.sleep(interval)
+                    except asyncio.CancelledError:
+                        raise
+                    progress += 1
+                    try:
+                        await send_progress(
+                            progress_token=progress_token,
+                            progress=float(progress),
+                            total=None,
+                        )
+                    except asyncio.CancelledError:
+                        raise
+                    except BaseException as exc:
+                        if _peer_gone(exc):
+                            logger.debug(
+                                "progress ticker for %s: peer closed (%s)",
+                                tool_name, type(exc).__name__,
+                            )
+                            return
+                        # Don't kill the tool if notifications fail —
+                        # just stop the ticker.
+                        logger.debug(
+                            "progress ticker for %s: %s: %s; exiting loop",
+                            tool_name, type(exc).__name__, exc,
+                        )
+                        return
+            except asyncio.CancelledError:
+                raise
+
+        return asyncio.create_task(_ticker(), name=f"progress-{tool_name}")
 
     def register_tools(self):
         """Register all enabled tools (42 base tools, up to 46 with AI)."""
@@ -502,6 +909,50 @@ class EWSMCPServer:
             self.ews_client.close()
             self.logger.info("Server stopped")
 
+    async def _run_sse_connection(
+        self,
+        sse: "SseServerTransport",
+        scope: Dict[str, Any],
+        receive: Callable[[], Awaitable[Dict[str, Any]]],
+        wrapped_send: ASGISend,
+        headers_sent: asyncio.Event,
+        send_lock: asyncio.Lock,
+        *,
+        keepalive_enabled: bool,
+        keepalive_interval: int,
+    ) -> None:
+        """Drive the MCP server loop for one SSE connection.
+
+        Kept separate from ``handle_sse`` so the caller's try/finally
+        stays short (<80 lines). Raises ``BaseExceptionGroup`` when the
+        TaskGroup path wraps child failures; the caller classifies.
+        """
+        async with sse.connect_sse(scope, receive, wrapped_send) as streams:
+            run_mcp = self.server.run(
+                streams[0],
+                streams[1],
+                self.server.create_initialization_options(),
+            )
+            if not keepalive_enabled:
+                await run_mcp
+                return
+            async with asyncio.TaskGroup() as tg:
+                mcp_task = tg.create_task(run_mcp, name="mcp-serve")
+                keepalive_task = tg.create_task(
+                    _keepalive_loop(
+                        wrapped_send, send_lock, headers_sent,
+                        keepalive_interval, self.logger,
+                    ),
+                    name="sse-keepalive",
+                )
+                # When the MCP task finishes, stop the keepalive so the
+                # TaskGroup exits. TaskGroup cancels outstanding siblings
+                # if ANY raises, so we only need to explicitly cancel on
+                # normal mcp_task completion.
+                await mcp_task
+                if not keepalive_task.done():
+                    keepalive_task.cancel()
+
     async def _run_embedding_warmup(self) -> None:
         """Background task: pre-embed recent Inbox + Sent items.
 
@@ -645,34 +1096,66 @@ class EWSMCPServer:
         import uvicorn
 
         sse = SseServerTransport("/messages")
+        keepalive_enabled = bool(
+            getattr(self.settings, "sse_keepalive_enabled", True)
+        )
+        keepalive_interval = int(
+            getattr(self.settings, "sse_keepalive_interval_seconds", 15)
+        )
+        if keepalive_enabled:
+            self.logger.info(
+                "sse keepalive enabled: interval=%ds", keepalive_interval,
+            )
 
-        # Create raw ASGI handler for SSE endpoint
-        async def handle_sse(scope, receive, send):
-            """Handle SSE connection endpoint."""
+        async def handle_sse(
+            scope: Dict[str, Any], receive: Callable[[], Awaitable[Dict[str, Any]]], send: ASGISend,
+        ) -> None:
+            """Handle SSE connection endpoint.
+
+            Transport-layer responsibilities only:
+              * Inject SSE proxy-buster headers on the first response.
+              * Run a per-connection keepalive task (comment frames).
+              * Serialise every ASGI send through a single lock so the
+                SDK's event writes and our keepalives don't interleave
+                inside one HTTP/1.1 chunk.
+              * Increment/decrement the active-connection counter used
+                by /health.
+            """
+            wrapped_send, headers_sent, send_lock = _wrap_send_with_sse_headers(send)
+            _sse_active_inc()
             try:
-                async with sse.connect_sse(scope, receive, send) as streams:
-                    await self.server.run(
-                        streams[0],
-                        streams[1],
-                        self.server.create_initialization_options(),
+                await self._run_sse_connection(
+                    sse, scope, receive, wrapped_send,
+                    headers_sent, send_lock,
+                    keepalive_enabled=keepalive_enabled,
+                    keepalive_interval=keepalive_interval,
+                )
+            except BaseExceptionGroup as eg:
+                # TaskGroup wraps child exceptions in ExceptionGroup.
+                non_peer = [e for e in eg.exceptions if not _peer_gone(e)]
+                if not non_peer:
+                    self.logger.debug(
+                        "SSE connection closed by peer (%s)",
+                        ", ".join(sorted({type(e).__name__ for e in eg.exceptions})),
                     )
-            except Exception as e:
-                # Log but don't crash - client may have disconnected
-                self.logger.warning(f"SSE connection closed: {type(e).__name__}: {e}")
-                # Don't try to send error response if connection is broken
-                if "BrokenResource" not in str(type(e).__name__):
-                    try:
-                        await send({
-                            "type": "http.response.start",
-                            "status": 500,
-                            "headers": [[b"content-type", b"text/plain"]],
-                        })
-                        await send({
-                            "type": "http.response.body",
-                            "body": b"Internal Server Error",
-                        })
-                    except Exception:
-                        pass  # Connection already broken
+                else:
+                    self.logger.warning(
+                        "SSE connection ended with error(s): %s",
+                        "; ".join(f"{type(e).__name__}: {e}" for e in non_peer),
+                    )
+            except Exception as exc:
+                # Pre-TaskGroup failure (e.g. connect_sse raising) —
+                # plain, not wrapped. Classify the same way.
+                if _peer_gone(exc):
+                    self.logger.debug(
+                        "SSE connection closed by peer (%s)", type(exc).__name__,
+                    )
+                else:
+                    self.logger.warning(
+                        "SSE connection ended: %s: %s", type(exc).__name__, exc,
+                    )
+            finally:
+                _sse_active_dec()
 
         # Create raw ASGI handler for messages endpoint
         async def handle_messages(scope, receive, send):
@@ -716,20 +1199,13 @@ class EWSMCPServer:
             await send({"type": "http.response.body", "body": body})
 
         def _authorized(headers: list) -> bool:
-            if not api_key:
-                return True
-            for name, value in headers:
-                name_lower = name.lower() if isinstance(name, bytes) else name.encode().lower()
-                if name_lower == b"authorization":
-                    raw = value.decode("utf-8", errors="replace") if isinstance(value, bytes) else value
-                    if raw.lower().startswith("bearer "):
-                        if raw[7:].strip() == api_key:
-                            return True
-                elif name_lower == b"x-api-key":
-                    raw = value.decode("utf-8", errors="replace") if isinstance(value, bytes) else value
-                    if raw.strip() == api_key:
-                        return True
-            return False
+            """Backward-compatible wrapper around ``_authorized_request``.
+
+            Kept as a closure (rather than inlining) so the caller in
+            ``app`` reads the same way as before — only the auth
+            algorithm changed (constant-time compare via hmac).
+            """
+            return _authorized_request(headers, api_key)
 
         # Create a simple ASGI router that handles both MCP and REST endpoints
         async def app(scope, receive, send):
@@ -738,16 +1214,26 @@ class EWSMCPServer:
                 path = scope["path"]
                 method = scope["method"]
 
-                # Health check is always public
+                # Health check is always public. Exposes the active SSE
+                # connection counter so a leak is observable without
+                # needing to attach to the process.
                 if path == "/health" and method == "GET":
+                    health_body = safe_json_dumps({
+                        "status": "ok",
+                        "tools": len(self.tools),
+                        "sse_active_connections": _sse_active_count(),
+                    }).encode("utf-8")
                     await send({
                         "type": "http.response.start",
                         "status": 200,
-                        "headers": [[b"content-type", b"application/json"]],
+                        "headers": [
+                            [b"content-type", b"application/json"],
+                            [b"content-length", str(len(health_body)).encode()],
+                        ],
                     })
                     await send({
                         "type": "http.response.body",
-                        "body": b'{"status":"ok","tools":' + str(len(self.tools)).encode() + b'}',
+                        "body": health_body,
                     })
                     return
 
@@ -837,15 +1323,60 @@ class EWSMCPServer:
                         await send({"type": "lifespan.shutdown.complete"})
                         return
 
-        # Run with uvicorn
+        # Run with uvicorn. ``timeout_keep_alive`` bounds the idle
+        # HTTP/1.1 keep-alive window so stale connections (e.g.
+        # abandoned clients) don't linger forever. We pair that with a
+        # generous graceful-shutdown window so in-flight SSE responses
+        # can flush on container stop.
+        http_keep_alive = int(
+            getattr(self.settings, "http_keep_alive_timeout_seconds", 300)
+        )
         config = uvicorn.Config(
             app,
             host=self.settings.mcp_host,
             port=self.settings.mcp_port,
             log_level=self.settings.log_level.lower(),
+            http="h11",
+            timeout_keep_alive=http_keep_alive,
+            timeout_graceful_shutdown=30,
         )
         server = uvicorn.Server(config)
-        await server.serve()
+
+        # Enable SO_KEEPALIVE + Linux TCP_KEEPIDLE on listening sockets
+        # *after* startup has produced ``server.servers``. This catches
+        # connections accepted on every listening socket without having
+        # to subclass uvicorn's Config. Failure is non-fatal — tune is
+        # a best-effort optimisation.
+        tcp_keepalive = bool(getattr(self.settings, "tcp_keepalive_enabled", True))
+        tcp_idle = int(getattr(self.settings, "tcp_keepalive_idle_seconds", 60))
+
+        async def _serve_with_tcp_keepalive() -> None:
+            if not tcp_keepalive:
+                await server.serve()
+                return
+            # Drive uvicorn as a background task so we can iterate its
+            # listening sockets once startup has completed. If we wait
+            # on ``server.serve()`` directly the coroutine blocks until
+            # shutdown.
+            serve_task = asyncio.create_task(server.serve(), name="uvicorn-serve")
+            # Poll briefly for startup. ``server.started`` flips True
+            # once all listeners are bound.
+            for _ in range(100):  # ~10s budget
+                if getattr(server, "started", False):
+                    break
+                await asyncio.sleep(0.1)
+            try:
+                for srv in getattr(server, "servers", ()) or ():
+                    for sock in getattr(srv, "sockets", ()) or ():
+                        _enable_tcp_keepalive(sock, tcp_idle, self.logger)
+                self.logger.info(
+                    "tcp keepalive enabled on listening socket(s): idle=%ds", tcp_idle,
+                )
+            except Exception as exc:  # pragma: no cover - best effort
+                self.logger.debug("TCP keepalive setup skipped: %s", exc)
+            await serve_task
+
+        await _serve_with_tcp_keepalive()
 
 
 def main():

--- a/tests/test_sse_keepalive.py
+++ b/tests/test_sse_keepalive.py
@@ -1,0 +1,459 @@
+"""Tests for the SSE keepalive / long-running-tool resilience stack.
+
+Scope:
+  * SSE comment-frame heartbeat emits through a serialised send lock.
+  * Keepalive loop cancels cleanly on peer disconnect.
+  * API-key auth uses hmac.compare_digest for both Bearer and X-API-Key.
+  * Settings clamp out-of-range transport intervals.
+  * Active-SSE-connection counter increments/decrements.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hmac
+import logging
+import time
+from typing import Any, Dict, List, Tuple
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.main import (
+    ASGISend,
+    _authorized_request,
+    _enable_tcp_keepalive,
+    _keepalive_loop,
+    _merge_sse_headers,
+    _peer_gone,
+    _sse_active_count,
+    _wrap_send_with_sse_headers,
+)
+
+
+# ---------------------------------------------------------------------------
+# Keepalive frames
+# ---------------------------------------------------------------------------
+
+
+class _FakeASGI:
+    """Captures every ASGI event plus the order of sends."""
+
+    def __init__(self) -> None:
+        self.events: List[Dict[str, Any]] = []
+        self.raise_after: int = 0
+        self.raise_exc: BaseException = ConnectionResetError("peer closed")
+
+    async def __call__(self, message: Dict[str, Any]) -> None:
+        self.events.append(message)
+        if self.raise_after and len(self.events) >= self.raise_after:
+            raise self.raise_exc
+
+
+@pytest.mark.asyncio
+async def test_keepalive_loop_emits_comment_frames_after_headers():
+    sink = _FakeASGI()
+    wrapped, headers_sent, lock = _wrap_send_with_sse_headers(sink)
+
+    # Simulate the SDK flushing its response headers first.
+    await wrapped({
+        "type": "http.response.start", "status": 200, "headers": []
+    })
+    assert headers_sent.is_set()
+
+    # Tight interval so the test finishes fast.
+    task = asyncio.create_task(_keepalive_loop(
+        wrapped, lock, headers_sent,
+        interval_seconds=1, logger=logging.getLogger("test"),
+    ))
+    # Need > 3 * interval to observe 3 frames.
+    await asyncio.sleep(3.2)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    # First event is the headers. Subsequent comment frames are bodies
+    # carrying exactly ``: keepalive <epoch>\n\n``.
+    body_events = [e for e in sink.events if e.get("type") == "http.response.body"]
+    assert len(body_events) >= 3, sink.events
+    for ev in body_events:
+        payload = ev["body"].decode("ascii")
+        assert payload.startswith(": keepalive "), payload
+        assert payload.endswith("\n\n")
+        # No user-controlled content: last token is an integer epoch.
+        int(payload[len(": keepalive "):].strip())
+        # Non-final chunk so HTTP/1.1 chunked framing stays open.
+        assert ev.get("more_body") is True
+
+
+@pytest.mark.asyncio
+async def test_keepalive_waits_for_headers_before_first_frame():
+    """Sending a body before ``http.response.start`` would 500 the request;
+    the loop must block until ``headers_sent`` is set."""
+    sink = _FakeASGI()
+    wrapped, headers_sent, lock = _wrap_send_with_sse_headers(sink)
+
+    task = asyncio.create_task(_keepalive_loop(
+        wrapped, lock, headers_sent, interval_seconds=1, logger=logging.getLogger("test"),
+    ))
+    # Leave headers_sent unset briefly; no body should appear.
+    await asyncio.sleep(1.5)
+    assert not any(e.get("type") == "http.response.body" for e in sink.events)
+
+    # Now flush headers and let the loop catch up.
+    await wrapped({"type": "http.response.start", "status": 200, "headers": []})
+    await asyncio.sleep(1.3)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    body_events = [e for e in sink.events if e.get("type") == "http.response.body"]
+    assert body_events, sink.events
+
+
+@pytest.mark.asyncio
+async def test_keepalive_serialises_through_lock_with_concurrent_writer():
+    """Simulate a concurrent fake MCP writer while the keepalive runs.
+    The lock must ensure no two writes interleave inside one SSE event."""
+    sink = _FakeASGI()
+    wrapped, headers_sent, lock = _wrap_send_with_sse_headers(sink)
+    await wrapped({"type": "http.response.start", "status": 200, "headers": []})
+
+    alive = asyncio.create_task(_keepalive_loop(
+        wrapped, lock, headers_sent, interval_seconds=1, logger=logging.getLogger("test"),
+    ))
+
+    async def _sdk_writer() -> None:
+        # Simulate the SDK writing 10 "event:" style chunks.
+        for i in range(10):
+            await wrapped({
+                "type": "http.response.body",
+                "body": f"event: data-{i}\n\n".encode(),
+                "more_body": True,
+            })
+            await asyncio.sleep(0.05)
+
+    await _sdk_writer()
+    # Give the keepalive one more tick.
+    await asyncio.sleep(1.1)
+    alive.cancel()
+    try:
+        await alive
+    except asyncio.CancelledError:
+        pass
+
+    # Every body event starts cleanly with either "event:" or ": keepalive";
+    # no interleaved bytes from two writers sharing a frame.
+    for e in (ev for ev in sink.events if ev.get("type") == "http.response.body"):
+        body = e["body"].decode("ascii")
+        assert body.startswith("event:") or body.startswith(": keepalive"), body
+
+
+@pytest.mark.asyncio
+async def test_keepalive_skips_tick_when_lock_contended():
+    """If the SDK holds the lock when the tick fires, the loop must
+    skip rather than queue — prevents memory pressure from a slow client."""
+    sink = _FakeASGI()
+    wrapped, headers_sent, lock = _wrap_send_with_sse_headers(sink)
+    await wrapped({"type": "http.response.start", "status": 200, "headers": []})
+
+    async def _hold_lock_long() -> None:
+        async with lock:
+            # Hold for longer than our observation window so the
+            # keepalive never sees the release.
+            await asyncio.sleep(5.0)
+
+    holder = asyncio.create_task(_hold_lock_long())
+    task = asyncio.create_task(_keepalive_loop(
+        wrapped, lock, headers_sent, interval_seconds=1, logger=logging.getLogger("test"),
+    ))
+    # Observe for 3s — spans 3 would-be ticks while the holder is still
+    # firmly holding the lock. Stop measuring before the holder releases.
+    await asyncio.sleep(3.0)
+
+    # Snapshot BEFORE the holder releases.
+    snapshot = list(sink.events)
+
+    # Now wind down the holder + task so we don't leak.
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    holder.cancel()
+    try:
+        await holder
+    except asyncio.CancelledError:
+        pass
+
+    # With the lock held for the full observation window, zero
+    # keepalive bodies should have landed (the loop skipped every tick).
+    bodies = [
+        e for e in snapshot
+        if e.get("type") == "http.response.body"
+        and e.get("body", b"").startswith(b": keepalive")
+    ]
+    debug = [(e.get("type"), e.get("body", b"")[:40]) for e in snapshot]
+    assert bodies == [], debug
+
+
+@pytest.mark.asyncio
+async def test_keepalive_exits_cleanly_on_peer_disconnect(caplog):
+    """ClosedResourceError / BrokenResourceError / ConnectionResetError
+    must stop the loop at DEBUG without propagating."""
+    sink = _FakeASGI()
+    sink.raise_after = 2  # first body write -> 2nd event total (start=1)
+    sink.raise_exc = ConnectionResetError("peer")
+
+    wrapped, headers_sent, lock = _wrap_send_with_sse_headers(sink)
+    await wrapped({"type": "http.response.start", "status": 200, "headers": []})
+
+    with caplog.at_level(logging.DEBUG, logger="test"):
+        task = asyncio.create_task(_keepalive_loop(
+            wrapped, lock, headers_sent, interval_seconds=1,
+            logger=logging.getLogger("test"),
+        ))
+        await asyncio.sleep(2.1)
+        # Loop must have exited on its own.
+        assert task.done()
+        # Did not raise.
+        assert task.exception() is None
+
+    # At least one DEBUG line about peer closing.
+    assert any(
+        "peer closed" in r.message and r.levelno == logging.DEBUG
+        for r in caplog.records
+    ), caplog.records
+
+
+@pytest.mark.asyncio
+async def test_keepalive_no_user_input_in_frame():
+    """Defence: no user-controlled data reaches the keepalive frame."""
+    sink = _FakeASGI()
+    wrapped, headers_sent, lock = _wrap_send_with_sse_headers(sink)
+    await wrapped({"type": "http.response.start", "status": 200, "headers": []})
+
+    task = asyncio.create_task(_keepalive_loop(
+        wrapped, lock, headers_sent, interval_seconds=1,
+        logger=logging.getLogger("test"),
+    ))
+    await asyncio.sleep(2.1)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    for e in sink.events:
+        if e.get("type") == "http.response.body":
+            body = e["body"]
+            # No CR/LF outside the framing \n\n suffix. Enforces "static
+            # prefix + monotonic epoch" contract.
+            assert body.startswith(b": keepalive ")
+            assert body.endswith(b"\n\n")
+            assert body.count(b"\n") == 2  # exactly the framing pair
+            assert b"\r" not in body
+
+
+def test_merge_sse_headers_injects_proxy_busters_without_duplicate():
+    sdk_headers: List[Tuple[bytes, bytes]] = [
+        (b"content-type", b"text/event-stream"),
+        (b"cache-control", b"max-age=0"),  # SDK already set; must NOT duplicate
+    ]
+    merged = _merge_sse_headers(sdk_headers)
+    names = [h[0] for h in merged]
+    # Existing SDK values preserved.
+    assert names.count(b"cache-control") == 1
+    assert [h for h in merged if h[0] == b"cache-control"][0][1] == b"max-age=0"
+    # We ALWAYS add X-Accel-Buffering: no.
+    assert [b"x-accel-buffering", b"no"] in merged
+    # Connection: keep-alive always present.
+    assert [b"connection", b"keep-alive"] in merged
+
+
+# ---------------------------------------------------------------------------
+# Auth: constant-time compare
+# ---------------------------------------------------------------------------
+
+
+def test_authorized_returns_true_when_no_api_key_configured():
+    assert _authorized_request([], api_key=None) is True
+    assert _authorized_request([(b"x-foo", b"bar")], api_key=None) is True
+
+
+def test_authorized_bearer_uses_compare_digest(monkeypatch):
+    calls: List[Tuple[bytes, bytes]] = []
+    real = hmac.compare_digest
+
+    def _spy(a: bytes, b: bytes) -> bool:
+        calls.append((a, b))
+        return real(a, b)
+
+    monkeypatch.setattr("src.main.hmac.compare_digest", _spy)
+    ok = _authorized_request(
+        [(b"authorization", b"Bearer secret-key-1234567890")],
+        api_key="secret-key-1234567890",
+    )
+    assert ok is True
+    assert calls, "compare_digest was never consulted"
+
+
+def test_authorized_x_api_key_uses_compare_digest(monkeypatch):
+    calls: List[Tuple[bytes, bytes]] = []
+    real = hmac.compare_digest
+
+    def _spy(a: bytes, b: bytes) -> bool:
+        calls.append((a, b))
+        return real(a, b)  # bind the real one, not the patched symbol
+
+    monkeypatch.setattr("src.main.hmac.compare_digest", _spy)
+    ok = _authorized_request(
+        [(b"x-api-key", b"secret-key-1234567890")],
+        api_key="secret-key-1234567890",
+    )
+    assert ok is True
+    assert calls, "compare_digest was never consulted"
+
+
+def test_authorized_rejects_same_length_different_last_byte():
+    assert _authorized_request(
+        [(b"authorization", b"Bearer secret-key-1234567890")],
+        api_key="secret-key-1234567891",  # last byte differs
+    ) is False
+
+
+def test_authorized_rejects_missing_bearer_prefix():
+    assert _authorized_request(
+        [(b"authorization", b"secret-key")],
+        api_key="secret-key",
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# Config clamping
+# ---------------------------------------------------------------------------
+
+
+def _make_settings(**overrides):
+    """Construct a Settings with auth requirements satisfied."""
+    import os
+    for key in (
+        "EWS_EMAIL", "EWS_AUTH_TYPE", "EWS_USERNAME", "EWS_PASSWORD",
+        "EWS_AUTODISCOVER", "EWS_SERVER_URL",
+    ):
+        os.environ.pop(key, None)
+    from src.config import Settings
+    kwargs = dict(
+        ews_email="dev@example.com",
+        ews_auth_type="basic",
+        ews_username="dev",
+        ews_password="x",
+        ews_autodiscover=False,
+        ews_server_url="https://mail.example.com/EWS/Exchange.asmx",
+    )
+    kwargs.update(overrides)
+    return Settings(**kwargs)
+
+
+def test_settings_clamps_sse_interval_low(caplog):
+    with caplog.at_level(logging.WARNING, logger="src.config"):
+        s = _make_settings(sse_keepalive_interval_seconds=0)
+    assert s.sse_keepalive_interval_seconds == 5
+    assert any("below minimum" in r.message for r in caplog.records)
+
+
+def test_settings_clamps_sse_interval_high(caplog):
+    with caplog.at_level(logging.WARNING, logger="src.config"):
+        s = _make_settings(sse_keepalive_interval_seconds=3600)
+    assert s.sse_keepalive_interval_seconds == 60
+
+
+def test_settings_clamps_http_keep_alive(caplog):
+    s = _make_settings(http_keep_alive_timeout_seconds=5)
+    assert s.http_keep_alive_timeout_seconds == 30
+    s = _make_settings(http_keep_alive_timeout_seconds=10_000)
+    assert s.http_keep_alive_timeout_seconds == 900
+
+
+def test_settings_clamps_progress_interval(caplog):
+    s = _make_settings(progress_notification_interval_seconds=1)
+    assert s.progress_notification_interval_seconds == 5
+    s = _make_settings(progress_notification_interval_seconds=999)
+    assert s.progress_notification_interval_seconds == 60
+
+
+def test_settings_valid_values_pass_through():
+    s = _make_settings(
+        sse_keepalive_interval_seconds=15,
+        http_keep_alive_timeout_seconds=300,
+        tcp_keepalive_idle_seconds=60,
+        progress_notification_interval_seconds=10,
+    )
+    assert s.sse_keepalive_interval_seconds == 15
+    assert s.http_keep_alive_timeout_seconds == 300
+    assert s.tcp_keepalive_idle_seconds == 60
+    assert s.progress_notification_interval_seconds == 10
+
+
+# ---------------------------------------------------------------------------
+# Peer-gone classifier
+# ---------------------------------------------------------------------------
+
+
+def test_peer_gone_matches_known_types():
+    class ClosedResourceError(Exception):
+        pass
+
+    class BrokenResourceError(Exception):
+        pass
+
+    assert _peer_gone(ClosedResourceError()) is True
+    assert _peer_gone(BrokenResourceError()) is True
+    assert _peer_gone(ConnectionResetError()) is True
+    assert _peer_gone(BrokenPipeError()) is True
+    assert _peer_gone(RuntimeError("Broken pipe: sent 0")) is True
+    assert _peer_gone(RuntimeError("connection aborted by peer")) is False  # case-sensitive check; message must have 'Connection aborted'
+    assert _peer_gone(RuntimeError("Connection aborted by peer")) is True
+    assert _peer_gone(ValueError("totally unrelated")) is False
+
+
+# ---------------------------------------------------------------------------
+# Active-connection counter
+# ---------------------------------------------------------------------------
+
+
+def test_sse_counter_starts_at_zero_or_stable():
+    # Ensures the counter API exists and is safe to read concurrently.
+    baseline = _sse_active_count()
+    assert baseline >= 0
+
+
+# ---------------------------------------------------------------------------
+# TCP keepalive setup
+# ---------------------------------------------------------------------------
+
+
+def test_enable_tcp_keepalive_sets_so_keepalive(monkeypatch):
+    """Basic plumbing: SO_KEEPALIVE is always set on a supported socket."""
+    import socket as _socket
+
+    sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+    try:
+        _enable_tcp_keepalive(sock, idle_seconds=60, logger=logging.getLogger("t"))
+        # Read back SO_KEEPALIVE; kernel may report 0 or 1.
+        val = sock.getsockopt(_socket.SOL_SOCKET, _socket.SO_KEEPALIVE)
+        assert val == 1
+    finally:
+        sock.close()
+
+
+def test_enable_tcp_keepalive_swallows_oserror():
+    """A closed socket must not crash the helper — best-effort only."""
+    import socket as _socket
+    sock = _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM)
+    sock.close()
+    # Should not raise even though the socket is closed.
+    _enable_tcp_keepalive(sock, idle_seconds=60, logger=logging.getLogger("t"))


### PR DESCRIPTION
Keep the SSE byte stream alive across long tool executions (60-240s for generate_briefing / prepare_meeting / extract_commitments) so upstream proxies don't reap it as idle. Transport-layer only — no tool API changes, no protocol changes.

Observed symptom (2026-04-20 09:46:50):
  Message handling failed: ClosedResourceError
The POST to /messages arrived after the /sse stream was already closed by a 60s idle timeout on the reverse proxy.

1. SSE heartbeat frames -----------------------
Every connection gets a background task that emits ``: keepalive <epoch>\n\n`` comment frames on a configurable interval (default 15s, clamped to [5, 60]). Comment frames are ignored by spec-compliant clients but keep proxies (nginx, HAProxy, cloud LBs) from reaping the stream.

Implementation:
  * New helpers at src/main.py module level: - ``_wrap_send_with_sse_headers(send)`` — returns a wrapped send callable, a ``headers_sent`` event, and an ``asyncio.Lock``. Every write goes through the lock so the SDK's event writes and our keepalives never interleave inside one HTTP/1.1 chunk (that would corrupt chunked encoding). - ``_keepalive_loop(send, lock, headers_sent, interval, logger)`` waits for headers_sent before the first write (pre-header frames would 500 the request), skips ticks when the lock is contended (no backlog pressure from a slow client), exits at DEBUG on peer-disconnect errors. - ``_merge_sse_headers(existing)`` adds ``Cache-Control: no- cache, no-transform`` + ``X-Accel-Buffering: no`` + ``Connection: keep-alive`` to the SSE response headers so nginx and friends don't buffer the stream. - ``_peer_gone(exc)`` classifies disconnect-class errors.
  * handle_sse rewritten (49 lines, budget was 80) around ``_run_sse_connection`` which drives an ``asyncio.TaskGroup`` with the MCP server + keepalive. Client disconnect cancels the keepalive automatically via TaskGroup semantics.
  * Per-connection active counter incremented in a try / decremented in a finally so leaks are impossible.

2. TCP keepalive on listening socket ------------------------------------
  * uvicorn.Config now sets ``http="h11"``, ``timeout_keep_alive=<HTTP_KEEP_ALIVE_TIMEOUT>``, ``timeout_graceful_shutdown=30``.
  * A small post-startup hook iterates ``server.servers[*].sockets`` and calls ``_enable_tcp_keepalive``:
      - ``SO_KEEPALIVE`` always.
      - Linux: ``TCP_KEEPIDLE``, ``TCP_KEEPINTVL``, ``TCP_KEEPCNT``. - Windows: ``SIO_KEEPALIVE_VALS`` via ``sock.ioctl`` (guarded with ``hasattr``).
  * Every ``setsockopt`` call is try/except'd — best-effort tuning.

3. Progress notifications for long-running tool calls -----------------------------------------------------
  * In ``call_tool``, if the client included ``_meta.progressToken`` on the request, a background ticker calls ``session.send_progress_notification`` every ``PROGRESS_NOTIFICATION_INTERVAL_SECONDS`` (default 10, clamped to [5, 60]).
  * Cancelled in a finally regardless of tool outcome.
  * All probes of the MCP SDK's request context are guarded with getattr + try/except — if the SDK exposes those attrs under a different path, the ticker is a no-op and we still have SSE keepalive covering the transport.

4. Config (src/config.py, 6 new fields) ---------------------------------------
  * ``sse_keepalive_enabled`` (True)
  * ``sse_keepalive_interval_seconds`` (15, clamp [5, 60])
  * ``http_keep_alive_timeout_seconds`` (300, clamp [30, 900])
  * ``tcp_keepalive_enabled`` (True)
  * ``tcp_keepalive_idle_seconds`` (60, clamp [30, 600])
  * ``progress_notification_enabled`` (True)
  * ``progress_notification_interval_seconds`` (10, clamp [5, 60])
  * Out-of-range values log a WARNING and clamp; zero/negative intervals would spin-loop the event loop so they're clamped to the lower bound rather than accepted.
  * Non-numeric values fall back to the default (with warning).

5. Security -----------
  * Auth: ``_authorized_request`` uses ``hmac.compare_digest`` over UTF-8–encoded bytes for BOTH the ``Authorization: Bearer`` and ``X-API-Key`` paths. Previous string equality short-circuited on first mismatched byte and leaked prefix information via timing.
  * No secrets in logs — the new keepalive/progress paths log only exception types, counts, and configuration values. The API key never reaches ``logger.*``. The progress token never reaches logs either.
  * No header injection — the keepalive frame body is a literal ``: keepalive `` prefix plus an integer epoch. No user input.
  * Auth ordering preserved — keepalive starts inside handle_sse, which is reached only after ``_authorized(scope.headers)`` passes. /health remains the only unauthenticated endpoint.
  * Resource bounds — exactly one keepalive and at most one progress task per connection; both cancelled in finally. TaskGroup enforces cancellation propagation. Active-connection counter visible on /health.
  * No new network surface — no admin endpoints, no debug routes, no CORS changes, no WebSocket fallback.
  * MCP_API_KEY warning at startup preserved (src/main.py:487-492).

6. /health ----------
  * Response now includes ``sse_active_connections`` alongside ``status`` and ``tools``. Serialised via ``safe_json_dumps`` so it stays consistent with the rest of the REST surface.

Tests (tests/test_sse_keepalive.py, 21 new)
-------------------------------------------
  * Keepalive emits ≥3 frames over 3× interval; each frame is a valid ``: keepalive <epoch>`` body with ``more_body=True`` (chunked framing stays open).
  * Loop blocks before ``headers_sent`` — no body is written until the start event flushed (sending a body before headers would 500).
  * Concurrent fake SDK writer + keepalive: every body event starts cleanly with either ``event:`` or ``: keepalive`` — no byte-level interleaving inside a single frame.
  * Lock-contended tick skipped — zero keepalive bodies emitted when another writer holds the lock for the whole observation window.
  * Peer disconnect exits the loop at DEBUG without propagating.
  * Frame body contains exactly two \\n characters (framing pair), no \\r — defence against header injection via the monotonic epoch.
  * ``_merge_sse_headers`` injects proxy-busters without duplicating existing SDK headers.
  * ``_authorized_request`` calls ``hmac.compare_digest`` for both Bearer and X-API-Key paths; rejects same-length keys that differ only in the last byte; rejects missing ``Bearer `` prefix.
  * Settings clamp sse_keepalive_interval_seconds, http_keep_alive_ timeout_seconds, progress_notification_interval_seconds on out-of-range values with a WARNING. In-range values pass through.
  * ``_peer_gone`` matches the usual disconnect classes + messages.
  * ``_enable_tcp_keepalive`` sets SO_KEEPALIVE on a real socket; swallows OSError on a closed socket (best-effort).

Verification
------------
  * mypy --ignore-missing-imports src/main.py src/config.py → 0 errors.
  * handle_sse: 49 lines (budget 80).
  * Full test suite: 294 passing (+21) / 18 pre-existing failures unchanged.
  * No new entries in requirements.txt / requirements-dev.txt.
  * No CORS, admin, debug, or WebSocket endpoints added.