### PR TITLE
fix(email): qualify _MAX_MESSAGES_HARD_CAP with self in GetEmailsBulk…

### DIFF
--- a/src/tools/email_tools.py
+++ b/src/tools/email_tools.py
@@ -2008,11 +2008,11 @@ class GetEmailsBulkTool(BaseTool):
                     "max_messages": {
                         "type": "integer",
                         "minimum": 1,
-                        "maximum": _MAX_MESSAGES_HARD_CAP,
+                        "maximum": self._MAX_MESSAGES_HARD_CAP,
                         "default": 50,
                         "description": (
                             "Cap on input list size. Default 50, hard cap "
-                            f"{_MAX_MESSAGES_HARD_CAP}. Use paging for larger sets."
+                            f"{self._MAX_MESSAGES_HARD_CAP}. Use paging for larger sets."
                         ),
                     },
                     "target_mailbox": {

--- a/tests/test_get_emails_bulk.py
+++ b/tests/test_get_emails_bulk.py
@@ -36,6 +36,21 @@ def _fake_msg(i: int, *, subject: str | None = None):
 # ---------------------------------------------------------------------------
 
 
+def test_issue5_get_schema_builds_without_nameerror(mock_ews_client):
+    """Regression: the schema used ``_MAX_MESSAGES_HARD_CAP`` as a bare
+    name inside a method, which crashed ``register_tools`` at server
+    startup with NameError. Every tool's ``get_schema`` must return a
+    plain dict without raising — that's how the MCP server discovers
+    them on boot."""
+    from src.tools.email_tools import GetEmailsBulkTool
+
+    tool = GetEmailsBulkTool(mock_ews_client)
+    schema = tool.get_schema()
+    assert schema["name"] == "get_emails_bulk"
+    props = schema["inputSchema"]["properties"]
+    assert props["max_messages"]["maximum"] == 100
+
+
 @pytest.mark.asyncio
 async def test_issue5_batch_fetch_returns_all_requested(mock_ews_client):
     """10 ids -> 1 account.fetch() call -> 10 items back."""


### PR DESCRIPTION
…Tool schema

Server startup crashed with ``NameError: name '_MAX_MESSAGES_HARD_CAP' is not defined`` inside ``register_tools`` because the schema dict referenced the class attribute as a bare name — Python method scope does not pick up the enclosing class body.

* Qualify both references (``maximum`` and the f-string in ``description``) as ``self._MAX_MESSAGES_HARD_CAP``.
* New regression ``test_issue5_get_schema_builds_without_nameerror`` calls ``tool.get_schema()`` — the same path ``register_tools`` takes on boot — so this class of startup crash is caught by the test suite the next time it's introduced.