### PR TITLE
fix(docker): redirect startup banner to stderr for MCP stdio clients

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,8 +9,10 @@ mkdir -p /app/logs/analysis 2>/dev/null || true
 chown -R mcp:mcp /app/logs 2>/dev/null || true
 chmod -R 755 /app/logs 2>/dev/null || true
 
-# Single startup message for monitoring
-echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] EWS-MCP v3.4 starting"
+# Single startup message for monitoring.
+# Goes to stderr: MCP stdio transport reserves stdout for JSON-RPC, and any
+# pre-handshake byte on stdout breaks strict clients (e.g. Claude Desktop).
+echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] EWS-MCP v3.4 starting" >&2
 
 # Switch to non-root user and start application
 # All runtime logs go to /app/logs via Python logging


### PR DESCRIPTION
## Summary

One-character fix: add `>&2` to the startup banner in `docker-entrypoint.sh` so it no longer writes to stdout.

## Problem

The container entrypoint prints a single banner line on startup:

```bash
echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] EWS-MCP v3.4 starting"
```

Under the default `stdio` transport this byte stream goes into the client's JSON-RPC pipe **before** the handshake, which strict clients treat as a protocol violation. Claude Desktop in particular surfaces a red "MCP server failed to connect" badge even though the server then works correctly — the tools register, calls succeed, but the UI keeps nagging the user.

The Python side of the server already follows the stdio invariant. See `src/middleware/logging.py`:

```python
# Console handler: INFO level for monitoring
console_handler = logging.StreamHandler(sys.stderr)
# ...
# - Console (stderr): Minimal monitoring info only
# - MCP requires stdout clean for JSON-RPC protocol
```

The bash entrypoint is the only remaining leak.

## Fix

Redirect the banner to stderr and document why:

```diff
-# Single startup message for monitoring
-echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] EWS-MCP v3.4 starting"
+# Single startup message for monitoring.
+# Goes to stderr: MCP stdio transport reserves stdout for JSON-RPC, and any
+# pre-handshake byte on stdout breaks strict clients (e.g. Claude Desktop).
+echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] EWS-MCP v3.4 starting" >&2
```

The line is preserved (it's genuinely useful for `docker logs` / k8s / journalctl, which capture both streams) — only the stream changes.

## Verification

Built the image locally and confirmed stream separation:

```console
$ docker build -t ews-mcp:local .
$ docker run --rm --entrypoint /usr/local/bin/docker-entrypoint.sh \
    ews-mcp:local echo STDOUT_OK 2>/tmp/err 1>/tmp/out
$ cat /tmp/out
STDOUT_OK
$ cat /tmp/err
[2026-04-24T11:31:13Z] EWS-MCP v3.4 starting
```

Then swapped Claude Desktop's config to the patched image and restarted — red badge is gone, tools work normally.

## Scope

- No behaviour change for `sse` / HTTP transports (they don't read stdout/stderr for protocol data).
- No behaviour change for log aggregation — `docker logs` and friends merge both streams by default.
- No code changes outside `docker-entrypoint.sh`.