### PR TITLE
fix(delete_email): drop disposal_type kwarg — Item.delete() in exchan…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased — `delete_email(permanent=True)` no longer 500s
+
+**Bug**: every `delete_email` / `manage_email` call with `permanent=True` (or
+`hard_delete=True`) returned `500 ToolExecutionError: Failed to delete email:
+TypeError: Item.delete() got an unexpected keyword argument 'disposal_type'`
+on the live NAS. Soft-delete (move-to-trash) was unaffected.
+
+**Cause**: the source called `item.delete(disposal_type=HARD_DELETE)` with a
+fallback to `item.delete(disposal_type="HardDelete")`. Neither kwarg exists
+on `exchangelib.items.Item.delete()` in 5.x — its signature is
+`delete(send_meeting_cancellations, affected_task_occurrences, suppress_read_receipts)`
+and it already invokes `_delete(delete_type=HARD_DELETE)` internally. The
+unit tests passed because `MagicMock().delete(disposal_type=...)` silently
+records any kwarg, so the divergence between the mock and the real signature
+was never caught.
+
+**Fix**: call the bare `item.delete()` — already a HARD_DELETE in 5.x.
+Added a guard test that pins `inspect.signature(Item.delete).parameters` so
+we'd notice if the API ever grows that kwarg back. Surfaced during a live
+NAS smoke test of the reply/forward double-escape fix.
+
 ## Unreleased — Reply/forward thread no longer accumulates `&amp;` entities
 
 **Bug**: long email threads would show cascading ampersands between contact

--- a/src/tools/email_tools.py
+++ b/src/tools/email_tools.py
@@ -2238,25 +2238,18 @@ class DeleteEmailTool(BaseTool):
             item = find_message_for_account(account, message_id)
 
             if permanent:
-                # ``item.delete()`` in exchangelib defaults to a
-                # MoveToDeletedItems disposal — the item ends up in
-                # Trash, defeating "permanent". The correct API is
-                # ``item.delete(disposal_type=HARD_DELETE)``; the
-                # constant lives in ``exchangelib.items``, not at the
-                # top-level ``exchangelib`` package (the previous fix
-                # imported from the wrong place and also used the
-                # wrong keyword ``delete_type=`` — both produced 500s).
-                try:
-                    from exchangelib.items import HARD_DELETE
-                    item.delete(disposal_type=HARD_DELETE)
-                except ImportError:
-                    # Fall back to the wire string if the constant
-                    # ever moves again. ``disposal_type="HardDelete"``
-                    # is accepted by exchangelib in all recent versions.
-                    item.delete(disposal_type="HardDelete")
+                # In exchangelib 5.x, ``Item.delete()`` is already a
+                # HardDelete by default — its body calls ``self._delete(
+                # delete_type=HARD_DELETE, ...)`` internally and the public
+                # method takes no ``disposal_type``/``delete_type`` kwarg.
+                # Earlier versions of this code passed ``disposal_type=``,
+                # which raised ``TypeError`` against exchangelib 5.x and
+                # surfaced as a 500 from delete_email(permanent=True).
+                # See ``Item.delete`` in exchangelib/items/item.py.
+                item.delete()
                 action = "permanently deleted"
             else:
-                # Move to trash folder (Deleted Items) so user can recover.
+                # Move to trash (Deleted Items) so the user can recover.
                 item.move(account.trash)
                 action = "moved to trash"
 

--- a/tests/test_tool_reliability_round2.py
+++ b/tests/test_tool_reliability_round2.py
@@ -131,9 +131,11 @@ def test_con008_loose_validator_rejects_real_garbage():
 
 @pytest.mark.asyncio
 async def test_delete_email_hard_delete_uses_hard_delete_type(mock_ews_client):
-    """hard_delete=True must call item.delete with the HARD_DELETE
-    delete_type — not move() to trash and not a plain delete() that
-    defaults to MoveToDeletedItems."""
+    """hard_delete=True must call ``item.delete()`` with no kwargs —
+    exchangelib 5.x's ``Item.delete()`` is already HARD_DELETE by default
+    and rejects any ``disposal_type``/``delete_type`` kwarg with TypeError.
+    Must NOT call ``item.move()`` (that would put it in Trash, not
+    permanently delete it)."""
     from src.tools.email_tools import DeleteEmailTool
 
     item = MagicMock()
@@ -147,17 +149,8 @@ async def test_delete_email_hard_delete_uses_hard_delete_type(mock_ews_client):
 
     # move() must NOT be called — that would put the item in Trash.
     item.move.assert_not_called()
-    # delete() must be called with an explicit HARD_DELETE via the
-    # correct ``disposal_type`` kwarg (the exchangelib API; the
-    # previous round used the wrong kwarg ``delete_type``).
-    assert item.delete.called
-    call_kwargs = item.delete.call_args.kwargs
-    assert "disposal_type" in call_kwargs, (
-        f"expected disposal_type kwarg; got {call_kwargs!r}"
-    )
-    assert "delete_type" not in call_kwargs
-    disposal = call_kwargs["disposal_type"]
-    assert str(disposal).replace("_", "").lower().endswith("harddelete"), disposal
+    # delete() must be called with no kwargs (the bare 5.x API).
+    item.delete.assert_called_once_with()
     # Response reports permanent=True and hard_delete=True (both aliases).
     assert result["permanent"] is True
     assert result["hard_delete"] is True

--- a/tests/test_tool_reliability_round3.py
+++ b/tests/test_tool_reliability_round3.py
@@ -128,12 +128,12 @@ def test_aware_datetime_passes_through_unchanged():
 
 
 @pytest.mark.asyncio
-async def test_eds006_hard_delete_uses_disposal_type_kwarg(mock_ews_client):
-    """The exchangelib API is ``item.delete(disposal_type=...)`` (not
-    ``delete_type=``) and the HARD_DELETE constant lives in
-    ``exchangelib.items`` (not the top-level ``exchangelib`` package).
-    Previous fix used the wrong keyword AND the wrong import path — both
-    produced 500s."""
+async def test_eds006_hard_delete_calls_bare_delete(mock_ews_client):
+    """``Item.delete()`` in exchangelib 5.x already does HARD_DELETE
+    internally and accepts no kwargs. Passing ``disposal_type=`` or
+    ``delete_type=`` raises TypeError — the live NAS surfaced this as a
+    500 on every delete_email(permanent=True). The fix is to call the
+    bare method."""
     from src.tools.email_tools import DeleteEmailTool
 
     item = MagicMock()
@@ -143,30 +143,24 @@ async def test_eds006_hard_delete_uses_disposal_type_kwarg(mock_ews_client):
         tool = DeleteEmailTool(mock_ews_client)
         await tool.execute(message_id="AAMk-1", hard_delete=True)
 
-    # item.delete() called with disposal_type=..., NOT delete_type=...
-    assert item.delete.called
-    call_kwargs = item.delete.call_args.kwargs
-    assert "disposal_type" in call_kwargs, (
-        f"expected disposal_type kwarg; got {call_kwargs!r}"
-    )
-    assert "delete_type" not in call_kwargs
-    # Value is either the exchangelib.items.HARD_DELETE constant or the
-    # literal "HardDelete" fallback — both are valid.
-    value = call_kwargs["disposal_type"]
-    assert str(value).replace("_", "").lower().endswith("harddelete")
+    # Bare call — no disposal_type / delete_type, no positional args.
+    item.delete.assert_called_once_with()
 
 
-def test_eds006_hard_delete_constant_import_path():
-    """``HARD_DELETE`` lives in ``exchangelib.items``, not the package root."""
-    # Must import without error from the documented location.
-    from exchangelib.items import HARD_DELETE
-    assert HARD_DELETE is not None
-    # The top-level package no longer re-exports it.
-    import exchangelib
-    assert not hasattr(exchangelib, "HARD_DELETE"), (
-        "If exchangelib starts re-exporting HARD_DELETE, that's fine; the "
-        "important thing is that src/tools/email_tools.py works with BOTH."
+def test_eds006_real_exchangelib_delete_signature_has_no_disposal_type():
+    """Regression guard against the original sandbox-vs-prod divergence:
+    ``MagicMock().delete(disposal_type=X)`` silently records the kwarg, so
+    a unit test using a plain mock would have green-lit the bug. Pin the
+    real exchangelib signature so we'd notice if it ever grows back."""
+    import inspect
+    from exchangelib.items import Item
+    sig = inspect.signature(Item.delete)
+    params = set(sig.parameters)
+    assert "disposal_type" not in params, (
+        "exchangelib.Item.delete() now accepts disposal_type — adjust the "
+        "production code in src/tools/email_tools.py and revisit this guard."
     )
+    assert "delete_type" not in params
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
…gelib 5.x is already HardDelete

Every delete_email(permanent=True) call against the live NAS returned 500: "TypeError: Item.delete() got an unexpected keyword argument 'disposal_type'".

The source called item.delete(disposal_type=HARD_DELETE) with a fallback to item.delete(disposal_type="HardDelete"). Neither kwarg exists on exchangelib.items.Item.delete() in 5.x — the public method takes only send_meeting_cancellations / affected_task_occurrences / suppress_read_receipts and already calls _delete(delete_type=HARD_DELETE) internally.

Unit tests passed because MagicMock().delete(disposal_type=...) silently records any kwarg. Replaced with item.delete.assert_called_once_with() (no kwargs) and added a guard that pins inspect.signature(Item.delete) so the real-vs-mock divergence can't slip past again.

Surfaced during a live NAS smoke test of the reply/forward double-escape fix (#107) — that one passed cleanly; this is a separate, older breakage.