### PR TITLE
fix(ai): make semantic_search reachable from Docker bridge + smarter …

### DIFF
--- a/.env.ai.example
+++ b/.env.ai.example
@@ -39,9 +39,25 @@ AI_EMBEDDING_MODEL=text-embedding-3-small
 
 # OR Local Model Configuration (e.g., Ollama, LM Studio)
 # AI_PROVIDER=local
-# AI_BASE_URL=http://localhost:11434/v1
 # AI_MODEL=llama3
 # AI_EMBEDDING_MODEL=nomic-embed-text
+#
+# Pick AI_BASE_URL based on how the server is running:
+#   • Bare-metal / `python run_server.py` on the same machine as Ollama:
+#       AI_BASE_URL=http://localhost:11434/v1
+#   • Docker bridge network (default for docker-compose-ghcr.yml):
+#       AI_BASE_URL=http://host.docker.internal:11434/v1
+#     (the compose file maps host.docker.internal to the host gateway)
+#   • Docker host networking (docker-compose.yml dev mode, network_mode: host):
+#       AI_BASE_URL=http://localhost:11434/v1
+#   • Different machine on the LAN:
+#       AI_BASE_URL=http://10.0.0.10:11434/v1
+#
+# DO NOT use the host's LAN IP (e.g. 10.0.0.10) when running inside a
+# bridge network — the bridge cannot route to the host's external interface
+# and the embedding call will fail with "ConnectError: All connection
+# attempts failed".
+# AI_BASE_URL=http://host.docker.internal:11434/v1
 
 # AI Generation Settings
 AI_MAX_TOKENS=4096

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## Unreleased — AI / semantic_search reachable from Docker bridge networks
+
+**Bug**: every `semantic_search_emails` call against the production NAS
+returned `ToolExecutionError: Embedding provider error: Embedding endpoint
+unreachable at http://&lt;HOST_LAN_IP&gt;:11434/v1/embeddings: ConnectError: All
+connection attempts failed`. The hint pointed at `AI_EMBEDDING_MODEL`, which
+sent the operator on a wrong-trail debug — Ollama was healthy and the model
+was correct.
+
+**Cause**: two issues stacked.
+1. *Networking*: the production container runs on a Docker bridge network
+   (`mcp-network`). From inside the bridge, the host's LAN IP
+   (`&lt;HOST_LAN_IP&gt;`) is NOT routable — bridge containers can only reach the
+   host via the bridge gateway. `AI_BASE_URL=http://&lt;HOST_LAN_IP&gt;:11434/v1`
+   silently failed at TCP-connect time.
+2. *Diagnostic*: `_embedding_error_hint` always returned the same model-name
+   hint regardless of whether the underlying error was an HTTP 404 (wrong
+   model) or a `ConnectError` (unreachable host).
+
+**Fix**:
+- Added `extra_hosts: "host.docker.internal:host-gateway"` to
+  `docker-compose-ghcr.yml` so the host gateway is reachable from inside
+  the bridge as `host.docker.internal`.
+- Updated `.env.ai.example` with concrete `AI_BASE_URL` choices per
+  deployment topology (bare-metal vs. bridge vs. host networking vs. LAN).
+  Strong warning against using the host's LAN IP from inside a bridge.
+- Refactored the hint dispatcher into `_embedding_error_hint(exc_msg)` —
+  branches on the underlying error and returns a *networking* hint
+  (host.docker.internal + extra_hosts) when the error is connect-style,
+  otherwise the *model-name* hint. New regression test
+  `tests/test_ai_embedding_hint.py` pins the dispatch.
+
+**Operator action**: re-pull and recreate the container with the new
+compose file, then set `AI_BASE_URL=http://host.docker.internal:11434/v1`.
+
 ## Unreleased — `delete_email(permanent=True)` no longer 500s
 
 **Bug**: every `delete_email` / `manage_email` call with `permanent=True` (or

--- a/docker-compose-ghcr.yml
+++ b/docker-compose-ghcr.yml
@@ -30,6 +30,15 @@ services:
     # Networking
     networks:
       - mcp-network
+    # Make the host's gateway reachable as `host.docker.internal` from inside
+    # the bridge so AI_BASE_URL can point at services on the host (Ollama at
+    # :11434, LM Studio at :1234, etc.) without hard-coding the LAN IP. On
+    # bridge networks the host's LAN IP (e.g. 10.0.0.10) is NOT routable
+    # from inside the container — the embedding endpoint times out with
+    # "ConnectError: All connection attempts failed". Use
+    # AI_BASE_URL=http://host.docker.internal:11434/v1 for Ollama.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       # Optional: Expose port for SSE transport (if MCP_TRANSPORT=sse)
       # - "8000:8000"

--- a/src/tools/ai_tools.py
+++ b/src/tools/ai_tools.py
@@ -28,6 +28,41 @@ def _id_from_doc(doc: Dict[str, Any]) -> str:
     return str(raw or "")
 
 
+def _embedding_error_hint(exc_msg: str) -> str:
+    """Return an actionable hint for an EmbeddingError message.
+
+    Two distinct failure modes deserve distinct hints — a connection failure
+    ("unreachable" / "All connection attempts failed" / connect refused /
+    timeout) almost always means the AI_BASE_URL host isn't routable from
+    inside the container (typical bridge-network-to-host-LAN-IP trap). A
+    404/400/model-not-found means the model name is wrong. Conflating both
+    under the same generic "check your model" hint sent operators on long
+    debug detours (see fix/ai-docker-networking).
+    """
+    msg = (exc_msg or "").lower()
+    is_unreachable = (
+        "unreachable" in msg
+        or "all connection attempts failed" in msg
+        or ("connect" in msg and ("refused" in msg or "timeout" in msg or "timed out" in msg))
+    )
+    if is_unreachable:
+        return (
+            "AI_BASE_URL host is not reachable from this process. "
+            "If running in a Docker bridge network, the host's LAN IP is "
+            "NOT routable from inside the container — use "
+            "AI_BASE_URL=http://host.docker.internal:11434/v1 "
+            "(and ensure the container has "
+            "extra_hosts: 'host.docker.internal:host-gateway'). "
+            "If running with network_mode: host or bare-metal, use "
+            "http://localhost:11434/v1."
+        )
+    return (
+        "Verify AI_EMBEDDING_MODEL matches an installed model at "
+        "AI_BASE_URL (e.g. 'text-embedding-3-small' for OpenAI, "
+        "'nomic-embed-text' for Ollama)."
+    )
+
+
 class SemanticSearchEmailsTool(BaseTool):
     """Tool for semantic search across emails."""
 
@@ -206,13 +241,9 @@ class SemanticSearchEmailsTool(BaseTool):
                     threshold=threshold,
                 )
             except EmbeddingError as exc:
-                hint = (
-                    "Verify AI_EMBEDDING_MODEL matches an installed model at "
-                    "AI_BASE_URL (e.g. 'text-embedding-3-small' for OpenAI, "
-                    "'nomic-embed-text' for Ollama)."
-                )
                 raise ToolExecutionError(
-                    f"Embedding provider error: {exc} | Hint: {hint}"
+                    f"Embedding provider error: {exc} | "
+                    f"Hint: {_embedding_error_hint(str(exc))}"
                 ) from exc
 
             # Bug 7: dedupe by message_id. Keep the highest-scoring hit

--- a/tests/test_ai_embedding_hint.py
+++ b/tests/test_ai_embedding_hint.py
@@ -1,0 +1,76 @@
+"""Regression tests for the embedding-error hint dispatcher.
+
+The live NAS surfaced a ConnectError when AI_BASE_URL was set to the host's
+LAN IP from inside a Docker bridge network. The original hint pointed
+exclusively at AI_EMBEDDING_MODEL, which sent the user on a wrong-trail
+debug. The dispatcher now branches on the underlying error message and
+returns either a networking hint or a model-name hint — these tests pin
+that branching so future refactors can't silently merge the two.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.tools.ai_tools import _embedding_error_hint
+
+
+# --- Networking-style failures should produce the docker hint ----------
+
+@pytest.mark.parametrize(
+    "msg",
+    [
+        # The exact shape of the error we saw against a real bridge-network
+        # deployment (IP redacted to a documentation range):
+        "Embedding endpoint unreachable at http://10.0.0.10:11434/v1/embeddings: "
+        "ConnectError: All connection attempts failed",
+        # httpx variants — these are *connection* failures, not slow upstream:
+        "ConnectError: connection refused",
+        "ConnectTimeout: timed out",
+        # Bare TCP refusals:
+        "[Errno 111] Connection refused",
+    ],
+)
+def test_unreachable_hint_points_at_docker_networking(msg):
+    hint = _embedding_error_hint(msg)
+    assert "host.docker.internal" in hint, hint
+    assert "extra_hosts" in hint, hint
+    assert "AI_BASE_URL" in hint, hint
+
+
+def test_read_timeout_is_not_classified_as_unreachable():
+    """ReadTimeout means the TCP connection succeeded but the upstream was
+    slow to respond — that's a model/load issue, not a docker-networking
+    issue. Keep it on the model-name hint path so we don't mislead operators
+    whose routing is fine but whose Ollama is just under-provisioned."""
+    hint = _embedding_error_hint("ReadTimeout: timeout")
+    assert "host.docker.internal" not in hint
+    assert "AI_EMBEDDING_MODEL" in hint
+
+
+# --- Model-name / API-shape failures should keep the original hint -----
+
+@pytest.mark.parametrize(
+    "msg",
+    [
+        "OpenAI API error 404: model not found",
+        "Embedding API error 400: invalid model 'ollama'",
+        "model 'foo' is not installed",
+    ],
+)
+def test_model_hint_points_at_embedding_model(msg):
+    hint = _embedding_error_hint(msg)
+    assert "AI_EMBEDDING_MODEL" in hint, hint
+    assert "text-embedding-3-small" in hint, hint
+    assert "nomic-embed-text" in hint, hint
+    # And it must NOT recommend swapping the URL — that wastes a debug
+    # cycle on a fully-routable endpoint that just doesn't have the model.
+    assert "host.docker.internal" not in hint
+
+
+# --- Empty/None safety -------------------------------------------------
+
+def test_empty_message_falls_back_to_model_hint():
+    """An EmbeddingError with no message shouldn't crash the dispatcher;
+    the safest default is the model-name hint."""
+    assert "AI_EMBEDDING_MODEL" in _embedding_error_hint("")
+    assert "AI_EMBEDDING_MODEL" in _embedding_error_hint(None)  # type: ignore[arg-type]


### PR DESCRIPTION
…hint

semantic_search_emails returned ConnectError when AI_BASE_URL pointed at the host's LAN IP — that IP is NOT routable from inside a Docker bridge network. The accompanying hint blamed AI_EMBEDDING_MODEL, sending operators on a wrong-trail debug when Ollama was healthy and the model was correct.

Three changes, no behaviour change for working deployments:

- docker-compose-ghcr.yml: add extra_hosts host.docker.internal mapping so the host gateway is reachable from inside the bridge.
- .env.ai.example: replace one-line localhost example with a per-topology guide (bare-metal vs. bridge vs. network_mode:host vs. LAN). Strong warning against using LAN IP from inside a bridge.
- src/tools/ai_tools.py: extract hint dispatch into _embedding_error_hint(exc_msg) and branch on connect-style errors vs. model/API errors. Networking failures now point at host.docker.internal
  + extra_hosts; model-name failures keep the original hint.

Regression coverage: tests/test_ai_embedding_hint.py — 9 cases pinning the dispatch (ConnectError-style strings go to the docker hint; 404/model-not-found go to the model hint; ReadTimeout stays on the model hint since TCP reached upstream).

Operator action after merge: re-pull, recreate container with the new compose, set AI_BASE_URL=http://host.docker.internal:11434/v1.