### PR TITLE
fix(ai)!: prefer shared external network over host.docker.internal

### DIFF
--- a/.env.ai.example
+++ b/.env.ai.example
@@ -43,21 +43,34 @@ AI_EMBEDDING_MODEL=text-embedding-3-small
 # AI_EMBEDDING_MODEL=nomic-embed-text
 #
 # Pick AI_BASE_URL based on how the server is running:
-#   • Bare-metal / `python run_server.py` on the same machine as Ollama:
-#       AI_BASE_URL=http://localhost:11434/v1
-#   • Docker bridge network (default for docker-compose-ghcr.yml):
-#       AI_BASE_URL=http://host.docker.internal:11434/v1
-#     (the compose file maps host.docker.internal to the host gateway)
-#   • Docker host networking (docker-compose.yml dev mode, network_mode: host):
-#       AI_BASE_URL=http://localhost:11434/v1
-#   • Different machine on the LAN:
-#       AI_BASE_URL=http://10.0.0.10:11434/v1
 #
-# DO NOT use the host's LAN IP (e.g. 10.0.0.10) when running inside a
-# bridge network — the bridge cannot route to the host's external interface
-# and the embedding call will fail with "ConnectError: All connection
-# attempts failed".
-# AI_BASE_URL=http://host.docker.internal:11434/v1
+#   1. Docker, separate compose stacks sharing an external network
+#      (recommended — what docker-compose-ghcr.yml is wired for):
+#        Prerequisite (one-time):  docker network create claude-shared
+#        Both ews-mcp and Ollama attach to `claude-shared` and Docker DNS
+#        resolves the Ollama container name. Set:
+#          AI_BASE_URL=http://ollama:11434/v1
+#        (where `ollama` is the Ollama container_name or network alias)
+#
+#   2. Docker bridge fallback (no shared network — uses the host gateway):
+#      Add `extra_hosts: ["host.docker.internal:host-gateway"]` to the
+#      ews-mcp service and have the Ollama container publish 11434 on
+#      the host. Then:
+#          AI_BASE_URL=http://host.docker.internal:11434/v1
+#
+#   3. Docker host networking (docker-compose.yml dev mode, network_mode: host):
+#          AI_BASE_URL=http://localhost:11434/v1
+#
+#   4. Bare-metal / `python run_server.py` on the same machine as Ollama:
+#          AI_BASE_URL=http://localhost:11434/v1
+#
+#   5. Different machine on the LAN (only when ews-mcp is NOT in a
+#      bridge network — bridges cannot route to the host's external IP):
+#          AI_BASE_URL=http://10.0.0.10:11434/v1
+#
+# DO NOT use the host's LAN IP from inside a Docker bridge — the embedding
+# call will fail with "ConnectError: All connection attempts failed".
+# AI_BASE_URL=http://ollama:11434/v1
 
 # AI Generation Settings
 AI_MAX_TOKENS=4096

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,20 +20,28 @@ was correct.
    model) or a `ConnectError` (unreachable host).
 
 **Fix**:
-- Added `extra_hosts: "host.docker.internal:host-gateway"` to
-  `docker-compose-ghcr.yml` so the host gateway is reachable from inside
-  the bridge as `host.docker.internal`.
-- Updated `.env.ai.example` with concrete `AI_BASE_URL` choices per
-  deployment topology (bare-metal vs. bridge vs. host networking vs. LAN).
-  Strong warning against using the host's LAN IP from inside a bridge.
+- `docker-compose-ghcr.yml` now attaches ews-mcp to a shared external
+  bridge `claude-shared` alongside its private `mcp-network`. Sibling
+  containers (Ollama, Postgres/pgvector, future shared services)
+  attached to the same network resolve each other by container name
+  via Docker DNS — no host-port hop, no hard-coded LAN IPs, and each
+  app keeps its own compose file. A `host.docker.internal` fallback is
+  documented for single-stack deployments that don't want a shared net.
+- Updated `.env.ai.example` with five concrete `AI_BASE_URL` choices
+  ranked by topology (shared external net → bridge fallback →
+  host-network → bare-metal → LAN). Strong warning against using the
+  host's LAN IP from inside a bridge.
 - Refactored the hint dispatcher into `_embedding_error_hint(exc_msg)` —
-  branches on the underlying error and returns a *networking* hint
-  (host.docker.internal + extra_hosts) when the error is connect-style,
-  otherwise the *model-name* hint. New regression test
+  branches on the underlying error and returns a *networking* hint that
+  surfaces both the recommended `claude-shared` path and the
+  `host.docker.internal` fallback when the error is connect-style.
+  Otherwise returns the *model-name* hint. New regression test
   `tests/test_ai_embedding_hint.py` pins the dispatch.
 
-**Operator action**: re-pull and recreate the container with the new
-compose file, then set `AI_BASE_URL=http://host.docker.internal:11434/v1`.
+**Operator action**: one-time `docker network create claude-shared` on
+the host, then attach the Ollama compose to the same external network
+(name the container `ollama` or set a network alias), re-pull ews-mcp
+with the new compose, and set `AI_BASE_URL=http://ollama:11434/v1`.
 
 ## Unreleased — `delete_email(permanent=True)` no longer 500s
 

--- a/docker-compose-ghcr.yml
+++ b/docker-compose-ghcr.yml
@@ -28,17 +28,28 @@ services:
     tty: true
 
     # Networking
+    #
+    # ews-mcp keeps its own private bridge (`mcp-network`) for any
+    # future side-car services it wants to ship with, AND attaches to an
+    # external `claude-shared` bridge so it can reach sibling services
+    # (Ollama, Postgres/pgvector, future shared infra) by container name
+    # over Docker DNS — no host-port hop, no hard-coded LAN IPs.
+    #
+    # Prerequisite (one-time, on the host):
+    #     docker network create claude-shared
+    #
+    # Then in your .env:
+    #     AI_BASE_URL=http://ollama:11434/v1
+    # (where `ollama` is the container_name / network alias of the
+    # Ollama service, also attached to `claude-shared`).
+    #
+    # Fallback if you don't want a shared network: replace the
+    # claude-shared block below with `extra_hosts:
+    # ["host.docker.internal:host-gateway"]` and use
+    # AI_BASE_URL=http://host.docker.internal:11434/v1.
     networks:
       - mcp-network
-    # Make the host's gateway reachable as `host.docker.internal` from inside
-    # the bridge so AI_BASE_URL can point at services on the host (Ollama at
-    # :11434, LM Studio at :1234, etc.) without hard-coding the LAN IP. On
-    # bridge networks the host's LAN IP (e.g. 10.0.0.10) is NOT routable
-    # from inside the container — the embedding endpoint times out with
-    # "ConnectError: All connection attempts failed". Use
-    # AI_BASE_URL=http://host.docker.internal:11434/v1 for Ollama.
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - claude-shared
     ports:
       # Optional: Expose port for SSE transport (if MCP_TRANSPORT=sse)
       # - "8000:8000"
@@ -92,3 +103,11 @@ networks:
     labels:
       - "app=ews-mcp"
       - "environment=production"
+  # Cross-app service plane. Other compose stacks (Ollama, Postgres, …)
+  # attach to this same network so containers can resolve each other by
+  # name. Marked external so this compose file does NOT own it — create
+  # once with `docker network create claude-shared`. If the network is
+  # missing, `docker compose up` fails fast with a clear message instead
+  # of silently falling back to no service discovery.
+  claude-shared:
+    external: true

--- a/src/tools/ai_tools.py
+++ b/src/tools/ai_tools.py
@@ -48,11 +48,16 @@ def _embedding_error_hint(exc_msg: str) -> str:
     if is_unreachable:
         return (
             "AI_BASE_URL host is not reachable from this process. "
-            "If running in a Docker bridge network, the host's LAN IP is "
-            "NOT routable from inside the container — use "
-            "AI_BASE_URL=http://host.docker.internal:11434/v1 "
-            "(and ensure the container has "
-            "extra_hosts: 'host.docker.internal:host-gateway'). "
+            "If running in Docker, the host's LAN IP is NOT routable from "
+            "inside a bridge network. Two options: "
+            "(1) RECOMMENDED — attach both ews-mcp and the Ollama "
+            "container to a shared external network "
+            "(`docker network create claude-shared`, then declare it as "
+            "external in both compose files), and set "
+            "AI_BASE_URL=http://ollama:11434/v1 (Docker DNS); "
+            "(2) FALLBACK — add `extra_hosts: "
+            "'host.docker.internal:host-gateway'` to the ews-mcp service "
+            "and set AI_BASE_URL=http://host.docker.internal:11434/v1. "
             "If running with network_mode: host or bare-metal, use "
             "http://localhost:11434/v1."
         )

--- a/tests/test_ai_embedding_hint.py
+++ b/tests/test_ai_embedding_hint.py
@@ -32,8 +32,14 @@ from src.tools.ai_tools import _embedding_error_hint
 )
 def test_unreachable_hint_points_at_docker_networking(msg):
     hint = _embedding_error_hint(msg)
+    # Both options must surface so the operator can pick whichever fits
+    # their topology. The recommended path is the shared external network
+    # (Docker DNS) — that's what docker-compose-ghcr.yml is wired for.
+    assert "claude-shared" in hint, hint
+    assert "http://ollama:11434" in hint, hint
+    # The fallback must still be discoverable for operators who can't
+    # create a shared network (managed Docker, single-stack deployments).
     assert "host.docker.internal" in hint, hint
-    assert "extra_hosts" in hint, hint
     assert "AI_BASE_URL" in hint, hint
 
 
@@ -44,6 +50,7 @@ def test_read_timeout_is_not_classified_as_unreachable():
     whose routing is fine but whose Ollama is just under-provisioned."""
     hint = _embedding_error_hint("ReadTimeout: timeout")
     assert "host.docker.internal" not in hint
+    assert "claude-shared" not in hint
     assert "AI_EMBEDDING_MODEL" in hint
 
 


### PR DESCRIPTION
Switch the recommended Docker topology from per-container extra_hosts:host.docker.internal to a shared external bridge `claude-shared`. Each app keeps its own compose file (ews-mcp owns this one, Ollama owns its own); both attach to the same external network and resolve each other by container name via Docker DNS.

Why this is better for a multi-app NAS than the previous fix:
- Ollama doesn't need to publish 11434 on the host (better isolation)
- No host-network bounce
- Scales: Postgres/pgvector and future shared services slot in cleanly
- Each compose stack stays decoupled — only contract is the network name

Changes:
- docker-compose-ghcr.yml: attach ews-mcp to mcp-network (private) AND claude-shared (external). Drop extra_hosts. Comment block documents the one-time `docker network create claude-shared` prerequisite and the host.docker.internal fallback for single-stack deployments.
- .env.ai.example: five-option topology guide, ranked. Recommended AI_BASE_URL=http://ollama:11434/v1; fallbacks documented.
- src/tools/ai_tools.py: _embedding_error_hint now surfaces the shared-network path FIRST when the error is connect-style, with host.docker.internal as the documented fallback.
- tests/test_ai_embedding_hint.py: assertions updated; both claude-shared and host.docker.internal must appear in the docker hint, neither in the model-name hint.

Operator action: one-time `docker network create claude-shared`, attach the Ollama compose to the same external network (container name `ollama` or a network alias), re-pull ews-mcp with the new compose, set AI_BASE_URL=http://ollama:11434/v1.