### PR TITLE
fix(attachments,ews_client): real CreateAttachment + FaultTolerance retry

### DIFF
--- a/src/ews_client.py
+++ b/src/ews_client.py
@@ -1,6 +1,6 @@
 """Exchange Web Services client wrapper."""
 
-from exchangelib import Account, Configuration, DELEGATE, IMPERSONATION, Version, EWSTimeZone
+from exchangelib import Account, Configuration, DELEGATE, IMPERSONATION, FaultTolerance, Version, EWSTimeZone
 from exchangelib.protocol import BaseProtocol, NoVerifyHTTPAdapter
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type, retry_if_not_exception_type
 import logging
@@ -115,11 +115,16 @@ class EWSClient:
 
                 self.logger.info(f"Using EWS endpoint: {ews_url}")
 
-                # Always use service_endpoint to bypass autodiscovery completely
+                # Always use service_endpoint to bypass autodiscovery completely.
+                # FaultTolerance covers transient EWS soap-shape failures we
+                # observed against SDB Exchange under sustained traffic
+                # (occasional "No Body element in SOAP response" — load balancer
+                # returning HTML instead of SOAP). Outer tenacity retry on
+                # _create_account handles auth-time / connect-time errors.
                 config = Configuration(
                     service_endpoint=ews_url,
                     credentials=credentials,
-                    retry_policy=None,  # Disable built-in retry, we handle it
+                    retry_policy=FaultTolerance(max_wait=30),
                     max_connections=self.config.connection_pool_size
                 )
 
@@ -234,7 +239,7 @@ class EWSClient:
                 config = Configuration(
                     service_endpoint=self._get_ews_url(),
                     credentials=credentials,
-                    retry_policy=None,
+                    retry_policy=FaultTolerance(max_wait=30),
                     max_connections=self.config.connection_pool_size
                 )
 

--- a/src/tools/attachment_tools.py
+++ b/src/tools/attachment_tools.py
@@ -531,12 +531,14 @@ class AddAttachmentTool(BaseTool):
                 attachment_kwargs["content_id"] = content_id
             attachment = FileAttachment(**attachment_kwargs)
 
-            # Add attachment to message
-            if not hasattr(message, 'attachments'):
-                message.attachments = []
+            # Persist via CreateAttachment. `Item.attach(...)` issues the
+            # EWS call and mutates `attachment.attachment_id` in place — the
+            # earlier `attachments.append(...) + message.save()` pattern
+            # only mutated the local list and never reached the server, so
+            # subsequent list_attachments calls returned an empty list.
+            message.attach(attachment)
 
-            message.attachments.append(attachment)
-            message.save()
+            attachment_id = extract_attachment_id(attachment)
 
             self.logger.info(f"Added attachment '{file_name}' to message {message_id}")
 
@@ -546,6 +548,7 @@ class AddAttachmentTool(BaseTool):
             return format_success_response(
                 f"Attachment '{file_name}' added successfully",
                 message_id=message_id,
+                attachment_id=attachment_id,
                 attachment_name=file_name,
                 attachment_size=len(file_content),
                 content_type=content_type,
@@ -654,9 +657,10 @@ class DeleteAttachmentTool(BaseTool):
             if not attachment_to_delete:
                 raise ToolExecutionError(f"Attachment not found")
 
-            # Remove the attachment
-            message.attachments.remove(attachment_to_delete)
-            message.save()
+            # Persist via DeleteAttachment. Same reason as add_attachment:
+            # mutating the local list and saving the parent item does not
+            # send DeleteAttachment to EWS.
+            message.detach(attachment_to_delete)
 
             self.logger.info(f"Deleted attachment '{deleted_name}' from message {message_id}")
 

--- a/tests/integration/test_full_workflow.py
+++ b/tests/integration/test_full_workflow.py
@@ -1,31 +1,98 @@
-"""Integration tests for full workflows."""
+"""End-to-end workflow SIT.
+
+The three workflow tests below verify that the high-level paths work
+against a real Exchange mailbox. They are env-gated by ``EWS_LIVE_SIT``
+(see ``tests/integration/conftest.py``) so a normal ``pytest`` run still
+skips them.
+
+These cover read-mostly workflows. The narrower tool-by-tool SIT lives
+in ``test_live_sit.py``; this module exists for "does the whole shape
+work" smoke tests.
+"""
+
+from __future__ import annotations
 
 import pytest
 
-# Mark all tests in this module as integration tests
-pytestmark = pytest.mark.integration
+from .conftest import LIVE_SIT_ENABLED, LIVE_SIT_WRITE_ENABLED, SKIP_REASON_LIVE, SKIP_REASON_WRITE, fetch_top_inbox_message
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not LIVE_SIT_ENABLED, reason=SKIP_REASON_LIVE),
+]
 
 
-@pytest.mark.skip(reason="Requires live Exchange server")
 @pytest.mark.asyncio
-async def test_full_email_workflow():
-    """Test complete email workflow: send, read, search, delete."""
-    # This test requires a real Exchange server connection
-    # Enable only when testing against a live server
-    pass
+async def test_full_email_workflow(live_client):
+    """Search → get details → list folders. Read-only roundtrip."""
+    from src.tools.email_tools import GetEmailDetailsTool
+    from src.tools.folder_tools import ListFoldersTool
+
+    top = await fetch_top_inbox_message(live_client)
+    if top is None:
+        pytest.skip("Inbox is empty.")
+
+    msg_id = top.get("message_id") or top.get("id")
+    assert msg_id, "search_emails returned an item without a message_id"
+
+    details = await GetEmailDetailsTool(live_client).execute(message_id=msg_id)
+    assert details.get("success") is not False
+    assert details.get("subject") is not None or details.get("message_id") == msg_id
+
+    folders = await ListFoldersTool(live_client).execute(folder="inbox", max_depth=1)
+    assert folders.get("success") is not False
+    assert "folders" in folders or "items" in folders
 
 
-@pytest.mark.skip(reason="Requires live Exchange server")
 @pytest.mark.asyncio
-async def test_full_calendar_workflow():
-    """Test complete calendar workflow: create, read, update, delete."""
-    # This test requires a real Exchange server connection
-    pass
+async def test_full_calendar_workflow(live_client):
+    """Get calendar → check availability → find meeting times. Read-only."""
+    from datetime import datetime, timedelta, timezone
+
+    from src.tools.calendar_tools import (
+        CheckAvailabilityTool,
+        FindMeetingTimesTool,
+        GetCalendarTool,
+    )
+
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    end = now + timedelta(days=1)
+
+    cal = await GetCalendarTool(live_client).execute(
+        start_time=now.isoformat(),
+        end_time=end.isoformat(),
+    )
+    assert cal.get("success") is not False
+
+    avail = await CheckAvailabilityTool(live_client).execute(
+        attendees=[live_client.config.ews_email],
+        start_time=now.isoformat(),
+        end_time=(now + timedelta(hours=1)).isoformat(),
+    )
+    assert avail.get("success") is not False
+
+    suggestions = await FindMeetingTimesTool(live_client).execute(
+        attendees=[live_client.config.ews_email],
+        duration_minutes=30,
+        start_date=(now + timedelta(days=1)).date().isoformat(),
+        end_date=(now + timedelta(days=2)).date().isoformat(),
+    )
+    assert suggestions.get("success") is not False
 
 
-@pytest.mark.skip(reason="Requires live Exchange server")
 @pytest.mark.asyncio
-async def test_full_contact_workflow():
-    """Test complete contact workflow: create, search, update, delete."""
-    # This test requires a real Exchange server connection
-    pass
+@pytest.mark.skipif(not LIVE_SIT_WRITE_ENABLED, reason=SKIP_REASON_WRITE)
+async def test_full_contact_workflow(live_client):
+    """GAL find_person on the user's own address — read-only.
+
+    Gated by ``EWS_LIVE_SIT_WRITE`` only because GAL traffic against a
+    corporate directory can be sensitive to log; the call itself never
+    mutates anything.
+    """
+    from src.tools.contact_intelligence_tools import FindPersonTool
+
+    me = live_client.config.ews_email
+    result = await FindPersonTool(live_client).execute(query=me.split("@")[0])
+    assert result.get("success") is not False
+    items = result.get("items") or result.get("matches") or result.get("people") or []
+    assert isinstance(items, list)


### PR DESCRIPTION
## Summary
- **`add_attachment`/`delete_attachment` were silent no-ops** — they mutated `message.attachments` locally and called `message.save()`, which only saves the parent item. EWS never received CreateAttachment/DeleteAttachment, so `list_attachments` returned 0 immediately after add. Switched to `message.attach()` / `message.detach()` which issue the real EWS ops. The new attachment_id is now surfaced in the response.
- **`EWSClient` had `retry_policy=None`**, so transient SOAP failures (e.g. load balancer returning HTML on `find_person` GAL search → `MalformedResponseError: No Body element in SOAP response`) bubbled straight to tools. Switched to `FaultTolerance(max_wait=30)` — exchangelib's built-in backoff for exactly these transient classes. The outer tenacity retry on account creation is unchanged.
- Wired `tests/integration/test_full_workflow.py` into the SIT framework (placeholder skip removed; tests now run under `EWS_LIVE_SIT=1`).

## Test plan
- [x] Live SIT pre-fix: `add_attachment` returned success but `list_attachments` showed 0 — confirmed in production.
- [ ] Post-deploy SIT: `add_attachment` → `list_attachments` shows the attachment with the returned `attachment_id`.
- [ ] Post-deploy SIT: `find_person` no longer throws `MalformedResponseError` on transient GAL hiccups.
- [ ] Existing pytest unit suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
