### PR TITLE
fix(folder): use move_to_trash() for soft-delete (Folder has no soft_…

### DIFF
--- a/src/tools/folder_tools.py
+++ b/src/tools/folder_tools.py
@@ -590,8 +590,16 @@ class ManageFolderTool(BaseTool):
                     folder.delete()
                     action = "permanently deleted"
                 else:
-                    folder.soft_delete()
-                    action = "moved to Deleted Items"
+                    # exchangelib's `Folder` doesn't expose `soft_delete()` —
+                    # that name belongs to `Item`. The folder-level move-to-
+                    # trash is `move_to_trash()`. Falling back to delete()
+                    # if the underlying class is too old to have it.
+                    if hasattr(folder, "move_to_trash"):
+                        folder.move_to_trash()
+                        action = "moved to Deleted Items"
+                    else:
+                        folder.delete()
+                        action = "permanently deleted (no move_to_trash)"
             except Exception as del_exc:
                 # Exchange returns an informative error for common cases
                 # ("folder not empty", "system folder cannot be deleted",

--- a/tests/test_folder_management.py
+++ b/tests/test_folder_management.py
@@ -139,7 +139,9 @@ async def test_delete_folder_soft(mock_ews_client):
     assert "Deleted" in result["message"] or "deleted" in result["message"]
     assert result["folder_id"] == "folder-to-delete"
     assert result["permanent"] is False
-    mock_folder.soft_delete.assert_called_once()
+    # exchangelib's Folder uses move_to_trash(); soft_delete() is an Item method.
+    mock_folder.move_to_trash.assert_called_once()
+    mock_folder.soft_delete.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_reliability_followup.py
+++ b/tests/test_tool_reliability_followup.py
@@ -204,7 +204,12 @@ async def test_b4_manage_folder_delete_accepts_hard_delete_alias(mock_ews_client
 
 @pytest.mark.asyncio
 async def test_b4_manage_folder_delete_soft_default(mock_ews_client):
-    """Without hard_delete/permanent, soft_delete is called."""
+    """Without hard_delete/permanent, the folder is moved to Deleted Items.
+
+    exchangelib's Folder uses ``move_to_trash()`` for soft-delete;
+    ``soft_delete()`` is an ``Item`` method and raises AttributeError
+    on Folder. Pin the new behaviour.
+    """
     from src.tools.folder_tools import ManageFolderTool
 
     folder = MagicMock()
@@ -215,7 +220,8 @@ async def test_b4_manage_folder_delete_soft_default(mock_ews_client):
         result = await tool.execute(action="delete", folder_id="AAMkFolder")
     assert result["success"] is True
     assert result["permanent"] is False
-    folder.soft_delete.assert_called_once()
+    folder.move_to_trash.assert_called_once()
+    folder.soft_delete.assert_not_called()
     folder.delete.assert_not_called()
 
 


### PR DESCRIPTION
…delete)

manage_folder(action="delete", permanent=false) was calling `folder.soft_delete()` and crashing with `AttributeError: 'Folder' object has no attribute 'soft_delete'`. exchangelib reserves `soft_delete()` for `Item` (mail/appointment/task/contact); the folder-level move-to-Deleted-Items operation is `move_to_trash()`.

Switch to `folder.move_to_trash()` with a hasattr fallback so the tool keeps working against older exchangelib versions that lacked the method (those fall back to permanent delete with a clear "permanently deleted (no move_to_trash)" action label).

Confirmed live: pre-fix soft delete returned 500 with the AttributeError; permanent-delete path was unaffected.