### PR TITLE
fix(search_by_conversation): wrap conversation_id in ConversationId before filter

### DIFF
--- a/src/tools/search_tools.py
+++ b/src/tools/search_tools.py
@@ -8,6 +8,8 @@ Provides:
 from typing import Any, Dict, List, Optional, Set
 from datetime import datetime
 
+from exchangelib.properties import ConversationId
+
 from .base import BaseTool
 from ..exceptions import ToolExecutionError, ValidationError
 from ..utils import (
@@ -218,12 +220,21 @@ class SearchByConversationTool(BaseTool):
             searched_folders: List[str] = []
             start_time = datetime.now()
 
+            # exchangelib's Message.conversation_id is an EWSElementField
+            # whose value class is ConversationId — passing a raw string
+            # crashes with TypeError when the QuerySet builds the SOAP
+            # restriction (every per-folder filter() raised, so the tool
+            # walked 19 folders, marked all 19 skipped, and returned 0
+            # results). Wrap the id once so every folder.filter() below
+            # gets a properly typed value.
+            cid_filter = ConversationId(id=conversation_id)
+
             for folder in folders_to_search:
                 folder_name = safe_get(folder, "name", "Unknown")
                 searched_folders.append(folder_name)
                 try:
                     items = list(
-                        folder.filter(conversation_id=conversation_id)
+                        folder.filter(conversation_id=cid_filter)
                         .order_by("-datetime_received")[:max_results]
                     )
                 except Exception as exc:

--- a/tests/test_search_by_conversation.py
+++ b/tests/test_search_by_conversation.py
@@ -63,7 +63,11 @@ class _FakeFolder:
         if self._raise_on_filter is not None:
             raise self._raise_on_filter
         conv_id = kw.get("conversation_id")
-        items = [m for m in self._messages if m.conversation_id == conv_id]
+        # Production passes ConversationId objects (typed-field correctness);
+        # tests historically passed strings. Accept either by extracting the
+        # `.id` attribute if present.
+        target = getattr(conv_id, "id", conv_id)
+        items = [m for m in self._messages if m.conversation_id == target]
         return _FolderQuery(items)
 
 

--- a/tests/test_search_by_conversation_typed_id.py
+++ b/tests/test_search_by_conversation_typed_id.py
@@ -1,0 +1,63 @@
+"""Pin: search_by_conversation must pass a typed ConversationId to filter().
+
+Pre-fix every per-folder ``folder.filter(conversation_id=raw_string)`` raised
+TypeError when exchangelib built the SOAP restriction (Message.conversation_id
+is an EWSElementField with value_cls=ConversationId). The walker caught the
+exception per folder and marked all 19 mail folders as "skipped: TypeError",
+returning 0 results across the board.
+
+This test fails if a future refactor reverts to passing the raw string.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_filter_receives_typed_conversation_id(mock_ews_client):
+    """folder.filter(conversation_id=…) must receive a ConversationId, not str."""
+    from src.tools.search_tools import SearchByConversationTool
+    from exchangelib.properties import ConversationId
+
+    raw_cid = "AAQkADc3MWUyMGQ0LTU5OGUtNGE2MC1hOTUyLTFhZjc5ZDY1ZWJiOQ="
+
+    # Capture the kwarg value the tool passes to filter().
+    captured: dict = {}
+
+    fake_query = MagicMock()
+    fake_query.order_by.return_value.__getitem__ = lambda _self, _slc: []
+
+    fake_folder = MagicMock()
+    fake_folder.name = "Inbox"
+    fake_folder.id = "folder-inbox"
+    fake_folder.folder_class = "IPF.Note"
+
+    def _capture_filter(*a, **kw):
+        captured["conversation_id"] = kw.get("conversation_id")
+        return fake_query
+
+    fake_folder.filter = _capture_filter
+
+    # Wire the tool's folder-walk to return exactly one folder.
+    root = MagicMock()
+    root.walk.return_value = [fake_folder]
+    mock_ews_client.account.msg_folder_root = root
+    mock_ews_client.account.root = root
+    mock_ews_client.account.inbox = fake_folder
+    mock_ews_client.account.sent = fake_folder
+    mock_ews_client.account.trash = fake_folder
+    mock_ews_client.account.drafts = fake_folder
+
+    tool = SearchByConversationTool(mock_ews_client)
+    result = await tool.execute(conversation_id=raw_cid, max_results=10)
+
+    assert result["success"] is not False
+    passed = captured.get("conversation_id")
+    assert passed is not None, "filter() was never called with conversation_id"
+    assert isinstance(passed, ConversationId), (
+        f"expected ConversationId, got {type(passed).__name__}"
+    )
+    assert passed.id == raw_cid


### PR DESCRIPTION
## Summary
Live SIT round-2 surfaced this against the user mailbox: every call to `search_by_conversation` returned 0 results with **all** searched folders reported as `skipped: error_type=TypeError`.

Root cause: `Message.conversation_id` is an `EWSElementField` whose `value_cls=ConversationId`. Passing a raw string into `folder.filter(conversation_id="…")` crashes the QuerySet when it builds the SOAP restriction — the walker catches the per-folder exception, marks the folder skipped, and moves on. End user sees a clean response with `count=0` and a long `skipped_folders` array, not a stack trace, but the tool is fully broken.

Fix: wrap the id once with `ConversationId(id=conversation_id)` so every `folder.filter()` below receives a properly typed value. Mock fixtures updated to accept either form so existing assertions still hold.

## Test plan
- [x] New regression test (`tests/test_search_by_conversation_typed_id.py`) pins the typed value passed to `filter()`.
- [x] Full unit suite: 444 passed locally.
