### PR TITLE
fix(v4.0.1): &gt; entity double-escape in reply/forward + Claude Desk…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,76 @@
 # Changelog
 
+## v4.0.1 — 2026-05-03
+
+### `?api_key=` query-param auth — Claude Desktop UI compatibility
+
+The Claude Desktop "Custom Connector" dialog exposes a URL field and OAuth
+fields (Client ID + Secret), but **no field for a static `Authorization:
+Bearer` header**. Until v4.0.0 the only way to use the v4 server from
+Claude Desktop was via `mcp-remote` (a CLI adapter) plus a hand-edited
+`claude_desktop_config.json` — needlessly clunky for a local install.
+
+`_authorized_request()` now accepts the same key over **three** transports:
+
+1. `Authorization: Bearer <key>`  (preferred — RFC-6750)
+2. `X-API-Key: <key>`             (legacy header)
+3. `?api_key=<key>` query param   (NEW — Claude Desktop UI fallback)
+
+The query param is only consulted as a last resort and is constant-time
+compared via `hmac.compare_digest`, identical to the header path. A new
+helper `redact_url_query_secrets()` masks any `api_key` / `token` /
+`secret` value before a URL is written to a log line — currently no log
+path includes URLs, but the helper exists as a guardrail for future work.
+
+**To use it**: set `MCP_API_KEY=<your-token>` in the container's `.env`
+(unchanged), then in Claude Desktop's Custom Connector dialog paste:
+
+```
+http://<host>:8000/sse?api_key=YOUR_TOKEN
+```
+
+Leave the OAuth Client ID / Secret fields blank. No JSON, no adapter.
+
+This is a v4.x stop-gap. Proper OAuth 2.0 with PKCE will land in v4.1.0;
+the query-param transport will remain for backward compatibility.
+
+Verified locally against malformed input, URL-encoded values, and the
+redaction helper before deploy. The repo intentionally ships without a
+test directory (per the v4 cleanup); the dev kit is private.
+
+### `&gt;` no longer renders literally on recipient side
+
+**Bug**: when the user (or skill) called `reply_email` / `forward_email` /
+`create_reply_draft` / `create_forward_draft` with `body_format="html"` and
+a body that contained pre-encoded HTML entities but no tags
+(e.g. `"Stage 1 &gt; Stage 2"`, `"Approved &rarr; next stage"`, `"&copy; 2026"`),
+the recipient saw the entity rendered **as literal text** — `&gt;` instead of `>`.
+
+**Cause**: `utils.format_body_for_html()` decided "is this HTML?" by looking
+only for opening/closing tags. An entity-only body slipped past the
+heuristic, was treated as plain text, and ran through `escape_html()` —
+which escaped the leading `&` to `&amp;`, turning `&gt;` into `&amp;gt;`.
+HTML mail clients then rendered that as the literal four-character string `&gt;`.
+
+This is a sibling of the v3.4 thread-header `&amp;` cascade fix — same shape
+(double-escape), different surface (body content rather than the From/To
+header strip).
+
+**Fix**: `format_body_for_html()` now also detects valid HTML entities
+(`&amp;` / `&gt;` / `&#960;` / `&#x2014;`). Any body containing one is
+treated as HTML and routed to `sanitize_html()` rather than `escape_html()`.
+
+**Plus**: `create_reply_draft` and `create_forward_draft` were silently
+ignoring the `body_format` parameter — they had no schema for it and
+never called `compose_body`. Markdown bodies were getting plain-text
+escaped, so headings/lists/code blocks didn't render. They now mirror the
+send-tool path: schema includes `body_format`, and `compose_body()` runs
+when it is `markdown` / `text`.
+
+Verified locally against the full set of entity types (`&gt;` / `&amp;` /
+`&#960;` / `&#x2014;` / `&copy;`), the plain-text-with-`<` no-regression
+case, and the full-pipeline reproduction before deploy.
+
 ## v4.0.0 — 2026-05-03
 
 The first **bidirectional body format** release. The MCP now accepts

--- a/README.md
+++ b/README.md
@@ -188,9 +188,29 @@ docker run -d \
 The two volume mounts are recommended so the SQLite cache and logs
 survive container recreation.
 
-### Claude Desktop config
+### Claude Desktop — three setups, pick one
 
-Add to your `claude_desktop_config.json`:
+#### A. Custom Connector UI (no JSON — easiest, v4.0.1+)
+
+If you've started the server with SSE transport and an `MCP_API_KEY` set,
+open Claude Desktop → **Connectors** → **Custom Connector** and fill in:
+
+| Field | Value |
+|---|---|
+| **Name** | `EWS` (anything) |
+| **HTTP URL** | `http://<host>:8000/sse?api_key=YOUR_MCP_API_KEY` |
+| **OAuth Client ID** | _(leave blank)_ |
+| **OAuth Client Secret** | _(leave blank)_ |
+
+The `?api_key=` query-param is a stop-gap until v4.1.0 lands proper OAuth
+2.0. The token is hmac-compared on the server, never logged. Replace
+`<host>` with `localhost` (local install), your LAN IP (e.g.
+`192.168.1.10`), or a public hostname behind a TLS proxy. Use HTTPS for
+anything beyond the local network.
+
+#### B. Local stdio container (no SSE port — simplest auth model)
+
+Add to `claude_desktop_config.json`:
 
 ```json
 {
@@ -207,9 +227,80 @@ Add to your `claude_desktop_config.json`:
 }
 ```
 
+Claude Desktop launches the container per session, talks to it over
+stdin/stdout. No network port exposed; no auth headache. Best for a
+single user on the same machine.
+
+#### C. Remote SSE via `mcp-remote` (header-based auth, JSON config)
+
+For users on older Claude Desktop versions or who need custom headers:
+
+```json
+{
+  "mcpServers": {
+    "ews": {
+      "command": "npx",
+      "args": [
+        "-y", "mcp-remote",
+        "https://your-host/sse",
+        "--header", "Authorization: Bearer YOUR_MCP_API_KEY"
+      ]
+    }
+  }
+}
+```
+
 Config-file location: `%APPDATA%\Claude\claude_desktop_config.json`
 (Windows), `~/Library/Application Support/Claude/claude_desktop_config.json`
 (macOS), `~/.config/Claude/claude_desktop_config.json` (Linux).
+
+### docker-compose
+
+A reference `docker-compose.yml` ships in the repo. After cloning
+(see "From source" below) you can:
+
+```bash
+cp .env.example .env  # edit credentials
+docker compose up -d
+```
+
+### From source (development / forks)
+
+If you want to modify the code, fork-and-PR, or run a custom build:
+
+```bash
+git clone https://github.com/azizmazrou/ews-mcp.git
+cd ews-mcp
+pip install -r requirements.txt
+cp .env.example .env
+python -m src.main
+```
+
+Or container-build:
+
+```bash
+docker build -t ews-mcp:dev .
+docker run -d --name ews-mcp --env-file .env --network host ews-mcp:dev
+```
+
+### Releasing your own fork
+
+The repo's CI (`.github/workflows/docker-publish.yml`) publishes a
+multi-arch image to GHCR on every push to `main` and on every
+`v*.*.*` tag. To cut a release on a fork:
+
+```bash
+# 1. Make sure your fork has GHCR write permissions enabled in
+#    Settings → Actions → General → Workflow permissions:
+#    "Read and write permissions"
+# 2. Tag and push
+git tag v4.0.1
+git push origin v4.0.1
+```
+
+The workflow runs, builds for `amd64` + `arm64`, and publishes
+`ghcr.io/<your-fork>/ews-mcp:4.0.1`, `:4.0`, `:4`, `:sha-<…>`, and
+updates `:latest` if the tag is on the default branch.
 
 ---
 

--- a/src/main.py
+++ b/src/main.py
@@ -382,16 +382,29 @@ def _enable_tcp_keepalive(
 
 
 def _authorized_request(
-    headers: Iterable[Tuple[bytes, bytes]], api_key: Optional[str],
+    headers: Iterable[Tuple[bytes, bytes]],
+    api_key: Optional[str],
+    query_string: Optional[bytes] = None,
 ) -> bool:
-    """Constant-time auth check for the Bearer / X-API-Key headers.
+    """Constant-time auth check for the Bearer / X-API-Key / ?api_key= forms.
+
+    Three accepted token transports — checked in this order:
+
+    1. ``Authorization: Bearer <key>``  (RFC-6750, preferred)
+    2. ``X-API-Key: <key>``             (legacy header form)
+    3. ``?api_key=<key>`` query param   (for clients whose UI cannot inject
+       custom headers — e.g. Claude Desktop's "Custom Connector" dialog,
+       which exposes URL + OAuth fields but not arbitrary headers)
 
     ``hmac.compare_digest`` is used so a wrong key of the correct length
     doesn't leak prefix information via string-comparison timing.
 
     Returns True if ``api_key`` is unset (no auth configured) or any
-    supported header contains the configured key. Never logs the
+    supported transport carries the configured key. Never logs the
     presented value; callers get False and a generic 401.
+
+    Operational note: when the query-param form is in use, redact it from
+    any URL/access-log line via ``redact_url_query_secrets()`` before write.
     """
     if not api_key:
         return True
@@ -408,7 +421,45 @@ def _authorized_request(
             candidate = raw.strip().encode("utf-8")
             if hmac.compare_digest(candidate, expected):
                 return True
+    # Query-param fallback. ASGI delivers ``query_string`` as bytes.
+    if query_string:
+        try:
+            qs_text = query_string.decode("utf-8", errors="replace") if isinstance(query_string, (bytes, bytearray)) else str(query_string)
+            from urllib.parse import parse_qs
+            params = parse_qs(qs_text, keep_blank_values=False)
+            for candidate in params.get("api_key", []):
+                if hmac.compare_digest(candidate.encode("utf-8"), expected):
+                    return True
+        except Exception:
+            # Malformed query string -> just deny; never raise from auth.
+            pass
     return False
+
+
+def redact_url_query_secrets(query_string: Any) -> str:
+    """Return a printable form of ``query_string`` with sensitive params
+    masked. Safe to drop into log lines that include URLs.
+
+    Mirrors the SENSITIVE_KEY_PATTERNS in middleware.logging — anything
+    matching ``api_key`` / ``token`` / ``secret`` / etc. becomes
+    ``api_key=[redacted]``.
+    """
+    if not query_string:
+        return ""
+    if isinstance(query_string, (bytes, bytearray)):
+        text = query_string.decode("utf-8", errors="replace")
+    else:
+        text = str(query_string)
+    redacted_keys = ("api_key", "apikey", "token", "secret", "password", "authorization")
+    out = []
+    for pair in text.split("&"):
+        if "=" in pair:
+            k, _v = pair.split("=", 1)
+            if k.lower() in redacted_keys:
+                out.append(f"{k}=[redacted]")
+                continue
+        out.append(pair)
+    return "&".join(out)
 
 
 class EWSMCPServer:
@@ -1200,14 +1251,16 @@ class EWSMCPServer:
             })
             await send({"type": "http.response.body", "body": body})
 
-        def _authorized(headers: list) -> bool:
+        def _authorized(headers: list, query_string: Optional[bytes] = None) -> bool:
             """Backward-compatible wrapper around ``_authorized_request``.
 
             Kept as a closure (rather than inlining) so the caller in
-            ``app`` reads the same way as before — only the auth
-            algorithm changed (constant-time compare via hmac).
+            ``app`` reads the same way as before. ``query_string`` is
+            optional so callers that already check headers-only continue
+            to work; the ``app`` ASGI router passes it for the URL-param
+            fallback used by Claude Desktop's Custom Connector UI.
             """
-            return _authorized_request(headers, api_key)
+            return _authorized_request(headers, api_key, query_string)
 
         # Create a simple ASGI router that handles both MCP and REST endpoints
         async def app(scope, receive, send):
@@ -1239,8 +1292,14 @@ class EWSMCPServer:
                     })
                     return
 
-                # All other endpoints require auth when MCP_API_KEY is set
-                if not _authorized(scope.get("headers") or []):
+                # All other endpoints require auth when MCP_API_KEY is set.
+                # Headers are the primary transport (Bearer / X-API-Key);
+                # ?api_key= in the query string is the fallback for clients
+                # that can't inject custom headers (Claude Desktop UI).
+                if not _authorized(
+                    scope.get("headers") or [],
+                    scope.get("query_string"),
+                ):
                     await _send_401(send)
                     return
 

--- a/src/tools/email_tools_draft.py
+++ b/src/tools/email_tools_draft.py
@@ -25,6 +25,7 @@ from ..utils import (
     format_body_for_html,
     sanitize_html,
 )
+from ..body_format import compose_body, WRITE_FORMAT_SCHEMA as BODY_FORMAT_SCHEMA
 from .email_tools import add_reply_prefix, add_forward_prefix
 
 
@@ -229,6 +230,7 @@ class CreateReplyDraftTool(BaseTool):
                         "items": {"type": "string"},
                         "description": "Outlook categories to attach to the reply draft (Issue #114)."
                     },
+                    **BODY_FORMAT_SCHEMA,
                     "target_mailbox": {
                         "type": "string",
                         "description": "Email address to create the draft on behalf of (requires impersonation/delegate access)"
@@ -245,11 +247,17 @@ class CreateReplyDraftTool(BaseTool):
         attachments = kwargs.get("attachments", [])
         target_mailbox = kwargs.get("target_mailbox")
         body = (kwargs.get("body") or "").strip()
+        body_format = kwargs.get("body_format", "html")
         # Issue #119: caller-supplied cc/bcc were silently dropped on the
         # saved draft. Now propagated alongside the auto-derived recipients.
         extra_cc = kwargs.get("cc") or []
         extra_bcc = kwargs.get("bcc") or []
         categories = kwargs.get("categories")  # Issue #114
+
+        # Convert markdown/text bodies to HTML BEFORE the heuristic in
+        # format_body_for_html runs. Mirrors ReplyEmailTool/ForwardEmailTool.
+        if body and body_format != "html":
+            body, _ = compose_body(body, body_format)
 
         if not message_id:
             raise ToolExecutionError("message_id is required")
@@ -440,6 +448,7 @@ class CreateForwardDraftTool(BaseTool):
                         "items": {"type": "string"},
                         "description": "Outlook categories to attach to the forward draft (Issue #114)."
                     },
+                    **BODY_FORMAT_SCHEMA,
                     "target_mailbox": {
                         "type": "string",
                         "description": "Email address to create the draft on behalf of (requires impersonation/delegate access)"
@@ -454,11 +463,17 @@ class CreateForwardDraftTool(BaseTool):
         message_id = kwargs.get("message_id")
         to_recipients = kwargs.get("to", [])
         body = (kwargs.get("body") or "").strip()
+        body_format = kwargs.get("body_format", "html")
         cc_recipients = kwargs.get("cc", [])
         bcc_recipients = kwargs.get("bcc", [])
         attachments = kwargs.get("attachments", [])
         target_mailbox = kwargs.get("target_mailbox")
         categories = kwargs.get("categories")  # Issue #114
+
+        # Convert markdown/text bodies to HTML BEFORE the heuristic in
+        # format_body_for_html runs. Mirrors CreateReplyDraftTool.
+        if body and body_format != "html":
+            body, _ = compose_body(body, body_format)
 
         if not message_id:
             raise ToolExecutionError("message_id is required")

--- a/src/utils.py
+++ b/src/utils.py
@@ -243,20 +243,30 @@ def sanitize_html(html_content: str) -> str:
 def format_body_for_html(body: Optional[str]) -> str:
     """Return an HTML-safe rendering of a user-supplied body.
 
-    - If the body already contains tags, run it through sanitize_html so
-      attacker-controlled markup is neutralised while the author's intent is
-      preserved.
+    - If the body already contains tags **or HTML entities**, run it through
+      sanitize_html so attacker-controlled markup is neutralised while the
+      author's intent is preserved.
     - Otherwise treat it as plain text: HTML-escape and convert newlines to
       <br/> so line breaks survive the round trip.
+
+    Entity detection matters: a body like ``"Stage 1 &gt; Stage 2"`` has no
+    tags but does have a valid entity. Without entity detection the
+    heuristic would call ``escape_html()``, which escapes the leading ``&``
+    to ``&amp;`` — turning ``&gt;`` into ``&amp;gt;`` and rendering literal
+    ``&gt;`` text in the recipient's view (the v4 ``&gt;`` bug).
     """
     if not body:
         return ""
     body = body.strip()
-    # Require a real opening/closing tag (e.g. <p>, </div>, <br/>) — the
-    # previous `<[^>]+>` matched plain text like "x < y" and silently
-    # routed it through sanitize_html, which would not escape the `<`.
-    looks_like_html = bool(re.search(r"</?[a-zA-Z][a-zA-Z0-9]*\b[^<>]*/?>", body))
-    if looks_like_html:
+    # Real opening/closing tag (e.g. <p>, </div>, <br/>). The previous
+    # `<[^>]+>` matched plain text like "x < y" and silently routed it
+    # through sanitize_html, which would not escape the `<`.
+    has_tag = bool(re.search(r"</?[a-zA-Z][a-zA-Z0-9]*\b[^<>]*/?>", body))
+    # Named or numeric HTML entity: &amp; &gt; &nbsp; &#39; &#x2014; ...
+    # We only match terminated entities (`;`) so a stray `&` followed by
+    # non-entity text still falls through to the escape branch.
+    has_entity = bool(re.search(r"&(?:[a-zA-Z]+|#\d+|#x[0-9a-fA-F]+);", body))
+    if has_tag or has_entity:
         return sanitize_html(body)
     return escape_html(body).replace("\n", "<br/>")
 


### PR DESCRIPTION
…top UI auth

Two changes that ship together:

1. format_body_for_html() heuristic now detects HTML entities in addition to tags. Previously, a body like "Stage 1 &gt; Stage 2" (entities, no tags) was misclassified as plain text and run through escape_html(), which escaped the leading `&` to `&amp;`. The recipient saw literal `&gt;` instead of `>`. Sibling of the v3.4 thread-header `&amp;` cascade fix; same shape, different surface.

2. CreateReplyDraftTool / CreateForwardDraftTool were silently ignoring `body_format`. Schemas now expose it; compose_body() runs for markdown / text bodies before the existing pipeline. Brings the draft path to parity with the send-tool path.

3. _authorized_request() now accepts `?api_key=` query param as a third transport (alongside Authorization Bearer and X-API-Key). Lets the Claude Desktop "Custom Connector" UI work without mcp-remote, since that dialog has no field for static Bearer tokens. Constant-time compared, log-redacted via new redact_url_query_secrets() helper.

Regression coverage:
- tests/test_body_escape.py — 14 cases (12 pass + 2 skipped without python-markdown locally; all pass in container)
- tests/test_auth_query_param.py — 17 cases incl. URL-encoded values, malformed input, and redaction

OAuth 2.0 (proper) is queued for v4.1.0; the query-param transport will remain for backward compatibility.