### PR TITLE
fix(docker): drop COPY of the removed scripts/ directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,9 +73,6 @@ RUN grep -q "VERSION: 3.4.0 - RELIABILITY & ASYNC" /app/src/tools/contact_intell
     python -m py_compile /app/src/core/*.py /app/src/services/*.py /app/src/adapters/*.py || \
     (echo "ERROR: Python syntax errors" && exit 1)
 
-# Copy scripts
-COPY --chown=mcp:mcp scripts/ ./scripts/
-
 # Copy entrypoint script (keep as root for now)
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
The docs revamp deleted the legacy helper scripts and the empty directory with them; the image never used them at runtime, but the stale COPY failed every legacy build (Docker Build Smoke + publish).