### PR TITLE
fix(create_reply_draft): mirror original To/Cc on reply-all

### DIFF
--- a/src/tools/email_tools_draft.py
+++ b/src/tools/email_tools_draft.py
@@ -240,14 +240,22 @@ class CreateReplyDraftTool(BaseTool):
                 if r and hasattr(r, "email_address") and r.email_address
             ]
 
+            # Mirror standard reply-all semantics: sender + original To stay in
+            # To; original Cc recipients stay in Cc rather than being promoted.
+            reply_cc_recipients = []
             if reply_all:
                 seen = set()
                 reply_to_recipients = []
-                for email in [original_from_email] + original_to + original_cc:
+                for email in [original_from_email] + original_to:
                     if not email or email == account.primary_smtp_address or email in seen:
                         continue
                     seen.add(email)
                     reply_to_recipients.append(Mailbox(email_address=email))
+                for email in original_cc:
+                    if not email or email == account.primary_smtp_address or email in seen:
+                        continue
+                    seen.add(email)
+                    reply_cc_recipients.append(Mailbox(email_address=email))
             else:
                 reply_to_recipients = [Mailbox(email_address=original_from_email)]
 
@@ -288,6 +296,7 @@ class CreateReplyDraftTool(BaseTool):
                 subject=reply_subject,
                 body=HTMLBody(complete_body),
                 to_recipients=reply_to_recipients,
+                cc_recipients=reply_cc_recipients or None,
                 folder=account.drafts,
             )
 

--- a/tests/test_email_tools.py
+++ b/tests/test_email_tools.py
@@ -112,7 +112,7 @@ async def test_create_reply_draft_tool_saves_html_draft(mock_ews_client):
 
 @pytest.mark.asyncio
 async def test_create_reply_draft_tool_reply_all_uses_all_recipients(mock_ews_client):
-    """Test reply-all draft includes sender and original recipients except self."""
+    """Reply-all mirrors the original: sender + To stay in To, Cc stays in Cc, self excluded."""
     tool = CreateReplyDraftTool(mock_ews_client)
     mock_ews_client.get_account = Mock(return_value=mock_ews_client.account)
     mock_ews_client.account.drafts = MagicMock()
@@ -154,8 +154,10 @@ async def test_create_reply_draft_tool_reply_all_uses_all_recipients(mock_ews_cl
             )
 
     called_kwargs = mock_message.call_args.kwargs
-    recipients = [recipient.email_address for recipient in called_kwargs["to_recipients"]]
-    assert recipients == ["sender@example.com", "team@example.com", "other@example.com"]
+    to_addresses = [recipient.email_address for recipient in called_kwargs["to_recipients"]]
+    cc_addresses = [recipient.email_address for recipient in (called_kwargs["cc_recipients"] or [])]
+    assert to_addresses == ["sender@example.com", "team@example.com"]
+    assert cc_addresses == ["other@example.com"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Reply-all drafts previously merged the original sender, To, and Cc recipients all into `to_recipients`, promoting Cc recipients into To and misrepresenting the audience in formal threads.
- Now reply-all mirrors standard mail-client semantics: **To** = original sender + original To (minus self), **Cc** = original Cc (minus self and anyone already in To).
- Updated the reply-all recipient test to assert the To/Cc split.

## Test plan
- [x] `pytest tests/test_email_tools.py tests/test_reply_forward_escape.py` — 27 passed
- [x] Verified live against Exchange: reply-all draft produced correct To/Cc mirroring the original

🤖 Generated with [Claude Code](https://claude.com/claude-code)