### PR TITLE
fix(dto): keep the date on all-day events and mark them as such

### DIFF
--- a/v5/ewsmcp/dto.py
+++ b/v5/ewsmcp/dto.py
@@ -1,7 +1,7 @@
 """Token-lean DTO builders (DESIGN.md §DTOs). The model never sees a raw EWS id:
 ``id`` IS the short alias; the aliaser holds the raw id + changekey."""
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any, Dict, List, Optional
 from zoneinfo import ZoneInfo
 
@@ -10,8 +10,14 @@ from .ids import IdAliaser
 
 
 def fmt_dt(value: Any, tz: str) -> Optional[str]:
-    if value is None or not hasattr(value, "astimezone"):
+    if value is None:
         return None
+    if not hasattr(value, "astimezone"):
+        # All-day boundaries arrive as EWSDate — a plain date subclass with
+        # no clock time and no tzinfo, so there is nothing to convert.
+        # Returning None here dropped the date silently and left an all-day
+        # event indistinguishable from a broken record.
+        return value.isoformat() if isinstance(value, date) else None
     try:
         return value.astimezone(ZoneInfo(tz)).isoformat(timespec="minutes")
     except Exception:
@@ -140,6 +146,10 @@ def event_card(item: Any, aliaser: IdAliaser, tz: str) -> Dict[str, Any]:
         "start": fmt_dt(getattr(item, "start", None), tz),
         "end": fmt_dt(getattr(item, "end", None), tz),
     }
+    if getattr(item, "is_all_day", False):
+        # Without this the caller cannot tell a full-day block from a
+        # timed one, because all-day start/end carry a date but no clock.
+        card["all_day"] = True
     location = getattr(item, "location", None)
     if location:
         card["location"] = str(location)


### PR DESCRIPTION
Against the `v5/` tree (4.5.0a1).

`list_events` returns `{"start": null, "end": null}` for every all-day event, and the card carries no flag saying it is one — an all-day block is indistinguishable from a broken record.

### Cause

Both in `v5/ewsmcp/dto.py`:

- `fmt_dt()` gates on `hasattr(value, "astimezone")`. All-day boundaries arrive as `EWSDate`, a `datetime.date` subclass with no `astimezone`, so they fall straight through to `None`.
- `event_card()` never emits `is_all_day`, so the caller has no fallback signal either.

### Fix

`fmt_dt()` returns the ISO date for a `date` that carries no clock time, and `event_card()` sets `all_day: true` when the item says so. `list_events` fetches full items (no `.only()` projection), so the field is available.

### Verification

Against Exchange 2016, build 15.1.2507.27. A window holding a multi-day vacation block plus several birthdays:

| | before | after |
|---|---|---|
| events | 37 | 37 |
| all-day recognised | 0 | 6 |
| start of an all-day item | `null` | `2026-08-05` |

Full suite green (252 passed).
