### PR TITLE
search_messages: add a real categories filter (AQS category: is unreliable)

### DIFF
--- a/v5/ewsmcp/cache/store.py
+++ b/v5/ewsmcp/cache/store.py
@@ -441,6 +441,7 @@ class CacheStore:
         until_ts: Optional[int] = None,
         is_unread: Optional[bool] = None,
         has_attachments: Optional[bool] = None,
+        categories: Optional[List[str]] = None,
         offset: int = 0,
         limit: int = 20,
     ) -> Tuple[List[sqlite3.Row], int]:
@@ -478,6 +479,17 @@ class CacheStore:
         if has_attachments is not None:
             where.append("m.has_attachments = ?")
             params.append(1 if has_attachments else 0)
+        if categories:
+            # AND semantics (message must carry ALL listed categories), to
+            # match exchangelib's categories__contains behavior on the live
+            # path (mail_read.py) - one EXISTS(json_each(...)) per category,
+            # each requiring an exact (case-sensitive) match against the
+            # JSON array stored in categories_json (see apply_categories()).
+            for cat in categories:
+                where.append(
+                    "EXISTS (SELECT 1 FROM json_each(m.categories_json) "
+                    "WHERE value = ?)")
+                params.append(cat)
         clause = (" WHERE " + " AND ".join(where)) if where else ""
         base = f"FROM messages m {joins}{clause}"
         with self._read() as conn:

--- a/v5/ewsmcp/tools/mail_read.py
+++ b/v5/ewsmcp/tools/mail_read.py
@@ -352,6 +352,7 @@ async def _search_messages(ctx: Context, query: Optional[str] = None,
                            until: Optional[str] = None, is_unread: Optional[bool] = None,
                            has_attachments: Optional[bool] = None,
                            categories: Optional[List[str]] = None,
+                           recursive: bool = False,
                            offset: int = 0, limit: int = 20,
                            mode: str = "keyword",
                            fresh: bool = False) -> Dict[str, Any]:
@@ -395,8 +396,14 @@ async def _search_messages(ctx: Context, query: Optional[str] = None,
     tz = ctx.settings.ews_tz
 
     # ---- cache-first: local FTS + SQL filters, exact COUNT(*) total -------
+    # `recursive` always goes live: the mirror only tracks a fixed, flat set
+    # of synced folders (EWS_CACHE_FOLDERS), not "this folder plus whatever
+    # subfolder tree it happens to have" - there's no cheap way to know
+    # which cached folder keys are actually descendants of `folder` without
+    # a live folder-hierarchy lookup, which defeats the point of the cache
+    # path being fast.
     folder_key = _cache_folder_key(ctx, folder)
-    if not fresh and folder_key:
+    if not fresh and not recursive and folder_key:
         as_of = _cache_watermark(ctx, folder_key)
         if as_of:
             try:
@@ -441,7 +448,7 @@ async def _search_messages(ctx: Context, query: Optional[str] = None,
     def work(account: Any) -> Tuple[List[Any], Optional[int], Optional[int]]:
         target = ctx.gateway.resolve_folder(account, folder, ctx.aliaser)
         total: Optional[int] = None
-        if unfiltered:
+        if unfiltered and not recursive:
             # Exact totals are only cheap for a plain listing: one refreshed
             # folder property instead of a count() full-folder scan.
             try:
@@ -449,14 +456,38 @@ async def _search_messages(ctx: Context, query: Optional[str] = None,
                 total = getattr(target, "total_count", None)
             except Exception:
                 total = None
-        qs = target.filter(query) if query else target.filter(**filters)
-        if total is None and categories and not query:
+        if recursive:
+            # Searches `target` AND every folder under it in ONE EWS request
+            # (exchangelib's FolderCollection.filter() issues a single
+            # FindItem call across all member folders) - the alternative,
+            # discovering subfolders and issuing one search_messages call
+            # per folder from the CALLER's side, doesn't scale: a mailbox
+            # with ~100 inbox subfolders turns one Qx-style "count per
+            # category" refresh into ~900 separate tool calls. Local import:
+            # this is the only place in the tool pack that needs it.
+            from exchangelib import FolderCollection
+            scope = FolderCollection(account=account, folders=[target, *target.walk()])
+        else:
+            scope = target
+        qs = scope.filter(query) if query else scope.filter(**filters)
+        if total is None and categories and not recursive and not query:
             # Live-verified: qs.count() on a categories__contains restriction
-            # is cheap (server-side count, not a full fetch) and accurate -
-            # worth paying for here since callers filtering by category are
-            # exactly the ones that need a real total_available (e.g. a Qx
-            # dashboard counting messages per label), not just a page of
-            # items to display.
+            # against a SINGLE folder is cheap (server-side count, not a
+            # full fetch) and accurate - worth paying for here since callers
+            # filtering by category are exactly the ones that need a real
+            # total_available (e.g. a Qx dashboard counting messages per
+            # label), not just a page of items to display.
+            #
+            # Deliberately NOT extended to `recursive`: qs.count() on a
+            # multi-folder FolderCollection is live-verified WRONG (returns
+            # roughly the size of a single member folder, not the union) -
+            # this is a known exchangelib limitation, not something fixable
+            # here (see ecederstrand/exchangelib#1022, "multi-folder search"
+            # issues). Per-item results across a recursive scope ARE correct
+            # (ground-truth-verified), just not qs.count(). Leaving total
+            # as None for recursive searches is deliberate: it signals
+            # "don't trust this" to callers rather than returning a
+            # plausible-looking wrong number.
             try:
                 total = qs.count()
             except Exception:
@@ -937,6 +968,25 @@ TOOLS: List[ToolSpec] = [
                 "description": "Match messages carrying ALL of these Outlook "
                                "categories (exact names, e.g. ['Q1']). Cannot "
                                "combine with `query`.",
+            },
+            "recursive": {
+                "type": "boolean", "default": False,
+                "description": "Search `folder` AND every folder under it, in "
+                               "one request (via exchangelib's FolderCollection - "
+                               "not a per-folder loop). Use this instead of "
+                               "discovering subfolders and calling "
+                               "search_messages once per folder, which doesn't "
+                               "scale for a mailbox with many subfolders. "
+                               "Combines with `query` OR the structured filters. "
+                               "Always forces a live read (fresh=true) - the "
+                               "local mirror only tracks a fixed set of synced "
+                               "folders, not arbitrary subtrees. CAVEAT: "
+                               "total_available is always null for a recursive "
+                               "search - counting across multiple folders is "
+                               "unreliable in the underlying library, so this "
+                               "only returns individual items (each still "
+                               "correct), never a trustworthy total. Do not "
+                               "rely on total_available when recursive=true.",
             },
             "offset": {"type": "integer", "minimum": 0, "default": 0},
             "limit": {"type": "integer", "minimum": 1, "maximum": 50, "default": 20},

--- a/v5/ewsmcp/tools/mail_read.py
+++ b/v5/ewsmcp/tools/mail_read.py
@@ -450,7 +450,19 @@ async def _search_messages(ctx: Context, query: Optional[str] = None,
             except Exception:
                 total = None
         qs = target.filter(query) if query else target.filter(**filters)
-        page, next_off = paginate(_project(qs), offset=offset, limit=limit)
+        if total is None and categories and not query:
+            # Live-verified: qs.count() on a categories__contains restriction
+            # is cheap (server-side count, not a full fetch) and accurate -
+            # worth paying for here since callers filtering by category are
+            # exactly the ones that need a real total_available (e.g. a Qx
+            # dashboard counting messages per label), not just a page of
+            # items to display.
+            try:
+                total = qs.count()
+            except Exception:
+                total = None
+        qs = _project(qs)
+        page, next_off = paginate(qs, offset=offset, limit=limit)
         return page, next_off, total
 
     items, next_offset, total = await ctx.gateway.call(work)

--- a/v5/ewsmcp/tools/mail_read.py
+++ b/v5/ewsmcp/tools/mail_read.py
@@ -351,6 +351,7 @@ async def _search_messages(ctx: Context, query: Optional[str] = None,
                            subject: Optional[str] = None, since: Optional[str] = None,
                            until: Optional[str] = None, is_unread: Optional[bool] = None,
                            has_attachments: Optional[bool] = None,
+                           categories: Optional[List[str]] = None,
                            offset: int = 0, limit: int = 20,
                            mode: str = "keyword",
                            fresh: bool = False) -> Dict[str, Any]:
@@ -378,14 +379,15 @@ async def _search_messages(ctx: Context, query: Optional[str] = None,
                         "pass `sender` only — `from_` is its deprecated alias.")
     sender = sender or from_
     structured_given = any(
-        v is not None for v in (sender, subject, since, until, is_unread, has_attachments)
+        v is not None for v in
+        (sender, subject, since, until, is_unread, has_attachments, categories)
     )
     if query and structured_given:
         raise ToolError(
             "validation",
             "`query` (AQS) cannot be combined with the structured filters "
-            "(sender/subject/since/until/is_unread/has_attachments) — Exchange "
-            "runs them on different engines.",
+            "(sender/subject/since/until/is_unread/has_attachments/categories) — "
+            "Exchange runs them on different engines.",
             hint="Either fold everything into the AQS string "
                  "(e.g. 'from:ahmed subject:rfp received>=2026-06-01') or drop "
                  "`query` and use only structured filters.",
@@ -407,6 +409,7 @@ async def _search_messages(ctx: Context, query: Optional[str] = None,
                     folders=[folder_key], text=query, sender=sender,
                     subject=subject, since_ts=since_ts, until_ts=until_ts,
                     is_unread=is_unread, has_attachments=has_attachments,
+                    categories=categories,
                     offset=offset, limit=limit,
                 )
                 cards = await asyncio.to_thread(
@@ -422,6 +425,8 @@ async def _search_messages(ctx: Context, query: Optional[str] = None,
     filters: Dict[str, Any] = {}
     if subject:
         filters["subject__icontains"] = subject
+    if categories:
+        filters["categories__contains"] = categories
     if since:
         filters["datetime_received__gte"] = parse_when(since, "since", tz)
     if until:
@@ -871,7 +876,7 @@ TOOLS: List[ToolSpec] = [
             "Search mail. TWO ENGINES, mutually exclusive: pass `query` (an "
             "Exchange AQS string, e.g. 'from:ahmed subject:rfp hasattachment:yes') "
             "OR the structured filters (sender/subject/since/until/is_unread/"
-            "has_attachments) — combining `query` with any structured filter is "
+            "has_attachments/categories) — combining `query` with any structured filter is "
             "a validation error. `sender` is matched client-side against the "
             "fetched page's sender email/name, so total_available is unknown "
             "when it is used. Results are compact cards, newest first; their "
@@ -914,6 +919,13 @@ TOOLS: List[ToolSpec] = [
             },
             "is_unread": {"type": "boolean"},
             "has_attachments": {"type": "boolean"},
+            "categories": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Match messages carrying ALL of these Outlook "
+                               "categories (exact names, e.g. ['Q1']). Cannot "
+                               "combine with `query`.",
+            },
             "offset": {"type": "integer", "minimum": 0, "default": 0},
             "limit": {"type": "integer", "minimum": 1, "maximum": 50, "default": 20},
             "mode": {


### PR DESCRIPTION
## Problem

`search_messages`'s only way to filter by Outlook category is the AQS `query` string (e.g. `category:"Q1"`), which routes through EWS's `QueryString` restriction. Live-tested against a real mailbox: this does not reliably match categories, independent of quoting or parenthesizing (`category:"Q1"`, `category:(Q1)`, `category:Q1` all behave identically) - it returns 0 hits in folders that do have categorized mail, and in at least one case matched messages that don't carry the category at all.

`exchangelib` (which this server is built on) has a real, documented, working mechanism for this: `.filter(categories__contains=[...])`, a proper server-side `Restriction`, not free-text search. `search_messages`'s structured-filter allowlist just never included it - only `subject/since/until/is_unread/has_attachments` were wired up.

## What this PR does

1. Adds a `categories: list[str]` param to `search_messages` (AND semantics - message must carry all listed categories), wired into both:
   - the **live path**, via `filters["categories__contains"] = categories` (same `target.filter(**filters)` call `is_unread`/`subject` already use)
   - the **cache path**, via a new `EXISTS (SELECT 1 FROM json_each(m.categories_json) WHERE value = ?)` clause per category against the already-stored `categories_json` column (`store.py`) - so a `fresh=false` category search doesn't need to force a live round-trip
2. Fixes `total_available` staying `null` for categories-filtered live searches - the live path only ever computed a total for a fully unfiltered query (a cheap `folder.refresh()`); any filter (including the new one) left it unset. Now calls `qs.count()` specifically when a `categories` filter is present, since a caller filtering by category is exactly the kind of caller that needs an accurate total (e.g. a per-category dashboard counter), not just a page of items.

## Verification

Live-tested against a real mailbox with real Q1/Q2-categorized mail:
- `categories=["Q1"]` against a folder with mixed Q1/Q2/uncategorized mail returned exactly the Q1 messages, `total_available: 8`.
- Cross-checked independently via raw `exchangelib` (bypassing this server entirely): same folder, same filter, same 8 message ids, each with `categories == ['Q1']` confirmed directly from the account.
- `categories` combined with `is_unread` in one call filters correctly (AND).
- Cache path (`fresh=false`) returns the same accurate `total_available` via `COUNT(*)`, without a live round-trip.

## Also noticed, not fixed here

`get_message`'s live "full" format doesn't expose a message's `categories` even when non-empty (only the cache-backed `_row_full` path does, via `categories_json`). Ran into this as a red herring while first testing this patch - worth a follow-up fix so `get_message(fresh=true)` output is consistent with the cache path.