### PR TITLE
Follow-up flag completion IS available - add flag_complete support

### DIFF
--- a/v5/ewsmcp/dto.py
+++ b/v5/ewsmcp/dto.py
@@ -128,6 +128,8 @@ def msg_full(item: Any, aliaser: IdAliaser, tz: str, body_max_chars: int,
     imid = getattr(item, "message_id", None)
     if imid:
         full["internet_message_id"] = imid
+    if getattr(item, "flag_status", None) == 1:
+        full["flag_complete"] = True
     full.pop("snippet", None)
     return full
 

--- a/v5/ewsmcp/flag_property.py
+++ b/v5/ewsmcp/flag_property.py
@@ -1,0 +1,37 @@
+"""Registers the Outlook follow-up flag's completion state (PidTagFlagStatus,
+MAPI property tag 0x1090) as a queryable/writable field on Message.
+
+writes.py previously concluded flag completion was simply unavailable
+("exchangelib 5.0.3 exposes no first-class follow-up flag field, and
+pretending would be mock-drift bait") and used categories as a workaround
+marker instead. Live-tested against a real mailbox: it IS available via
+exchangelib's ExtendedProperty registration mechanism - reading, writing
+(item.save()), and filtering (folder.filter(flag_status=1)) all verified
+end to end (baseline count 0 -> set flag_status=1 on one message -> count
+1, correct match -> revert to None -> count 0 again).
+
+Value meanings (real MAPI semantics, PidTagFlagStatus): None = not
+flagged, 1 = flagged and marked Complete, 2 = flagged and still open
+(Outlook's plain "Flagged" state). This module only cares about the
+completion state (1 vs not-1), not the full flag lifecycle.
+"""
+from exchangelib import Message
+from exchangelib.extended_properties import ExtendedProperty
+
+
+class FlagStatus(ExtendedProperty):
+    property_tag = 0x1090
+    property_type = "Integer"
+
+
+_registered = False
+
+
+def ensure_registered() -> None:
+    """Idempotent - safe to call from every module that needs the field,
+    regardless of import order."""
+    global _registered
+    if _registered:
+        return
+    Message.register("flag_status", FlagStatus)
+    _registered = True

--- a/v5/ewsmcp/tools/mail_read.py
+++ b/v5/ewsmcp/tools/mail_read.py
@@ -27,8 +27,11 @@ from ..bodyclean import clean_body
 from ..dates import parse_when
 from ..dto import envelope, event_card, fmt_dt, msg_card, msg_full
 from ..errors import ToolError
+from ..flag_property import ensure_registered as ensure_flag_status_registered
 from ..gateway.client import WELL_KNOWN, paginate
 from .base import Context, ToolSpec
+
+ensure_flag_status_registered()
 
 logger = logging.getLogger(__name__)
 
@@ -351,6 +354,7 @@ async def _search_messages(ctx: Context, query: Optional[str] = None,
                            subject: Optional[str] = None, since: Optional[str] = None,
                            until: Optional[str] = None, is_unread: Optional[bool] = None,
                            has_attachments: Optional[bool] = None,
+                           flag_complete: Optional[bool] = None,
                            offset: int = 0, limit: int = 20,
                            mode: str = "keyword",
                            fresh: bool = False) -> Dict[str, Any]:
@@ -378,14 +382,15 @@ async def _search_messages(ctx: Context, query: Optional[str] = None,
                         "pass `sender` only — `from_` is its deprecated alias.")
     sender = sender or from_
     structured_given = any(
-        v is not None for v in (sender, subject, since, until, is_unread, has_attachments)
+        v is not None
+        for v in (sender, subject, since, until, is_unread, has_attachments, flag_complete)
     )
     if query and structured_given:
         raise ToolError(
             "validation",
             "`query` (AQS) cannot be combined with the structured filters "
-            "(sender/subject/since/until/is_unread/has_attachments) — Exchange "
-            "runs them on different engines.",
+            "(sender/subject/since/until/is_unread/has_attachments/flag_complete) — "
+            "Exchange runs them on different engines.",
             hint="Either fold everything into the AQS string "
                  "(e.g. 'from:ahmed subject:rfp received>=2026-06-01') or drop "
                  "`query` and use only structured filters.",
@@ -393,8 +398,11 @@ async def _search_messages(ctx: Context, query: Optional[str] = None,
     tz = ctx.settings.ews_tz
 
     # ---- cache-first: local FTS + SQL filters, exact COUNT(*) total -------
+    # `flag_complete` always goes live: the mirror's schema has no column
+    # for it (flag_status is an extended property the sync engine never
+    # fetches/stores), so a cached search can't filter on it.
     folder_key = _cache_folder_key(ctx, folder)
-    if not fresh and folder_key:
+    if not fresh and flag_complete is None and folder_key:
         as_of = _cache_watermark(ctx, folder_key)
         if as_of:
             try:
@@ -430,8 +438,10 @@ async def _search_messages(ctx: Context, query: Optional[str] = None,
         filters["is_read"] = not is_unread
     if has_attachments is not None:
         filters["has_attachments"] = bool(has_attachments)
+    if flag_complete is True:
+        filters["flag_status"] = 1
 
-    unfiltered = not query and not filters and not sender
+    unfiltered = not query and not filters and not sender and flag_complete is None
 
     def work(account: Any) -> Tuple[List[Any], Optional[int], Optional[int]]:
         target = ctx.gateway.resolve_folder(account, folder, ctx.aliaser)
@@ -445,7 +455,24 @@ async def _search_messages(ctx: Context, query: Optional[str] = None,
             except Exception:
                 total = None
         qs = target.filter(query) if query else target.filter(**filters)
-        page, next_off = paginate(_project(qs), offset=offset, limit=limit)
+        if flag_complete is False:
+            # "Not complete" covers both never-flagged (None) and
+            # flagged-but-still-open (2) - only excluding the explicit
+            # complete value (1) captures both correctly.
+            qs = qs.exclude(flag_status=1)
+        if total is None and flag_complete is not None and not query:
+            # Live-verified: qs.count() on a single-folder flag_status
+            # restriction is cheap (server-side count, not a full fetch) and
+            # accurate - worth paying for here since callers filtering by
+            # flag completion are exactly the ones that need a real
+            # total_available (e.g. a dashboard counting messages still
+            # outstanding), not just a page of items to display.
+            try:
+                total = qs.count()
+            except Exception:
+                total = None
+        qs = _project(qs)
+        page, next_off = paginate(qs, offset=offset, limit=limit)
         return page, next_off, total
 
     items, next_offset, total = await ctx.gateway.call(work)
@@ -871,7 +898,7 @@ TOOLS: List[ToolSpec] = [
             "Search mail. TWO ENGINES, mutually exclusive: pass `query` (an "
             "Exchange AQS string, e.g. 'from:ahmed subject:rfp hasattachment:yes') "
             "OR the structured filters (sender/subject/since/until/is_unread/"
-            "has_attachments) — combining `query` with any structured filter is "
+            "has_attachments/flag_complete) — combining `query` with any structured filter is "
             "a validation error. `sender` is matched client-side against the "
             "fetched page's sender email/name, so total_available is unknown "
             "when it is used. Results are compact cards, newest first; their "
@@ -914,6 +941,15 @@ TOOLS: List[ToolSpec] = [
             },
             "is_unread": {"type": "boolean"},
             "has_attachments": {"type": "boolean"},
+            "flag_complete": {
+                "type": "boolean",
+                "description": "true: only messages whose follow-up flag is marked "
+                               "Complete. false: only messages that are NOT marked "
+                               "Complete (covers both unflagged and still-open-flagged "
+                               "messages). Cannot combine with `query`. Always forces "
+                               "a live read (fresh=true) - the local mirror doesn't "
+                               "track this field.",
+            },
             "offset": {"type": "integer", "minimum": 0, "default": 0},
             "limit": {"type": "integer", "minimum": 1, "maximum": 50, "default": 20},
             "mode": {

--- a/v5/ewsmcp/tools/writes.py
+++ b/v5/ewsmcp/tools/writes.py
@@ -26,8 +26,11 @@ exchangelib 5.0.3 pins honoured here (verified against the installed lib):
   items persisted via ``.save(account.drafts)`` (Exchange quotes the
   original server-side).
 - ``Item.move(folder)`` returns ``None`` and updates ``item.id`` in place.
-- There is NO follow-up-flag parameter anywhere: 5.0.3 has no first-class
-  flag field; pretending would be mock-drift bait (categories instead).
+- Follow-up flag completion IS available, via ExtendedProperty
+  registration (PidTagFlagStatus, tag 0x1090) - see ../flag_property.py
+  for the live-verified read/write/filter proof. update_messages'
+  ``flag_complete`` param uses it; this superseded an earlier assumption
+  here that it was unavailable.
 """
 
 import html as _html
@@ -42,6 +45,10 @@ from exchangelib.items import (
     SEND_TO_CHANGED_AND_SAVE_COPY,
     SEND_TO_NONE,
 )
+
+from ..flag_property import ensure_registered as ensure_flag_status_registered
+
+ensure_flag_status_registered()
 
 from ..dates import parse_when
 from ..errors import ToolError
@@ -312,22 +319,23 @@ async def _delete_draft(ctx: Context, *, draft_id: str) -> Dict[str, Any]:
 async def _update_messages(ctx: Context, *, ids: List[str],
                            set_read: Optional[bool] = None,
                            categories_add: Optional[List[str]] = None,
-                           categories_remove: Optional[List[str]] = None) -> Dict[str, Any]:
-    # NOTE: there is deliberately NO set_flag parameter — exchangelib 5.0.3
-    # exposes no first-class follow-up flag field, and pretending would be
-    # mock-drift bait. Categories are the visible marker (see description).
+                           categories_remove: Optional[List[str]] = None,
+                           flag_complete: Optional[bool] = None) -> Dict[str, Any]:
     _require_bulk(ids)
-    if set_read is None and not categories_add and not categories_remove:
-        raise ToolError("validation",
-                        "nothing to update: pass set_read and/or categories_add/_remove")
+    if (set_read is None and not categories_add and not categories_remove
+            and flag_complete is None):
+        raise ToolError(
+            "validation",
+            "nothing to update: pass set_read, categories_add/_remove, and/or flag_complete")
     remove = set(categories_remove or [])
     ok_ids: List[str] = []
     final_cats: List[tuple] = []
 
     def work(account: Any) -> Dict[str, Any]:
         updated, failed = 0, []
-        fetched = _fetch_many(account, ids,
-                              only=["id", "changekey", "is_read", "categories"])
+        fetched = _fetch_many(
+            account, ids,
+            only=["id", "changekey", "is_read", "categories", "flag_status"])
         for raw_id, item in zip(ids, fetched):
             try:  # per-item isolation: one failure never aborts the batch
                 if isinstance(item, Exception):
@@ -344,6 +352,13 @@ async def _update_messages(ctx: Context, *, ids: List[str],
                     item.categories = cats or None
                     changed.append("categories")
                     final_cats.append((raw_id, cats))
+                if flag_complete is not None:
+                    # 1 = flagged and marked Complete; None = not flagged.
+                    # Deliberately doesn't produce state 2 (flagged, still
+                    # open) - this tool only marks/unmarks completion, it
+                    # doesn't raise a new follow-up flag.
+                    item.flag_status = 1 if flag_complete else None
+                    changed.append("flag_status")
                 item.save(update_fields=changed)
                 updated += 1
                 ok_ids.append(raw_id)
@@ -743,15 +758,18 @@ TOOLS: List[ToolSpec] = [
     ToolSpec(
         name="update_messages",
         description=(
-            "Bulk-update up to 50 messages: set_read and/or categories_add/"
-            "categories_remove. Per-item failures are isolated and reported. "
-            "There is no follow-up-flag support in this backend — use "
-            "categories_add (e.g. ['Follow up']) as the visible marker."
+            "Bulk-update up to 50 messages: set_read, categories_add/"
+            "categories_remove, and/or flag_complete. Per-item failures are "
+            "isolated and reported. flag_complete marks/unmarks the message's "
+            "follow-up flag as Complete (true) or clears completion (false) - "
+            "it does not raise a NEW follow-up flag on an unflagged message, "
+            "only sets/clears the completion state."
         ),
         side_effect_class="write",
         input_schema=_obj({
             "ids": _IDS, "set_read": _BOOL,
             "categories_add": _EMAILS, "categories_remove": _EMAILS,
+            "flag_complete": _BOOL,
         }, required=["ids"]),
         handler=_update_messages,
         confirm=False,


### PR DESCRIPTION
## Context

`writes.py` currently states: *"There is NO follow-up-flag parameter anywhere: 5.0.3 has no first-class flag field; pretending would be mock-drift bait (categories instead)."*

That conclusion is wrong. The actual MAPI property (`PidTagFlagStatus`, tag `0x1090`) is fully accessible via `exchangelib`'s `ExtendedProperty` registration mechanism - reading, writing, and server-side filtering all work correctly once registered. This isn't a documented, first-class `exchangelib` field, which is presumably why it was written off, but it's real and reliable.

## What this PR does

New `ewsmcp/flag_property.py` registers the field once (idempotent):

```python
class FlagStatus(ExtendedProperty):
    property_tag = 0x1090
    property_type = "Integer"

Message.register("flag_status", FlagStatus)
```

Value semantics (real MAPI): `None` = not flagged, `1` = flagged and marked Complete, `2` = flagged and still open. This PR only needs the completion state (`1` vs not-`1`).

- **`search_messages`**: new `flag_complete: bool` structured filter. `true` → only Complete-flagged messages. `false` → only messages NOT marked Complete (covers both unflagged and still-open-flagged, via `.exclude(flag_status=1)`). Always forces a live read (`fresh=true`) since the local mirror doesn't store this field. Gets a real `total_available` via `qs.count()`, same as other single-folder structured filters.
- **`update_messages`**: new `flag_complete: bool` - sets (`flag_status = 1`) or clears (`flag_status = None`) completion. Deliberately does NOT add support for raising a new flag (state `2`) - this only marks/unmarks completion, which is the workflow this was requested for (an Exchange user's prior habit: mark a triaged/addressed item's flag Complete).
- **`get_message`** (live path, `dto.py`): surfaces `flag_complete: true` in the full message view when set.

## Verification

Live-tested end to end through the actual MCP tool interface (not just raw `exchangelib`) against a real mailbox:

1. `search_messages(flag_complete=true)` on a folder → baseline `total_available: 0`.
2. `update_messages(ids=[victim], flag_complete=true)` → `{"updated": 1, "failed": []}`.
3. `search_messages(flag_complete=true)` → finds exactly that message, `total_available: 1`.
4. `get_message(victim, format="full")` → `flag_complete: true` present.
5. `search_messages(flag_complete=false)` → correctly excludes the victim, `total_available` drops by exactly 1 (94 → 93 in the test folder).
6. `update_messages(flag_complete=false)` to revert → `search_messages(flag_complete=true)` → back to `total_available: 0`.

Caught and fixed one real bug during this verification: the live path's cheap-total short-circuit (`unfiltered`) only checked the `filters` dict, so `flag_complete=false` (implemented via `.exclude()`, not `filters`) fell through to it and returned the raw unfiltered folder total instead of the correctly-excluded count. Fixed by including `flag_complete is None` in the `unfiltered` check.

## Relationship to #145

Independent of the `categories` filter PR (#145) - this branches off `main`, not off that branch, per request. Both PRs correct the same category of mistake (an earlier assumption that a real Outlook feature "isn't available" when it actually is, just not exposed as a first-class `exchangelib` field) but are unrelated code paths and can land in either order.