### PR TITLE
feat(v5): expose folder_class on list_folders rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+- `list_folders` rows now expose `folder_class`, the raw EWS
+  FolderClass string (`IPF.Note`, `IPF.Appointment`, `IPF.Contact`,
+  …), on both the cache and live lanes; omitted when Exchange
+  reports none. Existing local mirrors gain the `folders.folder_class`
+  column on open and fill it on the next hierarchy sync.
+
 ### Documentation
 - Repository-wide revamp: the root README is now a single front door
   (version guide, stdio-first quick start); `docs/README.md` maps all

--- a/v5/docs/API.md
+++ b/v5/docs/API.md
@@ -52,7 +52,7 @@ regenerate with `python scripts/dump_tool_table.py --write`.
 
 #### `list_folders` — read (min tier: read)
 
-List mail folders as a depth-limited tree walk. Each row is {id, name, path, total, unread, children}; `id` is a short folder alias (f7) reusable as a `folder`/`parent` argument anywhere. Well-known folders also carry `wk` (e.g. 'f:inbox') — prefer passing that stable alias. Set include_empty=false to hide folders with zero items.
+List mail folders as a depth-limited tree walk. Each row is {id, name, path, total, unread, children}; `id` is a short folder alias (f7) reusable as a `folder`/`parent` argument anywhere. Well-known folders also carry `wk` (e.g. 'f:inbox') — prefer passing that stable alias. Rows also carry the raw EWS FolderClass as `folder_class` when Exchange reports one (e.g. 'IPF.Note' for mail, 'IPF.Appointment' for calendar). Set include_empty=false to hide folders with zero items.
 
 | parameter | type | required | description |
 |---|---|---|---|

--- a/v5/ewsmcp/cache/store.py
+++ b/v5/ewsmcp/cache/store.py
@@ -35,7 +35,9 @@ from ..normalize import fts_match_expression, normalize_ar
 
 logger = logging.getLogger(__name__)
 
-_SCHEMA_VERSION = 1
+# Recorded in meta.schema so an operator inspecting a mirror can tell which
+# shape it holds; the migration itself is the additive check in _ensure_schema.
+_SCHEMA_VERSION = 2
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS meta (
@@ -107,13 +109,14 @@ CREATE TABLE IF NOT EXISTS tasks (
     status      TEXT
 );
 CREATE TABLE IF NOT EXISTS folders (
-    ews_id   TEXT PRIMARY KEY,
-    name     TEXT,
-    path     TEXT,
-    wk       TEXT,
-    total    INTEGER,
-    unread   INTEGER,
-    children INTEGER
+    ews_id       TEXT PRIMARY KEY,
+    name         TEXT,
+    path         TEXT,
+    wk           TEXT,
+    folder_class TEXT,
+    total        INTEGER,
+    unread       INTEGER,
+    children     INTEGER
 );
 CREATE TABLE IF NOT EXISTS sync_state (
     key   TEXT PRIMARY KEY,
@@ -216,6 +219,12 @@ class CacheStore:
         with self._lock:
             conn = self._writer_conn()
             conn.executescript(_SCHEMA)
+            # CREATE TABLE IF NOT EXISTS is a no-op on an already-deployed
+            # mirror, so schema 1 databases need the new column added by hand
+            # — the read path selects it unconditionally.
+            cols = {row["name"] for row in conn.execute("PRAGMA table_info(folders)")}
+            if "folder_class" not in cols:
+                conn.execute("ALTER TABLE folders ADD COLUMN folder_class TEXT")
             conn.execute(
                 "INSERT OR REPLACE INTO meta(key, value) VALUES ('schema', ?)",
                 (str(_SCHEMA_VERSION),),
@@ -363,11 +372,11 @@ class CacheStore:
                 conn.execute(
                     """
                     INSERT OR REPLACE INTO folders (ews_id, name, path, wk,
-                        total, unread, children)
-                    VALUES (:ews_id, :name, :path, :wk, :total, :unread,
-                        :children)
+                        folder_class, total, unread, children)
+                    VALUES (:ews_id, :name, :path, :wk, :folder_class, :total,
+                        :unread, :children)
                     """,
-                    r,
+                    {"folder_class": None, **r},  # optional: Exchange may omit it
                 )
 
     def get_sync_state(self, key: str) -> Optional[str]:

--- a/v5/ewsmcp/cache/sync.py
+++ b/v5/ewsmcp/cache/sync.py
@@ -265,6 +265,7 @@ class SyncEngine:
                         "name": name,
                         "path": path,
                         "wk": wk_by_raw.get(raw_id),
+                        "folder_class": getattr(child, "folder_class", None),
                         "total": getattr(child, "total_count", None) or 0,
                         "unread": getattr(child, "unread_count", None) or 0,
                         "children": len(list(getattr(child, "children", None) or [])),

--- a/v5/ewsmcp/tools/mail_read.py
+++ b/v5/ewsmcp/tools/mail_read.py
@@ -260,6 +260,8 @@ async def _list_folders(ctx: Context, parent: Optional[str] = None, depth: int =
                 }
                 if r["wk"]:
                     row["wk"] = r["wk"]
+                if r["folder_class"]:
+                    row["folder_class"] = r["folder_class"]
                 rows.append(row)
             as_of = ctx.cache.watermark("events")  # slow-lane watermark
             return _stamp(envelope(rows, total_available=len(rows), offset=0),
@@ -299,6 +301,10 @@ async def _list_folders(ctx: Context, parent: Optional[str] = None, depth: int =
                     wk = wk_by_raw_id.get(raw_id)
                     if wk:
                         row["wk"] = wk
+                    # getattr — not every folder object carries a FolderClass
+                    folder_class = getattr(child, "folder_class", None)
+                    if folder_class:
+                        row["folder_class"] = folder_class
                     rows.append(row)
                 walk(child, level + 1, path)
 
@@ -847,8 +853,10 @@ TOOLS: List[ToolSpec] = [
             "{id, name, path, total, unread, children}; `id` is a short folder "
             "alias (f7) reusable as a `folder`/`parent` argument anywhere. "
             "Well-known folders also carry `wk` (e.g. 'f:inbox') — prefer "
-            "passing that stable alias. Set include_empty=false to hide "
-            "folders with zero items."
+            "passing that stable alias. Rows also carry the raw EWS FolderClass "
+            "as `folder_class` when Exchange reports one (e.g. 'IPF.Note' for "
+            "mail, 'IPF.Appointment' for calendar). Set include_empty=false to "
+            "hide folders with zero items."
         ),
         side_effect_class="read",
         requires_ews=True,

--- a/v5/tests/test_cache_first_reads.py
+++ b/v5/tests/test_cache_first_reads.py
@@ -64,7 +64,11 @@ def seeded_store(tmp_path):
     }])
     store.replace_folders([{
         "ews_id": "F-IN", "name": "Inbox", "path": "Inbox", "wk": "f:inbox",
-        "total": 3, "unread": 1, "children": 0,
+        "total": 3, "unread": 1, "children": 0, "folder_class": "IPF.Note",
+    }, {
+        # no folder_class key at all: Exchange did not report one
+        "ews_id": "F-AR", "name": "Archive", "path": "Archive", "wk": None,
+        "total": 2, "unread": 0, "children": 0,
     }])
     return store
 
@@ -134,8 +138,11 @@ def test_list_folders_from_mirror(tmp_path):
     ctx = _ctx(tmp_path, NoTouchGateway())
     res = _run(ctx, "list_folders")
     assert res["source"] == "cache"
-    assert res["items"][0]["wk"] == "f:inbox"
-    assert res["items"][0]["unread"] == 1
+    by_path = {r["path"]: r for r in res["items"]}
+    assert by_path["Inbox"]["wk"] == "f:inbox"
+    assert by_path["Inbox"]["unread"] == 1
+    assert by_path["Inbox"]["folder_class"] == "IPF.Note"
+    assert "folder_class" not in by_path["Archive"]
 
 
 def test_fresh_true_forces_live(tmp_path):

--- a/v5/tests/test_cache_store.py
+++ b/v5/tests/test_cache_store.py
@@ -200,3 +200,39 @@ def test_task_rows(store):
     store.delete_tasks_by_id(["T1"])
     rows, total = store.task_rows(include_completed=True)
     assert total == 1
+
+
+# schema 1 folders table: no folder_class column.
+_LEGACY_FOLDERS_DDL = """
+CREATE TABLE folders (
+    ews_id   TEXT PRIMARY KEY,
+    name     TEXT,
+    path     TEXT,
+    wk       TEXT,
+    total    INTEGER,
+    unread   INTEGER,
+    children INTEGER
+);
+"""
+
+
+def test_schema_1_mirror_gains_folder_class_without_losing_rows(tmp_path):
+    """Deployed mirrors predate folder_class; CREATE TABLE IF NOT EXISTS will
+    not add it, and the read path selects the column unconditionally — so the
+    ALTER has to run on open, and mirrored folders have to survive it."""
+    db_path = tmp_path / "legacy.db"
+    legacy = sqlite3.connect(db_path)
+    legacy.executescript(_LEGACY_FOLDERS_DDL)
+    legacy.execute("INSERT INTO folders VALUES ('F-IN', 'Inbox', 'Inbox', "
+                   "'f:inbox', 3, 1, 0)")
+    legacy.commit()
+    legacy.close()
+
+    store = CacheStore(db_path)
+    try:
+        rows = store.folder_rows()
+        assert [r["path"] for r in rows] == ["Inbox"]
+        assert rows[0]["unread"] == 1
+        assert rows[0]["folder_class"] is None  # migrated, not yet backfilled
+    finally:
+        store.close()

--- a/v5/tests/test_exchangelib_signatures.py
+++ b/v5/tests/test_exchangelib_signatures.py
@@ -141,6 +141,13 @@ def test_folder_total_count_is_a_stored_field_not_a_probe():
     assert isinstance(Folder.total_count, IntegerField)
 
 
+def test_folder_class_is_a_real_field():
+    """folder_class is the raw EWS FolderClass string exposed verbatim by
+    list_folders (mail/calendar/contacts type marker) — pinned so an
+    exchangelib rename/removal breaks this test before it breaks the tool."""
+    assert "folder_class" in [f.name for f in Folder.FIELDS]
+
+
 def test_protocol_cache_is_evictable():
     """gateway.reset() calls CachingProtocol.clear_cache() to force a
     fresh session + auth negotiation; closing the protocol alone hands

--- a/v5/tests/test_mail_read.py
+++ b/v5/tests/test_mail_read.py
@@ -470,15 +470,16 @@ def test_overview_shape(tmp_path):
 # --- list_folders --------------------------------------------------------------------
 
 
-def _folder(raw_id, name, total=1, unread=0, children=()):
+def _folder(raw_id, name, total=1, unread=0, children=(), folder_class=None):
     return SimpleNamespace(id=raw_id, name=name, total_count=total,
-                           unread_count=unread, children=list(children))
+                           unread_count=unread, children=list(children),
+                           folder_class=folder_class)
 
 
 def test_list_folders_walk_with_paths_and_wk(tmp_path):
     sub = _folder("FLD-SUB=", "2026", total=4)
     inbox_folder = _folder("FLD-INBOX=", "Inbox", total=5, unread=2,
-                           children=[sub])
+                           children=[sub], folder_class="IPF.Note")
     empty = _folder("FLD-EMPTY=", "Archive Old", total=0)
     account = _account()
     account.msg_folder_root = _folder("FLD-ROOT=", "root",
@@ -493,7 +494,9 @@ def test_list_folders_walk_with_paths_and_wk(tmp_path):
     assert by_path["Inbox"]["unread"] == 2
     assert by_path["Inbox"]["children"] == 1
     assert by_path["Inbox"]["id"].startswith("f")
+    assert by_path["Inbox"]["folder_class"] == "IPF.Note"
     assert "wk" not in by_path["Inbox/2026"]
+    assert "folder_class" not in by_path["Inbox/2026"]
     # alias roundtrip: the f-alias resolves back to the raw folder id
     assert ctx.aliaser.resolve(by_path["Inbox"]["id"]) == "FLD-INBOX="
 

--- a/v5/tests/test_sync_engine.py
+++ b/v5/tests/test_sync_engine.py
@@ -144,11 +144,14 @@ def test_row_from_message_cleans_body_once(tmp_path):
 def test_slow_lane_syncs_folders_calendar_tasks(tmp_path):
     account = _account()
 
-    def folder_node(fid, name, children=(), total=0, unread=0):
+    def folder_node(fid, name, children=(), total=0, unread=0,
+                    folder_class=None):
         return SimpleNamespace(id=fid, name=name, children=list(children),
-                               total_count=total, unread_count=unread)
+                               total_count=total, unread_count=unread,
+                               folder_class=folder_class)
 
-    inbox_node = folder_node("F-IN", "Inbox", total=5, unread=2)
+    inbox_node = folder_node("F-IN", "Inbox", total=5, unread=2,
+                             folder_class="IPF.Note")
     account.msg_folder_root = folder_node("F-ROOT", "root", [inbox_node])
     account.inbox = FakeFolder("inbox")
     account.inbox.id = "F-IN"
@@ -175,6 +178,7 @@ def test_slow_lane_syncs_folders_calendar_tasks(tmp_path):
     engine._sync_slow_lane(account)
     folders = {r["path"]: r for r in store.folder_rows()}
     assert folders["Inbox"]["unread"] == 2
+    assert folders["Inbox"]["folder_class"] == "IPF.Note"
     assert store.events_window(0, 2**40)
     rows, total = store.task_rows()
     assert total == 1


### PR DESCRIPTION
## Summary

`list_folders` rows today give no way to tell a mail folder from a calendar, contacts, tasks, or notes folder except by guessing from `name`/`path` (the only structured signal, `wk`, covers just the handful of well-known folders). That guess breaks on renamed folders and on non-English mailboxes.

Exchange already reports this via the FolderClass property. `exchangelib` surfaces it as `folder.folder_class` (e.g. `IPF.Note` for mail, `IPF.Appointment` for calendar, `IPF.Contact` for contacts) at no extra cost on the same folder walk this tool already does.

This PR exposes it verbatim as an optional `folder_class` field on `list_folders` rows, on **both** read lanes (the cache-mirror lane and the live EWS-walk lane), so behavior doesn't depend on the `fresh` flag.

## Changes

- `ewsmcp/tools/mail_read.py` — both `_list_folders` lanes emit `folder_class` when Exchange reports one (omitted otherwise, matching the existing `wk` field's optional-field convention); tool description updated.
- `ewsmcp/cache/store.py` — `folders` table gains a `folder_class` column. Since `CREATE TABLE IF NOT EXISTS` is a no-op on an already-deployed mirror, `_ensure_schema()` also runs a guarded `ALTER TABLE` so existing local databases pick up the column in place, with no rows lost.
- `ewsmcp/cache/sync.py` — the slow-lane folder sync captures `folder.folder_class` into the row it hands to the store.
- Tests: cache-first read parity with/without the field, a schema-1-mirror migration test (legacy DB survives the ALTER, existing rows intact), a live-walk test, a sync-engine test, and a pinned test asserting `exchangelib.Folder` still declares a `folder_class` field (so an upstream rename/removal fails loudly here rather than silently).
- `CHANGELOG.md` and `docs/API.md` updated (`dump_tool_table.py --write`).

## Verification

- `python -m pytest tests -q` — 254 passed
- `python scripts/dump_tool_table.py --check` — docs match the registry
- `ruff check v5` — no new violations vs. `main` (confirmed identical pre-existing error count on both)

Additive and backward-compatible throughout: optional field, omitted when absent, no new dependency, no behavior change for any existing consumer.